### PR TITLE
Detect int variant

### DIFF
--- a/src/urt/meta/package.d
+++ b/src/urt/meta/package.d
@@ -1,10 +1,25 @@
 module urt.meta;
 
+pure nothrow @nogc:
 
 alias Alias(alias a) = a;
 alias Alias(T) = T;
 
 alias AliasSeq(TList...) = TList;
+
+ulong bit_mask(size_t bits)
+{
+    return (1UL << bits) - 1;
+}
+
+template bit_mask(size_t bits, bool signed = false)
+{
+    static assert(bits <= 64, "bit_mask only supports up to 64 bits");
+    static if (bits == 64)
+        enum IntForWidth!(64, signed) bit_mask = ~0UL;
+    else
+        enum IntForWidth!(bits, signed) bit_mask = (1UL << bits) - 1;
+}
 
 template IntForWidth(size_t bits, bool signed = false)
 {

--- a/src/urt/variant.d
+++ b/src/urt/variant.d
@@ -119,11 +119,35 @@ nothrow @nogc:
     this(F)(F f)
         if (is_some_float!F)
     {
-        static if (is(F == float))
-            flags = Flags.NumberFloat;
+        import urt.math : float_is_integer;
+
+        if (int sign = float_is_integer(f, value.ul))
+        {
+            if (sign < 0)
+            {
+                flags = Flags.NumberInt64;
+                if (value.l >= int.min)
+                    flags |= Flags.IntFlag;
+            }
+            else
+            {
+                flags = Flags.NumberUint64;
+                if (value.ul <= int.max)
+                    flags |= Flags.IntFlag | Flags.UintFlag | Flags.Int64Flag;
+                else if (value.ul <= uint.max)
+                    flags |= Flags.UintFlag | Flags.Int64Flag;
+                else if (value.ul <= long.max)
+                    flags |= Flags.Int64Flag;
+            }
+        }
         else
-            flags = Flags.NumberDouble;
-        value.d = f;
+        {
+            static if (is(F == float))
+                flags = Flags.NumberFloat;
+            else
+                flags = Flags.NumberDouble;
+            value.d = f;
+        }
     }
 
     this(E)(E e)


### PR DESCRIPTION
Properly detect numeric variants as integers when fed via float (like numbers from command line).