### PR TITLE
Linux kernel wifi drivers

### DIFF
--- a/platforms.mk
+++ b/platforms.mk
@@ -403,6 +403,10 @@ ifeq ($(OS),windows)
 endif
 ifneq ($(filter linux ubuntu freebsd,$(OS)),)
     URT_SOURCES := $(URT_SOURCES) $(shell find "$(URT_SRCDIR)/urt/driver/posix" -type f -name '*.d')
+    # Native WPA STA supplicant + 4-way handshake (and its EAPOL/802.1X codec),
+    # driven by the nl80211 backend in src/driver/linux instead of wpa_supplicant.
+    URT_SOURCES := $(URT_SOURCES) $(shell find "$(URT_SRCDIR)/urt/driver/wpa" -type f -name '*.d')
+    URT_SOURCES := $(URT_SOURCES) $(shell find "$(URT_SRCDIR)/urt/driver/dot1x" -type f -name '*.d')
 endif
 ifeq ($(OS),freertos)
     URT_SOURCES := $(URT_SOURCES) $(shell find "$(URT_SRCDIR)/urt/driver/freertos" -type f -name '*.d')

--- a/src/urt/driver/bl808_m0/wifi.d
+++ b/src/urt/driver/bl808_m0/wifi.d
@@ -388,19 +388,21 @@ bool wifi_hw_ap_configure(ubyte port, ref const WifiApConfig cfg)
     _ap_ssid_buf[0 .. cfg.ssid.length] = cast(ubyte[])cfg.ssid;
     _ap_ssid_buf[cfg.ssid.length] = 0;
     bool ap_open = cfg.auth == WifiAuth.open || cfg.password.length == 0;
-    if (!ap_open && cfg.max_clients > 1)
-        return false;
     if (ap_open)
+    {
         _ap_pw_buf[0] = 0;
+        ap_auth_reset();
+    }
     else
     {
         _ap_pw_buf[0 .. cfg.password.length] = cast(ubyte[])cfg.password;
         _ap_pw_buf[cfg.password.length] = 0;
+        if (!ap_auth_configure())
+            return false;
     }
-    ap_auth_reset();
 
     apm_start_cfm cfm;
-    ubyte ap_max_clients = ap_open ? cfg.max_clients : 1;
+    ubyte ap_max_clients = cfg.max_clients;
     if (ap_max_clients != 0 && !wifi_hw_ap_set_max_clients(port, ap_max_clients))
         return false;
 
@@ -426,8 +428,6 @@ bool wifi_hw_ap_configure(ubyte port, ref const WifiApConfig cfg)
 bool wifi_hw_ap_set_max_clients(ubyte port, ubyte max_clients)
 {
     if (port != 0 || !_bl_hw.is_up)
-        return false;
-    if (_ap_pw_buf[0] != 0 && max_clients > 1)
         return false;
 
     ubyte max_sta = max_clients == 0 || max_clients > NX_REMOTE_STA_MAX

--- a/src/urt/driver/bl808_m0/wifi_wpa.d
+++ b/src/urt/driver/bl808_m0/wifi_wpa.d
@@ -6,6 +6,7 @@ import urt.driver.bl808_m0.wifi;
 import urt.driver.bl808_m0.wifi_lmac;
 import urt.driver.wifi;
 import urt.driver.wpa.eapol;
+import urt.driver.wpa.authenticator;
 
 nothrow @nogc:
 package:
@@ -39,251 +40,150 @@ nothrow @nogc:
 extern(C) int bl_wifi_register_wpa_cb_internal(const(wpa_funcs)* cb);
 extern(C) bool bl_wifi_auth_done_internal(ubyte sta_idx, ushort reason_code);
 private __gshared ubyte _ap_hapd_sentinel;
-private __gshared ubyte _ap_sm_sentinel;
-private __gshared ubyte[6] _ap_auth_sta_mac;
-private __gshared ubyte[6] _ap_auth_ap_mac;
-private __gshared ubyte _ap_auth_sta_idx = ubyte.max;
-private __gshared ubyte[32] _ap_auth_anonce;
-private __gshared ubyte[8] _ap_auth_replay;
-private __gshared ubyte[32] _ap_auth_pmk;
-private __gshared ubyte[48] _ap_auth_ptk;
-private __gshared ubyte[16] _ap_auth_gtk;
-private __gshared ubyte[8] _ap_auth_group_rsc;
-private __gshared bool _ap_auth_have_pmk;
-private __gshared uint _ap_auth_msg1_count;
-private __gshared uint _ap_auth_msg2_count;
-private __gshared uint _ap_auth_msg3_count;
-private __gshared uint _ap_auth_msg4_count;
-private __gshared ubyte[14 + 160] _ap_auth_last_msg3;
-private __gshared size_t _ap_auth_last_msg3_len;
-private __gshared uint _ap_auth_msg3_retx;
-private __gshared ulong _ap_auth_msg3_next_retx_us;
+private __gshared WpaApAuthenticator _ap_auth;
+
+// Per-STA handle round-tripped through the firmware's wpa_funcs callbacks: we
+// return &_ap_slots[i] as the `sm` from _wpa_ap_join and the firmware hands it
+// back on associate / rx-eapol / remove. Carries the STA's firmware sta_idx so
+// the key-install and auth-done primitives can be addressed by MAC.
+private struct ApStaSlot
+{
+    ubyte[6] mac;
+    ubyte sta_idx;
+    bool in_use;
+}
+private __gshared ApStaSlot[WpaApAuthenticator.max_stations] _ap_slots;
+
+// AP RSN IE advertised in the beacon and echoed in EAPOL-Key msg 3: WPA2-PSK,
+// CCMP pairwise + group, PSK AKM. Must outlive the authenticator -> immutable.
+private static immutable ubyte[22] _ap_rsn_ie = [
+    0x30, 0x14,
+    0x01, 0x00,
+    0x00, 0x0f, 0xac, 0x04,
+    0x01, 0x00,
+    0x00, 0x0f, 0xac, 0x04,
+    0x01, 0x00,
+    0x00, 0x0f, 0xac, 0x02,
+    0x00, 0x00,
+];
 
 void ap_auth_reset()
 {
-    _ap_auth_sta_idx = ubyte.max;
-    _ap_auth_have_pmk = false;
-    _ap_auth_msg1_count = 0;
-    _ap_auth_msg2_count = 0;
-    _ap_auth_msg3_count = 0;
-    _ap_auth_msg4_count = 0;
-    _ap_auth_last_msg3_len = 0;
-    _ap_auth_msg3_retx = 0;
-    _ap_auth_msg3_next_retx_us = 0;
-    _ap_auth_group_rsc[] = 0;
-    _ap_auth_ap_mac[] = 0;
-    _ap_auth_sta_mac[] = 0;
+    _ap_auth = WpaApAuthenticator.init;
+    foreach (ref s; _ap_slots)
+        s = ApStaSlot.init;
 }
 
-private bool ap_install_keys()
+bool ap_auth_has_pmk()
+    => _ap_auth.have_pmk;
+
+void ap_auth_tick()
 {
-    int pair_ret = bl_wifi_set_sta_key_internal(
-        cast(ubyte)_bl_hw.vif_index_ap, _ap_auth_sta_idx,
-        wpa_alg_ccmp, 0, 1,
-        null, 0, _ap_auth_ptk.ptr + 32, 16,
-        true);
-
-    int group_ret = -1;
-    if (_bl_hw.ap_bcmc_idx >= 0)
-        group_ret = bl_wifi_set_sta_key_internal(
-            cast(ubyte)_bl_hw.vif_index_ap, cast(ubyte)_bl_hw.ap_bcmc_idx,
-            wpa_alg_ccmp, 1, 1,
-            _ap_auth_group_rsc.ptr, _ap_auth_group_rsc.length,
-            _ap_auth_gtk.ptr, _ap_auth_gtk.length,
-            false);
-
-    return pair_ret == 0 && group_ret == 0;
+    import urt.driver.bl618.timer : mtime_read;
+    _ap_auth.tick(mtime_read());
 }
 
-private bool ap_compute_pmk()
+// Compute the PMK + GTK and bind the driver hooks for a secured BSS. Called at
+// AP bring-up; open APs never configure an authenticator.
+bool ap_auth_configure()
 {
-    import urt.crypto.pbkdf2 : wpa2_psk_to_pmk;
-
     size_t ssid_len;
     while (ssid_len < _ap_ssid_buf.length && _ap_ssid_buf[ssid_len] != 0) ++ssid_len;
     size_t pass_len;
     while (pass_len < _ap_pw_buf.length && _ap_pw_buf[pass_len] != 0) ++pass_len;
     if (ssid_len == 0 || pass_len < 8)
         return false;
+
+    ap_auth_reset();
+    _ap_auth.hooks.send_eapol = &ap_hook_send_eapol;
+    _ap_auth.hooks.install_pairwise_key = &ap_hook_install_pairwise;
+    _ap_auth.hooks.install_group_key = &ap_hook_install_group;
+    _ap_auth.hooks.handshake_complete = &ap_hook_complete;
+
     auto ssid = cast(const(char)[])_ap_ssid_buf[0 .. ssid_len];
     auto pass = cast(const(char)[])_ap_pw_buf[0 .. pass_len];
-    _ap_auth_have_pmk = wpa2_psk_to_pmk(pass, ssid, _ap_auth_pmk).succeeded;
-    return _ap_auth_have_pmk;
+    return _ap_auth.configure(pass, ssid, _vif_mac_ap, _ap_rsn_ie[]).succeeded;
 }
 
-bool ap_auth_has_pmk()
+private ApStaSlot* ap_slot_alloc(const(ubyte)[6] mac)
 {
-    return _ap_auth_have_pmk;
+    foreach (ref s; _ap_slots)
+        if (s.in_use && s.mac[] == mac[])
+            return &s;
+    foreach (ref s; _ap_slots)
+        if (!s.in_use)
+        {
+            s = ApStaSlot.init;
+            s.mac[] = mac[];
+            s.in_use = true;
+            return &s;
+        }
+    return null;
 }
 
-private void ap_mic(const(ubyte)[] kck, const(ubyte)[] frame, ref ubyte[16] out_mic)
+private void ap_slot_free(ApStaSlot* s)
 {
-    import urt.digest.hmac : HMACContext, hmac_init, hmac_update, hmac_finalise;
-    import urt.digest.sha : SHA1Context;
-
-    HMACContext!SHA1Context h;
-    hmac_init(h, kck);
-    hmac_update(h, frame);
-    ubyte[SHA1Context.DigestLen] digest = hmac_finalise(h);
-    out_mic[] = digest[0 .. 16];
+    if (s !is null)
+        *s = ApStaSlot.init;
 }
 
-private bool ap_verify_mic(const(ubyte)[] kck, const(ubyte)[] frame, const(ubyte)[16] expected)
+private bool ap_slot_idx(const(ubyte)[6] mac, out ubyte sta_idx)
 {
-    import urt.driver.wpa.eapol : off_mic, eapol_key_mic_len;
-
-    ubyte[256] scratch = void;
-    if (frame.length > scratch.length || frame.length < off_mic + eapol_key_mic_len)
-        return false;
-    scratch[0 .. frame.length] = frame[];
-    scratch[off_mic .. off_mic + eapol_key_mic_len] = 0;
-    ubyte[16] computed;
-    ap_mic(kck, scratch[0 .. frame.length], computed);
-    ubyte diff;
-    foreach (i; 0 .. 16)
-        diff |= computed[i] ^ expected[i];
-    return diff == 0;
+    foreach (ref s; _ap_slots)
+        if (s.in_use && s.mac[] == mac[])
+        {
+            sta_idx = s.sta_idx;
+            return true;
+        }
+    return false;
 }
 
-private void ap_inc_replay()
+private bool ap_hook_send_eapol(const(ubyte)[6] sta, const(ubyte)[] eapol)
 {
-    foreach_reverse (i; 0 .. _ap_auth_replay.length)
-    {
-        _ap_auth_replay[i]++;
-        if (_ap_auth_replay[i] != 0)
-            break;
-    }
-}
-
-private bool ap_send_msg1()
-{
-    import urt.crypto.random : crypto_random_bytes;
-
-    if (_ap_auth_sta_idx == ubyte.max)
+    ubyte[14 + 256] frame = void;
+    if (eapol.length > frame.length - 14)
         return false;
-    if (!crypto_random_bytes(_ap_auth_anonce[]).succeeded)
-        return false;
-    if (!_ap_auth_have_pmk && !ap_compute_pmk())
-        return false;
-    _ap_auth_ap_mac[] = _vif_mac_ap[];
-
-    _ap_auth_replay[] = 0;
-    _ap_auth_replay[eapol_key_replay_len - 1] = cast(ubyte)(_ap_auth_msg1_count + 1);
-
-    ubyte[8] zero_rsc = 0;
-    ubyte[128] eapol = void;
-    ushort key_info = key_info_type_pairwise | key_info_key_ack | key_info_ver_hmac_sha1_aes;
-    size_t eapol_len = encode_eapol_key(eapol[],
-        eapol_version_2004, key_desc_type_rsn,
-        key_info, 16,
-        _ap_auth_replay, _ap_auth_anonce, zero_rsc,
-        null);
-    if (eapol_len == 0)
-        return false;
-
-    ubyte[14 + 128] frame = void;
-    frame[0 .. 6] = _ap_auth_sta_mac[];
-    frame[6 .. 12] = _ap_auth_ap_mac[];
+    frame[0 .. 6] = sta[];
+    frame[6 .. 12] = _vif_mac_ap[];
     frame[12] = 0x88;
     frame[13] = 0x8e;
-    frame[14 .. 14 + eapol_len] = eapol[0 .. eapol_len];
-
-    bool ok = wifi_hw_tx(0, WifiVif.ap, frame[0 .. 14 + eapol_len]);
-    _ap_auth_msg1_count++;
-    return ok;
+    frame[14 .. 14 + eapol.length] = eapol[];
+    return wifi_hw_tx(0, WifiVif.ap, frame[0 .. 14 + eapol.length]);
 }
 
-private bool ap_send_msg3(const(ubyte)[] msg2_frame, ref const EapolKeyFrame msg2)
+private bool ap_hook_install_pairwise(const(ubyte)[6] sta, const(ubyte)[] tk)
 {
-    import urt.crypto.aes_keywrap : aes_wrap;
-    import urt.crypto.random : crypto_random_bytes;
-    import urt.driver.wpa.crypto : wpa2_pmk_to_ptk;
-
-    if (_ap_auth_sta_idx == ubyte.max || !_ap_auth_have_pmk)
+    ubyte sta_idx;
+    if (!ap_slot_idx(sta, sta_idx))
         return false;
+    return bl_wifi_set_sta_key_internal(
+        cast(ubyte)_bl_hw.vif_index_ap, sta_idx,
+        wpa_alg_ccmp, 0, 1,
+        null, 0, tk.ptr, tk.length,
+        true) == 0;
+}
 
-    if (!wpa2_pmk_to_ptk(_ap_auth_pmk, _ap_auth_ap_mac, _ap_auth_sta_mac,
-                         _ap_auth_anonce, msg2.key_nonce, _ap_auth_ptk[]).succeeded)
+private bool ap_hook_install_group(const(ubyte)[6] sta, ubyte key_idx, const(ubyte)[] gtk, const(ubyte)[] rsc)
+{
+    if (_bl_hw.ap_bcmc_idx < 0)
         return false;
+    return bl_wifi_set_sta_key_internal(
+        cast(ubyte)_bl_hw.vif_index_ap, cast(ubyte)_bl_hw.ap_bcmc_idx,
+        wpa_alg_ccmp, key_idx, 1,
+        rsc.ptr, rsc.length, gtk.ptr, gtk.length,
+        false) == 0;
+}
 
-    if (!ap_verify_mic(_ap_auth_ptk[0 .. 16], msg2_frame, msg2.key_mic))
-        return false;
-
-    if (_ap_auth_msg3_count == 0)
-    {
-        if (!crypto_random_bytes(_ap_auth_gtk[]).succeeded)
-            return false;
-    }
-
-    static immutable ubyte[22] rsn_ie = [
-        0x30, 0x14,
-        0x01, 0x00,
-        0x00, 0x0f, 0xac, 0x04,
-        0x01, 0x00,
-        0x00, 0x0f, 0xac, 0x04,
-        0x01, 0x00,
-        0x00, 0x0f, 0xac, 0x02,
-        0x00, 0x00,
-    ];
-    ubyte[56] key_plain = void;
-    size_t key_plain_len;
-    key_plain[key_plain_len .. key_plain_len + rsn_ie.length] = rsn_ie[];
-    key_plain_len += rsn_ie.length;
-    key_plain[key_plain_len + 0] = 0xdd;
-    key_plain[key_plain_len + 1] = 0x16;
-    key_plain[key_plain_len + 2] = 0x00;
-    key_plain[key_plain_len + 3] = 0x0f;
-    key_plain[key_plain_len + 4] = 0xac;
-    key_plain[key_plain_len + 5] = 0x01;
-    key_plain[key_plain_len + 6] = 0x01;
-    key_plain[key_plain_len + 7] = 0x00;
-    key_plain[key_plain_len + 8 .. key_plain_len + 24] = _ap_auth_gtk[];
-    key_plain_len += 24;
-    if ((key_plain_len & 7) != 0)
-    {
-        key_plain[key_plain_len++] = 0xdd;
-        while ((key_plain_len & 7) != 0)
-            key_plain[key_plain_len++] = 0;
-    }
-
-    ubyte[64] wrapped = void;
-    auto wrapped_len = key_plain_len + 8;
-    if (!aes_wrap(_ap_auth_ptk[16 .. 32], key_plain[0 .. key_plain_len], wrapped[0 .. wrapped_len]).succeeded)
-        return false;
-
-    ap_inc_replay();
-    ushort key_info = key_info_type_pairwise | key_info_install | key_info_key_ack |
-        key_info_key_mic | key_info_secure | key_info_encr_key_data | key_info_ver_hmac_sha1_aes;
-
-    ubyte[160] eapol = void;
-    size_t eapol_len = encode_eapol_key(eapol[],
-        eapol_version_2004, key_desc_type_rsn,
-        key_info, 16,
-        _ap_auth_replay, _ap_auth_anonce, _ap_auth_group_rsc,
-        wrapped[0 .. wrapped_len]);
-    if (eapol_len == 0)
-        return false;
-
-    ubyte[16] mic;
-    ap_mic(_ap_auth_ptk[0 .. 16], eapol[0 .. eapol_len], mic);
-    patch_mic(eapol[0 .. eapol_len], mic);
-
-    ubyte[14 + 160] frame = void;
-    frame[0 .. 6] = _ap_auth_sta_mac[];
-    frame[6 .. 12] = _ap_auth_ap_mac[];
-    frame[12] = 0x88;
-    frame[13] = 0x8e;
-    frame[14 .. 14 + eapol_len] = eapol[0 .. eapol_len];
-    bool ok = wifi_hw_tx(0, WifiVif.ap, frame[0 .. 14 + eapol_len]);
-    _ap_auth_last_msg3[0 .. 14 + eapol_len] = frame[0 .. 14 + eapol_len];
-    _ap_auth_last_msg3_len = 14 + eapol_len;
-    _ap_auth_msg3_retx = 0;
-    {
-        import urt.driver.bl618.timer : mtime_read;
-        _ap_auth_msg3_next_retx_us = mtime_read() + 500_000;
-    }
-    _ap_auth_msg3_count++;
-    return ok;
+private void ap_hook_complete(const(ubyte)[6] sta, bool success, ushort reason)
+{
+    ubyte sta_idx;
+    if (!ap_slot_idx(sta, sta_idx))
+        return;
+    enum ushort reason_mic_failure = 14;
+    enum ushort reason_4way_timeout = 15;
+    ushort code = success ? 0
+        : (reason == cast(ushort)WpaHandshakeReason.mic_failed ? reason_mic_failure : reason_4way_timeout);
+    bl_wifi_auth_done_internal(sta_idx, code);
 }
 
 extern(C) void* _wpa_ap_init(void* parm)
@@ -295,69 +195,46 @@ extern(C) bool _wpa_ap_deinit(void*)
 extern(C) bool _wpa_ap_join(void** sm, ubyte* mac, ubyte* wpa_ie, ubyte wpa_ie_len)
 {
     bool encrypted = wpa_ie !is null && wpa_ie_len > 0;
-    bool busy = encrypted && _ap_auth_sta_mac[] != typeof(_ap_auth_sta_mac).init
-                && (mac is null || _ap_auth_sta_mac[] != mac[0 .. 6]);
-    if (busy)
+    if (!encrypted || mac is null)
     {
         if (sm) *sm = null;
-        return false;
+        return !encrypted;          // open station accepted; encrypted-without-MAC rejected
     }
-
-    if (mac)
-        _ap_auth_sta_mac[] = mac[0 .. 6];
-    _ap_auth_sta_idx = ubyte.max;
-    if (sm && !encrypted)
-        *sm = null;
-    else if (sm)
-        *sm = &_ap_sm_sentinel;
+    ApStaSlot* slot = ap_slot_alloc(mac[0 .. 6]);
+    if (slot is null)
+    {
+        if (sm) *sm = null;
+        return false;               // station table full
+    }
+    if (sm) *sm = slot;
     return true;
 }
 
 extern(C) void _wpa_ap_sta_associated(void* sm, ubyte sta_idx)
 {
-    _ap_auth_sta_idx = sta_idx;
-    if (sm !is null)
-        ap_send_msg1();
+    auto slot = cast(ApStaSlot*)sm;
+    if (slot is null)
+        return;
+    slot.sta_idx = sta_idx;
+    _ap_auth.station_join(slot.mac);    // derive ANonce, send msg 1
 }
 
 extern(C) bool _wpa_ap_remove(void* sm)
 {
-    if (sm !is null)
-        ap_auth_reset();
-    return sm !is null;
+    auto slot = cast(ApStaSlot*)sm;
+    if (slot is null)
+        return false;
+    _ap_auth.station_leave(slot.mac);
+    ap_slot_free(slot);
+    return true;
 }
 
-extern(C) bool _wpa_ap_rx_eapol(void*, void* sa, ubyte* data, size_t len)
+extern(C) bool _wpa_ap_rx_eapol(void*, void* sm, ubyte* data, size_t len)
 {
-    enum ushort reason_mic_failure = 14;
-    enum ushort reason_4way_timeout = 15;
-
-    EapolKeyFrame key;
-    bool decoded = data !is null && decode_eapol_key(data[0 .. len], key);
-    bool is_msg2 = decoded && (key.key_info & key_info_key_mic) != 0 &&
-        (key.key_info & key_info_key_ack) == 0 &&
-        (key.key_info & key_info_secure) == 0;
-    bool is_msg4 = decoded && (key.key_info & key_info_key_mic) != 0 &&
-        (key.key_info & key_info_key_ack) == 0 &&
-        (key.key_info & key_info_secure) != 0;
-    if (is_msg2)
-    {
-        _ap_auth_msg2_count++;
-        if (!ap_send_msg3(data[0 .. len], key) && _ap_auth_sta_idx != ubyte.max)
-            bl_wifi_auth_done_internal(_ap_auth_sta_idx, reason_4way_timeout);
-    }
-    else if (is_msg4)
-    {
-        _ap_auth_msg4_count++;
-        bool mic_ok = ap_verify_mic(_ap_auth_ptk[0 .. 16], data[0 .. len], key.key_mic);
-        bool keys_ok = mic_ok && ap_install_keys();
-        bool auth_ok = keys_ok && bl_wifi_auth_done_internal(_ap_auth_sta_idx, 0);
-        if (auth_ok)
-            _ap_auth_last_msg3_len = 0;
-        else if (_ap_auth_sta_idx != ubyte.max)
-            bl_wifi_auth_done_internal(_ap_auth_sta_idx,
-                mic_ok ? reason_4way_timeout : reason_mic_failure);
-    }
+    auto slot = cast(ApStaSlot*)sm;
+    if (slot is null || data is null)
+        return true;
+    _ap_auth.handle_eapol(slot.mac, data[0 .. len]);
     return true;
 }
 extern(C) int _wpa_parse_wpa_ie(const(ubyte)* ie, size_t len, void* data)
@@ -470,8 +347,8 @@ extern(C) int bl_wifi_set_appie_internal(ubyte vif_idx, ubyte appie_type,
 extern(C) bool bl_wifi_sta_is_ap_notify_completed_rsne_internal();
 extern(C) int bl_wifi_set_sta_key_internal(ubyte vif_idx, ubyte sta_idx,
                                             int alg, int key_idx, int set_tx,
-                                            ubyte* seq, size_t seq_len,
-                                            ubyte* key, size_t key_len,
+                                            const(ubyte)* seq, size_t seq_len,
+                                            const(ubyte)* key, size_t key_len,
                                             bool pairwise);
 
 
@@ -748,20 +625,6 @@ void sta_flush_pending_auth()
         queue_event(WifiEvent.sta_connected, null);
     }
 }
-
-void ap_auth_tick()
-{
-    import urt.driver.bl618.timer : mtime_read;
-    ulong now = mtime_read();
-    if (_ap_auth_last_msg3_len != 0 && _ap_auth_msg4_count == 0 &&
-        _ap_auth_msg3_retx < 3 && now >= _ap_auth_msg3_next_retx_us)
-    {
-        wifi_hw_tx(0, WifiVif.ap, _ap_auth_last_msg3[0 .. _ap_auth_last_msg3_len]);
-        _ap_auth_msg3_retx++;
-        _ap_auth_msg3_next_retx_us = now + 500_000;
-    }
-}
-
 
 __gshared wpa_funcs _wpa_stub_table = wpa_funcs(
     &_wpa_sta_init_real, &_wpa_sta_deinit_real,

--- a/src/urt/driver/esp32/wifi.d
+++ b/src/urt/driver/esp32/wifi.d
@@ -189,19 +189,17 @@ size_t wifi_hw_ap_get_clients(uint port, WifiStaInfo[] buf)
 
 bool wifi_hw_scan_start(uint port, ref const WifiScanConfig cfg)
 {
-    // TODO: esp_wifi_scan_start
-    return false;
+    assert(false, "TODO: esp_wifi_scan_start");
 }
 
 void wifi_hw_scan_stop(uint port)
 {
-    // TODO: esp_wifi_scan_stop
+    assert(false, "TODO: esp_wifi_scan_stop");
 }
 
 size_t wifi_hw_scan_get_results(uint port, WifiScanResult[] buf)
 {
-    // TODO: esp_wifi_scan_get_ap_records
-    return 0;
+    assert(false, "TODO: esp_wifi_scan_get_ap_records");
 }
 
 // Frame TX/RX

--- a/src/urt/driver/wpa/authenticator.d
+++ b/src/urt/driver/wpa/authenticator.d
@@ -1,0 +1,174 @@
+// WPA2-PSK AP authenticator: the multi-station manager for one BSS. Owns the
+// PMK (from the passphrase) and the group key, and routes EAPOL frames to a
+// pool of per-station FourwayAuthContext handshakes (urt.driver.wpa.fourway)
+// keyed by STA MAC. Driver adapters (Linux nl80211_ap, BL808) own a singleton
+// WpaApAuthenticator and translate its hooks to their key-install / TX paths.
+//
+// The mirror of WpaStaSupplicant on the STA side. WPA2-PSK / CCMP only.
+module urt.driver.wpa.authenticator;
+
+import urt.crypto.random : crypto_random_bytes;
+import urt.result : Result, InternalResult;
+
+import urt.driver.wpa.crypto : wpa_pmk_len;
+import urt.driver.wpa.eapol : eapol_key_rsc_len;
+import urt.driver.wpa.fourway : FourwayAuthContext, wpa_gtk_max_len;
+
+nothrow @nogc:
+
+
+enum size_t wpa_gtk_len_ccmp = 16;
+
+
+// Driver-facing hook set: function pointers, mirroring WpaSupplicantHooks on the
+// STA side. The manager adapts these into each station's FourwayAuthHooks
+// delegates.
+struct WpaApHooks
+{
+    bool function(const(ubyte)[6] sta, const(ubyte)[] eapol_payload) nothrow @nogc send_eapol;
+    bool function(const(ubyte)[6] sta, const(ubyte)[] tk) nothrow @nogc install_pairwise_key;
+    bool function(const(ubyte)[6] sta, ubyte key_idx, const(ubyte)[] gtk, const(ubyte)[] rsc) nothrow @nogc install_group_key;
+    void function(const(ubyte)[6] sta, bool success, ushort reason) nothrow @nogc handshake_complete;
+}
+
+
+// Multi-station authenticator for one BSS. Owns the PMK (from the passphrase)
+// and the group key, and routes EAPOL frames to per-station contexts by MAC.
+struct WpaApAuthenticator
+{
+    // Upper bound on concurrent associations; the driver enforces its own
+    // max_clients on top of this. Sized for a small embedded AP.
+    enum size_t max_stations = 8;
+
+    WpaApHooks hooks;
+
+    ubyte[wpa_pmk_len] pmk;
+    bool have_pmk;
+    ubyte[6] ap_mac;
+    const(ubyte)[] ap_rsn_ie;
+    ubyte[wpa_gtk_max_len] gtk;
+    size_t gtk_len;
+    ubyte gtk_key_id;
+    ubyte[eapol_key_rsc_len] gtk_rsc;
+
+nothrow @nogc:
+
+    // Compute the PMK from passphrase+SSID and generate the BSS group key.
+    // ap_rsn_ie must stay valid for the lifetime of the authenticator.
+    Result configure(const(char)[] passphrase, const(char)[] ssid,
+                     const(ubyte)[6] ap_mac_, const(ubyte)[] ap_rsn_ie_)
+    {
+        import urt.crypto.pbkdf2 : wpa2_psk_to_pmk;
+
+        have_pmk = false;
+        auto r = wpa2_psk_to_pmk(passphrase, ssid, pmk);
+        if (!r)
+            return r;
+
+        ap_mac = ap_mac_;
+        ap_rsn_ie = ap_rsn_ie_;
+        gtk_key_id = 1;
+        gtk_rsc[] = 0;
+        gtk_len = wpa_gtk_len_ccmp;
+        if (!crypto_random_bytes(gtk[0 .. gtk_len]).succeeded)
+            return InternalResult.failed;
+
+        have_pmk = true;
+        return Result.success;
+    }
+
+    // A station associated -> arm and kick off its 4-way handshake.
+    bool station_join(const(ubyte)[6] sta_mac)
+    {
+        if (!have_pmk)
+            return false;
+        size_t idx = find(sta_mac);
+        if (idx == max_stations)
+            idx = alloc();
+        if (idx == max_stations)
+            return false;
+
+        FourwayAuthContext* c = &_sta[idx];
+        *c = FourwayAuthContext.init;
+        c.hooks.send_eapol = &fwd_send_eapol;
+        c.hooks.install_pairwise_key = &fwd_install_pairwise;
+        c.hooks.install_group_key = &fwd_install_group;
+        c.hooks.handshake_complete = &fwd_complete;
+        c.configure(pmk, ap_mac, sta_mac, ap_rsn_ie, gtk[0 .. gtk_len], gtk_key_id, gtk_rsc);
+        _active[idx] = true;
+        return c.begin();
+    }
+
+    void station_leave(const(ubyte)[6] sta_mac)
+    {
+        size_t idx = find(sta_mac);
+        if (idx != max_stations)
+        {
+            _active[idx] = false;
+            _sta[idx] = FourwayAuthContext.init;
+        }
+    }
+
+    bool handle_eapol(const(ubyte)[6] sta_mac, const(ubyte)[] frame)
+    {
+        size_t idx = find(sta_mac);
+        if (idx == max_stations)
+            return false;
+        return _sta[idx].handle_eapol(frame);
+    }
+
+    void tick(ulong now_us)
+    {
+        foreach (i; 0 .. max_stations)
+            if (_active[i])
+                _sta[i].tick(now_us);
+    }
+
+    bool needs_tick() const pure
+    {
+        import urt.driver.wpa.fourway : FourwayAuthState;
+        foreach (i; 0 .. max_stations)
+        {
+            if (!_active[i])
+                continue;
+            if (_sta[i].state == FourwayAuthState.awaiting_msg2 ||
+                _sta[i].state == FourwayAuthState.awaiting_msg4)
+                return true;
+        }
+        return false;
+    }
+
+private:
+
+    // Adapt the per-station delegate hooks onto the driver function pointers.
+    bool fwd_send_eapol(const(ubyte)[6] sta, const(ubyte)[] eapol)
+        => hooks.send_eapol !is null && hooks.send_eapol(sta, eapol);
+    bool fwd_install_pairwise(const(ubyte)[6] sta, const(ubyte)[] tk)
+        => hooks.install_pairwise_key !is null && hooks.install_pairwise_key(sta, tk);
+    bool fwd_install_group(const(ubyte)[6] sta, ubyte key_idx, const(ubyte)[] gtk, const(ubyte)[] rsc)
+        => hooks.install_group_key !is null && hooks.install_group_key(sta, key_idx, gtk, rsc);
+    void fwd_complete(const(ubyte)[6] sta, bool success, ushort reason)
+    {
+        if (hooks.handshake_complete !is null)
+            hooks.handshake_complete(sta, success, reason);
+    }
+
+    FourwayAuthContext[max_stations] _sta;
+    bool[max_stations] _active;
+
+    size_t find(const(ubyte)[6] mac)
+    {
+        foreach (i; 0 .. max_stations)
+            if (_active[i] && _sta[i].sta_mac[] == mac[])
+                return i;
+        return max_stations;
+    }
+
+    size_t alloc()
+    {
+        foreach (i; 0 .. max_stations)
+            if (!_active[i])
+                return i;
+        return max_stations;
+    }
+}

--- a/src/urt/driver/wpa/eapol.d
+++ b/src/urt/driver/wpa/eapol.d
@@ -22,6 +22,9 @@ module urt.driver.wpa.eapol;
 
 public import urt.driver.dot1x.eapol;
 
+import urt.digest.hmac : HMACContext, hmac_init, hmac_update, hmac_finalise;
+import urt.digest.sha : SHA1Context;
+
 nothrow @nogc:
 
 
@@ -58,6 +61,7 @@ enum size_t eapol_key_mic_len      = 16;
 enum size_t eapol_key_replay_len   = 8;
 enum size_t eapol_key_rsc_len      = 8;
 enum size_t eapol_key_iv_len       = 16;
+enum size_t eapol_key_max_len      = 256;  // scratch bound for MIC verify
 
 // Offsets within an EAPOL-Key frame, measured from the start of the 802.1X
 // header (so the byte that holds the version is at offset 0).
@@ -202,4 +206,94 @@ void patch_mic(ubyte[] frame, const(ubyte)[eapol_key_mic_len] mic)
     if (frame.length < off_mic + eapol_key_mic_len)
         return;
     frame[off_mic .. off_mic + eapol_key_mic_len] = mic[];
+}
+
+
+void eapol_key_compute_mic(const(ubyte)[] kck, const(ubyte)[] frame, ref ubyte[eapol_key_mic_len] out_mic)
+{
+    HMACContext!SHA1Context h;
+    hmac_init(h, kck);
+    hmac_update(h, frame);
+    ubyte[SHA1Context.DigestLen] digest = hmac_finalise(h);
+    out_mic[] = digest[0 .. eapol_key_mic_len];
+}
+
+
+bool eapol_key_verify_mic(const(ubyte)[] kck, const(ubyte)[] frame, const(ubyte)[eapol_key_mic_len] expected)
+{
+    if (frame.length < off_mic + eapol_key_mic_len || frame.length > eapol_key_max_len)
+        return false;
+
+    ubyte[eapol_key_max_len] scratch = void;
+    scratch[0 .. frame.length] = frame[];
+    scratch[off_mic .. off_mic + eapol_key_mic_len] = 0;
+
+    ubyte[eapol_key_mic_len] computed;
+    eapol_key_compute_mic(kck, scratch[0 .. frame.length], computed);
+
+    ubyte diff = 0;
+    foreach (i; 0 .. eapol_key_mic_len)
+        diff |= computed[i] ^ expected[i];
+    return diff == 0;
+}
+
+
+int eapol_key_replay_compare(const(ubyte)[eapol_key_replay_len] a, const(ubyte)[eapol_key_replay_len] b)
+{
+    foreach (i; 0 .. eapol_key_replay_len)
+        if (int d = a[i] - b[i])
+            return d;
+    return 0;
+}
+
+
+bool parse_gtk_kde(const(ubyte)[] data, ubyte[] out_gtk, ref size_t out_len, ref ubyte out_key_id)
+{
+    size_t off = 0;
+    while (off + 2 <= data.length)
+    {
+        ubyte id  = data[off];
+        ubyte len = data[off + 1];
+        if (off + 2 + len > data.length)
+            return false;
+
+        if (id == 0xDD && len >= 6)
+        {
+            // Vendor-specific IE: OUI(3) + KDE type(1) + payload
+            if (data[off + 2] == 0x00 && data[off + 3] == 0x0F && data[off + 4] == 0xAC
+                && data[off + 5] == 0x01)
+            {
+                // GTK KDE payload: key_id/tx/reserved(1), reserved(1), GTK(N).
+                size_t body_off = off + 6;
+                size_t body_end = off + 2 + len;
+                if (body_end - body_off < 2)
+                    return false;
+                out_key_id = data[body_off] & 0x03;
+                size_t gtk_len = body_end - body_off - 2;
+                if (gtk_len > out_gtk.length)
+                    return false;
+                out_gtk[0 .. gtk_len] = data[body_off + 2 .. body_end];
+                out_len = gtk_len;
+                return true;
+            }
+        }
+
+        off += 2 + len;
+    }
+    return false;
+}
+
+
+size_t encode_gtk_kde(ubyte[] dst, ubyte key_id, const(ubyte)[] gtk)
+{
+    size_t total = 8 + gtk.length;
+    if (dst.length < total || gtk.length + 6 > 0xFF)
+        return 0;
+    dst[0] = 0xDD;
+    dst[1] = cast(ubyte)(6 + gtk.length);
+    dst[2] = 0x00; dst[3] = 0x0F; dst[4] = 0xAC; dst[5] = 0x01;
+    dst[6] = key_id & 0x03;
+    dst[7] = 0x00;
+    dst[8 .. total] = gtk[];
+    return total;
 }

--- a/src/urt/driver/wpa/fourway.d
+++ b/src/urt/driver/wpa/fourway.d
@@ -11,11 +11,9 @@
 // version 3 (AES-CMAC, used for PMF) is planned but not yet implemented.
 module urt.driver.wpa.fourway;
 
-import urt.crypto.aes_keywrap : aes_unwrap;
+import urt.crypto.aes_keywrap : aes_unwrap, aes_wrap;
 import urt.crypto.random : crypto_random_bytes;
 import urt.driver.wpa.crypto;
-import urt.digest.hmac;
-import urt.digest.sha;
 import urt.result : Result, InternalResult;
 
 import urt.driver.wpa.eapol;
@@ -53,6 +51,7 @@ enum WpaHandshakeReason : ushort
     pairwise_install_failed,
     group_install_failed,
     pmf_required_unsupported,
+    timeout,
 }
 
 struct FourwayHooks
@@ -206,7 +205,7 @@ private:
         }
 
         ubyte[eapol_key_mic_len] mic;
-        compute_mic(kck, out_buf[0 .. out_len], mic);
+        eapol_key_compute_mic(kck, out_buf[0 .. out_len], mic);
         patch_mic(out_buf[0 .. out_len], mic);
 
         if (!hooks.send_eapol(out_buf[0 .. out_len]))
@@ -242,11 +241,11 @@ private:
 
         // Replay: must be > last (we treat == as a retransmit and just
         // re-send the prior msg 2; not implemented yet, just drop).
-        if (compare_replay(f.replay_counter, last_replay) <= 0)
+        if (eapol_key_replay_compare(f.replay_counter, last_replay) <= 0)
             return true;
 
         // Verify MIC: compute over frame with the MIC field zeroed.
-        if (!verify_mic(kck, frame, f.key_mic))
+        if (!eapol_key_verify_mic(kck, frame, f.key_mic))
         {
             reset(WpaHandshakeReason.mic_failed);
             return true;
@@ -318,7 +317,7 @@ private:
         }
 
         ubyte[eapol_key_mic_len] mic;
-        compute_mic(kck, out_buf[0 .. out_len], mic);
+        eapol_key_compute_mic(kck, out_buf[0 .. out_len], mic);
         patch_mic(out_buf[0 .. out_len], mic);
         last_msg4[0 .. out_len] = out_buf[0 .. out_len];
         last_msg4_len = out_len;
@@ -367,104 +366,454 @@ const(char)[] wpa_handshake_reason_message(ushort reason) pure nothrow @nogc
         case WpaHandshakeReason.pairwise_install_failed: return "WPA handshake failed: pairwise key install failed";
         case WpaHandshakeReason.group_install_failed:    return "WPA handshake failed: group key install failed";
         case WpaHandshakeReason.pmf_required_unsupported:return "WPA PMF-required networks are not supported yet";
+        case WpaHandshakeReason.timeout:                 return "WPA handshake failed: timed out waiting for peer";
         default:                                        return "WPA handshake failed";
     }
 }
 
 
-private void compute_mic(const(ubyte)[] kck,
-                         const(ubyte)[] frame,
-                         ref ubyte[eapol_key_mic_len] out_mic)
+// =====================================================================
+// AP / authenticator side of the 4-way -- the mirror of FourwayContext:
+//   1/4: send ANonce to the STA (no MIC)
+//   2/4: receive SNonce + RSN IE + MIC -> derive PTK, verify MIC
+//   3/4: send GTK (AES-key-wrapped with KEK) + RSN IE + MIC, install bit set
+//   4/4: receive final MIC -> install pairwise TK + group GTK, authorize port
+// FourwayAuthContext holds one station's handshake; WpaApAuthenticator (in
+// urt.driver.wpa.authenticator) pools these per BSS.
+// =====================================================================
+
+private enum ulong retx_interval_us = 500_000;
+private enum uint  retx_max         = 3;
+
+
+enum FourwayAuthState : ubyte
 {
-    // HMAC-SHA1(KCK, frame_with_zero_mic). We feed the bytes around the MIC
-    // field; the caller passes a frame already zero-filled at off_mic..+16.
-    HMACContext!SHA1Context h;
-    hmac_init(h, kck);
-    hmac_update(h, frame);
-    ubyte[SHA1Context.DigestLen] digest = hmac_finalise(h);
-    out_mic[] = digest[0 .. eapol_key_mic_len];
+    idle,
+    awaiting_msg2,       // sent msg 1, waiting for the STA's SNonce
+    awaiting_msg4,       // sent msg 3, waiting for the STA's confirm
+    completed,
+    failed,
 }
 
 
-private bool verify_mic(const(ubyte)[] kck,
-                        const(ubyte)[] frame,
-                        const(ubyte)[eapol_key_mic_len] expected_mic)
+// Driver-side hooks the authenticator calls during the handshake. Each carries
+// the STA MAC so a single hook set serves every station in the BSS. The driver
+// prepends the ethernet header (dst=sta, src=ap, ethertype 0x888E) on send.
+struct FourwayAuthHooks
 {
-    if (frame.length < off_mic + eapol_key_mic_len)
-        return false;
-
-    // HMAC over frame with the MIC field zeroed. Copy frame into a scratch
-    // buffer so we don't mutate the caller's slice.
-    ubyte[wpa_max_eapol_len] scratch = void;
-    if (frame.length > scratch.length)
-        return false;
-    scratch[0 .. frame.length] = frame[];
-    scratch[off_mic .. off_mic + eapol_key_mic_len] = 0;
-
-    ubyte[eapol_key_mic_len] computed;
-    compute_mic(kck, scratch[0 .. frame.length], computed);
-
-    // Constant-time compare to avoid leaking timing info on the MIC.
-    ubyte diff = 0;
-    foreach (i; 0 .. eapol_key_mic_len)
-        diff |= computed[i] ^ expected_mic[i];
-    return diff == 0;
+    bool delegate(const(ubyte)[6] sta, const(ubyte)[] eapol_payload) nothrow @nogc send_eapol;
+    bool delegate(const(ubyte)[6] sta, const(ubyte)[] tk) nothrow @nogc install_pairwise_key;
+    bool delegate(const(ubyte)[6] sta, ubyte key_idx, const(ubyte)[] gtk, const(ubyte)[] rsc) nothrow @nogc install_group_key;
+    void delegate(const(ubyte)[6] sta, bool success, ushort reason) nothrow @nogc handshake_complete;
 }
 
 
-// Compare two 8-byte replay counters (big-endian). Returns -1 / 0 / 1.
-private int compare_replay(const(ubyte)[eapol_key_replay_len] a,
-                           const(ubyte)[eapol_key_replay_len] b)
+struct FourwayAuthContext
 {
-    foreach (i; 0 .. eapol_key_replay_len)
+    FourwayAuthHooks hooks;
+
+    // Configured material (set by configure)
+    ubyte[wpa_pmk_len] pmk;
+    ubyte[6] ap_mac;
+    ubyte[6] sta_mac;
+    // The RSN IE the AP advertises in its beacon -- echoed in msg 3 key_data.
+    // Live slice; the owner keeps the backing storage valid for the handshake.
+    const(ubyte)[] ap_rsn_ie;
+    ubyte[wpa_gtk_max_len] gtk;
+    size_t gtk_len;
+    ubyte gtk_key_id;
+    ubyte[eapol_key_rsc_len] gtk_rsc;
+
+    // Per-handshake state
+    ubyte[wpa_nonce_len] anonce;
+    ubyte[wpa_nonce_len] snonce;
+    ubyte[wpa_ptk_len_ccmp] ptk;
+    ubyte[eapol_key_replay_len] replay;
+    FourwayAuthState state;
+
+    // Retransmit: last AP-originated frame (msg 1 until msg 2, msg 3 until 4).
+    ubyte[wpa_max_eapol_len] last_tx;
+    size_t last_tx_len;
+    uint retx_count;
+    ulong next_retx_us;
+
+nothrow @nogc:
+
+    void configure(const(ubyte)[wpa_pmk_len] pmk_,
+                   const(ubyte)[6] ap_mac_,
+                   const(ubyte)[6] sta_mac_,
+                   const(ubyte)[] ap_rsn_ie_,
+                   const(ubyte)[] gtk_, ubyte gtk_key_id_,
+                   const(ubyte)[eapol_key_rsc_len] gtk_rsc_)
     {
-        if (a[i] < b[i]) return -1;
-        if (a[i] > b[i]) return 1;
+        pmk = pmk_;
+        ap_mac = ap_mac_;
+        sta_mac = sta_mac_;
+        ap_rsn_ie = ap_rsn_ie_;
+        gtk_len = gtk_.length <= gtk.length ? gtk_.length : gtk.length;
+        gtk[0 .. gtk_len] = gtk_[0 .. gtk_len];
+        gtk_key_id = gtk_key_id_;
+        gtk_rsc = gtk_rsc_;
+        state = FourwayAuthState.idle;
+        replay[] = 0;
+        last_tx_len = 0;
+        retx_count = 0;
+        next_retx_us = 0;
     }
-    return 0;
-}
 
+    @property const(ubyte)[] kck() const => ptk[0 .. wpa_kck_len];
+    @property const(ubyte)[] kek() const => ptk[wpa_kck_len .. wpa_kck_len + wpa_kek_len];
+    @property const(ubyte)[] tk()  const => ptk[wpa_kck_len + wpa_kek_len .. $];
 
-// Walk a buffer of EAPOL key-data IEs looking for the GTK KDE
-// (id=0xDD, OUI=00:0F:AC, kde_type=0x01). Returns true on success and
-// fills out_gtk + out_len + out_key_id.
-private bool parse_gtk_kde(const(ubyte)[] data,
-                           ubyte[] out_gtk,
-                           ref size_t out_len,
-                           ref ubyte out_key_id)
-{
-    size_t off = 0;
-    while (off + 2 <= data.length)
+    // Start the handshake: generate ANonce, send msg 1.
+    bool begin()
     {
-        ubyte id  = data[off];
-        ubyte len = data[off + 1];
-        if (off + 2 + len > data.length)
+        if (!crypto_random_bytes(anonce[]).succeeded)
+        {
+            fail(WpaHandshakeReason.random_failed);
+            return false;
+        }
+        replay[] = 0;
+        inc_replay();                       // replay = 1 for msg 1
+        state = FourwayAuthState.awaiting_msg2;
+        if (!send_msg1())
+        {
+            fail(WpaHandshakeReason.tx_failed);
+            return false;
+        }
+        return true;
+    }
+
+    // Process an incoming EAPOL-Key frame (802.1X payload, ethernet header
+    // already stripped). Returns true if consumed by this handshake.
+    bool handle_eapol(const(ubyte)[] frame)
+    {
+        EapolKeyFrame f;
+        if (!decode_eapol_key(frame, f))
+            return false;
+        if (f.descriptor_type != key_desc_type_rsn)
+            return false;
+        if (f.version_bits != key_info_ver_hmac_sha1_aes)
+            return false;
+        if (!f.pairwise)
+            return false;
+        if (f.key_ack)              // STA->AP frames never carry the ACK bit
+            return false;
+        if (!f.key_mic_set)         // msg 2 and msg 4 always carry a MIC
             return false;
 
-        if (id == 0xDD && len >= 6)
+        // The MIC covers exactly the 802.1X header + body; trim any trailing
+        // bytes (Ethernet padding etc.) so verification matches the sender.
+        size_t pdu = eapol_hdr_len + f.body_length;
+        if (pdu <= frame.length)
+            frame = frame[0 .. pdu];
+
+        if (!f.secure)
+            return handle_msg2(frame, f);
+        else
+            return handle_msg4(frame, f);
+    }
+
+    // Periodic tick (monotonic microseconds). Retransmits the outstanding
+    // AP-originated frame, failing the handshake after retx_max attempts.
+    void tick(ulong now_us)
+    {
+        if (state != FourwayAuthState.awaiting_msg2 && state != FourwayAuthState.awaiting_msg4)
+            return;
+        if (last_tx_len == 0)
+            return;
+        if (next_retx_us == 0)              // arm on the first tick after a send
         {
-            // Vendor-specific IE: OUI(3) + KDE type(1) + payload
-            if (data[off + 2] == 0x00 && data[off + 3] == 0x0F && data[off + 4] == 0xAC
-                && data[off + 5] == 0x01)
-            {
-                // GTK KDE payload: key_id/tx/reserved(1), reserved(1), GTK(N).
-                size_t body_off = off + 6;
-                size_t body_end = off + 2 + len;
-                if (body_end - body_off < 2)
-                    return false;
-                out_key_id = data[body_off] & 0x03;
-                size_t gtk_len = body_end - body_off - 2;
-                if (gtk_len > out_gtk.length)
-                    return false;
-                out_gtk[0 .. gtk_len] = data[body_off + 2 .. body_end];
-                out_len = gtk_len;
-                return true;
-            }
+            next_retx_us = now_us + retx_interval_us;
+            return;
+        }
+        if (now_us < next_retx_us)
+            return;
+        if (retx_count >= retx_max)
+        {
+            fail(WpaHandshakeReason.timeout);
+            return;
+        }
+        if (hooks.send_eapol)
+            hooks.send_eapol(sta_mac, last_tx[0 .. last_tx_len]);
+        ++retx_count;
+        next_retx_us = now_us + retx_interval_us;
+    }
+
+    void reset()
+    {
+        state = FourwayAuthState.idle;
+        last_tx_len = 0;
+        next_retx_us = 0;
+    }
+
+private:
+
+    bool send_msg1()
+    {
+        ushort key_info = key_info_type_pairwise | key_info_key_ack | key_info_ver_hmac_sha1_aes;
+        ubyte[eapol_key_rsc_len] zero_rsc = 0;
+
+        ubyte[wpa_max_eapol_len] buf = void;
+        size_t len = encode_eapol_key(buf[],
+            eapol_version_2004, key_desc_type_rsn,
+            key_info, wpa_tk_len_ccmp,
+            replay, anonce, zero_rsc,
+            null);
+        if (len == 0)
+            return false;
+        // msg 1 carries no MIC.
+        return tx(buf[0 .. len]);
+    }
+
+    bool handle_msg2(const(ubyte)[] frame, ref const EapolKeyFrame f)
+    {
+        if (state != FourwayAuthState.awaiting_msg2)
+            return false;
+        if (eapol_key_replay_compare(f.replay_counter, replay) != 0)
+            return true;        // not the reply to our outstanding msg 1
+
+        snonce = f.key_nonce;
+        if (!wpa2_pmk_to_ptk(pmk, ap_mac, sta_mac, anonce, snonce, ptk[]).succeeded)
+        {
+            fail(WpaHandshakeReason.ptk_failed);
+            return true;
+        }
+        if (!eapol_key_verify_mic(kck, frame, f.key_mic))
+        {
+            fail(WpaHandshakeReason.mic_failed);
+            return true;
         }
 
-        off += 2 + len;
-        if (id == 0xDD)
-            continue;
+        state = FourwayAuthState.awaiting_msg4;
+        if (!send_msg3())
+        {
+            fail(WpaHandshakeReason.encode_failed);
+            return true;
+        }
+        return true;
     }
-    return false;
+
+    bool send_msg3()
+    {
+        // key_data = AP RSN IE || GTK KDE, padded to a multiple of 8, then
+        // AES-key-wrapped with the KEK.
+        ubyte[wpa_max_eapol_len] plain = void;
+        if (ap_rsn_ie.length + 8 + gtk_len + 8 > plain.length)
+            return false;
+        size_t plen = ap_rsn_ie.length;
+        plain[0 .. plen] = ap_rsn_ie[];
+        size_t kde = encode_gtk_kde(plain[plen .. $], gtk_key_id, gtk[0 .. gtk_len]);
+        if (kde == 0)
+            return false;
+        plen += kde;
+        if ((plen & 7) != 0)
+        {
+            plain[plen++] = 0xDD;           // pad KDE
+            while ((plen & 7) != 0)
+                plain[plen++] = 0x00;
+        }
+
+        ubyte[wpa_max_eapol_len] wrapped = void;
+        size_t wlen = plen + 8;
+        if (wlen > wrapped.length)
+            return false;
+        if (!aes_wrap(kek, plain[0 .. plen], wrapped[0 .. wlen]).succeeded)
+            return false;
+
+        inc_replay();                       // replay = 2 for msg 3
+        ushort key_info = key_info_type_pairwise | key_info_install | key_info_key_ack |
+            key_info_key_mic | key_info_secure | key_info_encr_key_data | key_info_ver_hmac_sha1_aes;
+
+        ubyte[wpa_max_eapol_len] buf = void;
+        size_t len = encode_eapol_key(buf[],
+            eapol_version_2004, key_desc_type_rsn,
+            key_info, wpa_tk_len_ccmp,
+            replay, anonce, gtk_rsc,
+            wrapped[0 .. wlen]);
+        if (len == 0)
+            return false;
+
+        ubyte[eapol_key_mic_len] mic;
+        eapol_key_compute_mic(kck, buf[0 .. len], mic);
+        patch_mic(buf[0 .. len], mic);
+        return tx(buf[0 .. len]);
+    }
+
+    bool handle_msg4(const(ubyte)[] frame, ref const EapolKeyFrame f)
+    {
+        if (state != FourwayAuthState.awaiting_msg4)
+            return false;
+        if (eapol_key_replay_compare(f.replay_counter, replay) != 0)
+            return true;
+        if (!eapol_key_verify_mic(kck, frame, f.key_mic))
+        {
+            fail(WpaHandshakeReason.mic_failed);
+            return true;
+        }
+
+        if (hooks.install_pairwise_key && !hooks.install_pairwise_key(sta_mac, tk))
+        {
+            fail(WpaHandshakeReason.pairwise_install_failed);
+            return true;
+        }
+        if (hooks.install_group_key &&
+            !hooks.install_group_key(sta_mac, gtk_key_id, gtk[0 .. gtk_len], gtk_rsc[]))
+        {
+            fail(WpaHandshakeReason.group_install_failed);
+            return true;
+        }
+
+        last_tx_len = 0;
+        state = FourwayAuthState.completed;
+        if (hooks.handshake_complete)
+            hooks.handshake_complete(sta_mac, true, 0);
+        return true;
+    }
+
+    bool tx(const(ubyte)[] eapol)
+    {
+        if (eapol.length <= last_tx.length)
+        {
+            last_tx[0 .. eapol.length] = eapol[];
+            last_tx_len = eapol.length;
+        }
+        retx_count = 0;
+        next_retx_us = 0;                   // tick() re-arms the deadline
+        if (hooks.send_eapol is null)
+            return false;
+        return hooks.send_eapol(sta_mac, eapol);
+    }
+
+    void inc_replay()
+    {
+        foreach_reverse (i; 0 .. replay.length)
+        {
+            if (++replay[i] != 0)
+                break;
+        }
+    }
+
+    void fail(WpaHandshakeReason reason)
+    {
+        state = FourwayAuthState.failed;
+        last_tx_len = 0;
+        if (hooks.handshake_complete)
+            hooks.handshake_complete(sta_mac, false, cast(ushort)reason);
+    }
+}
+
+
+// Drives the supplicant-side FourwayContext against the authenticator-side
+// FourwayAuthContext through a non-reentrant frame mailbox, and asserts both
+// sides complete with a matching pairwise key and the GTK delivered intact.
+// Harness state lives in a struct so the hook delegates are bound method
+// pointers (no GC closure) -- the module is @nogc.
+unittest
+{
+    import urt.crypto.pbkdf2 : wpa2_psk_to_pmk;
+
+    static immutable ubyte[22] rsn_ie = [
+        0x30, 0x14,
+        0x01, 0x00,
+        0x00, 0x0f, 0xac, 0x04,
+        0x01, 0x00,
+        0x00, 0x0f, 0xac, 0x04,
+        0x01, 0x00,
+        0x00, 0x0f, 0xac, 0x02,
+        0x00, 0x00,
+    ];
+    static immutable ubyte[16] test_gtk = [
+        0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7,
+        0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF,
+    ];
+
+    static struct Harness
+    {
+        enum ubyte to_sta = 1, to_ap = 2;
+
+        FourwayContext sta;
+        FourwayAuthContext ap;
+
+        // Non-reentrant ping-pong mailbox: hooks enqueue, run() delivers.
+        ubyte[256][8] qbuf;
+        size_t[8] qlen;
+        ubyte[8] qtag;
+        size_t qhead, qtail;
+
+        bool sta_done, sta_ok, ap_done, ap_ok;
+        ubyte[wpa_tk_len_ccmp] sta_tk, ap_tk;
+        ubyte[wpa_gtk_max_len] sta_gtk;
+        size_t sta_gtk_len;
+
+    nothrow @nogc:
+
+        void push(ubyte tag, const(ubyte)[] p)
+        {
+            assert(qtail < qbuf.length && p.length <= qbuf[0].length);
+            qtag[qtail] = tag;
+            qbuf[qtail][0 .. p.length] = p[];
+            qlen[qtail] = p.length;
+            ++qtail;
+        }
+
+        bool sta_send(const(ubyte)[] p) { push(to_ap, p); return true; }
+        bool sta_pair(const(ubyte)[] t) { sta_tk[] = t[0 .. wpa_tk_len_ccmp]; return true; }
+        bool sta_grp(ubyte idx, const(ubyte)[] g, const(ubyte)[] rsc)
+        { sta_gtk_len = g.length; sta_gtk[0 .. g.length] = g[]; return true; }
+        void sta_complete(bool ok, ushort r) { sta_done = true; sta_ok = ok; }
+
+        bool ap_send(const(ubyte)[6] s, const(ubyte)[] p) { push(to_sta, p); return true; }
+        bool ap_pair(const(ubyte)[6] s, const(ubyte)[] t) { ap_tk[] = t[0 .. wpa_tk_len_ccmp]; return true; }
+        bool ap_grp(const(ubyte)[6] s, ubyte idx, const(ubyte)[] g, const(ubyte)[] rsc) { return true; }
+        void ap_complete(const(ubyte)[6] s, bool ok, ushort r) { ap_done = true; ap_ok = ok; }
+
+        void run()
+        {
+            uint guard = 0;
+            while (qhead < qtail)
+            {
+                ubyte tag = qtag[qhead];
+                const(ubyte)[] frame = qbuf[qhead][0 .. qlen[qhead]];
+                ++qhead;
+                if (tag == to_sta)
+                    sta.handle_eapol(frame);
+                else
+                    ap.handle_eapol(frame);
+                assert(++guard < 32);
+            }
+        }
+    }
+
+    ubyte[6] ap_mac  = [0x02, 0x00, 0x00, 0x00, 0x00, 0xAA];
+    ubyte[6] sta_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0xBB];
+
+    ubyte[wpa_pmk_len] pmk;
+    assert(wpa2_psk_to_pmk("password123", "testnet", pmk).succeeded);
+
+    Harness h;
+
+    h.sta.configure(pmk, sta_mac, ap_mac, rsn_ie[]);
+    h.sta.hooks.send_eapol = &h.sta_send;
+    h.sta.hooks.install_pairwise_key = &h.sta_pair;
+    h.sta.hooks.install_group_key = &h.sta_grp;
+    h.sta.hooks.handshake_complete = &h.sta_complete;
+    h.sta.begin_association();
+
+    ubyte[eapol_key_rsc_len] gtk_rsc = 0;
+    h.ap.configure(pmk, ap_mac, sta_mac, rsn_ie[], test_gtk[], 1, gtk_rsc);
+    h.ap.hooks.send_eapol = &h.ap_send;
+    h.ap.hooks.install_pairwise_key = &h.ap_pair;
+    h.ap.hooks.install_group_key = &h.ap_grp;
+    h.ap.hooks.handshake_complete = &h.ap_complete;
+
+    assert(h.ap.begin());
+    h.run();
+
+    assert(h.sta_done && h.sta_ok);
+    assert(h.ap_done && h.ap_ok);
+    assert(h.sta.state == FourwayState.completed);
+    assert(h.ap.state == FourwayAuthState.completed);
+    assert(h.sta_tk == h.ap_tk);                            // both derived the same PTK
+    assert(h.sta_gtk_len == 16 && h.sta_gtk[0 .. 16] == test_gtk[]);  // GTK delivered
 }

--- a/src/urt/driver/wpa/package.d
+++ b/src/urt/driver/wpa/package.d
@@ -1,5 +1,6 @@
 module urt.driver.wpa;
 
+public import urt.driver.wpa.authenticator;
 public import urt.driver.wpa.eapol;
 public import urt.driver.wpa.fourway;
 public import urt.driver.wpa.supplicant;

--- a/src/urt/driver/wpa/supplicant.d
+++ b/src/urt/driver/wpa/supplicant.d
@@ -225,8 +225,6 @@ WpaKeyMgmt infer_key_mgmt(ref const WifiStaConfig cfg)
     if (cfg.password.length == 0)
         return WpaKeyMgmt.none;
 
-    // The current WifiStaConfig does not expose scan-selected AKM yet. For the
-    // first BL808 target, a passphrase means WPA2-PSK unless a later scan/RSN
-    // parser upgrades it to SAE or enterprise.
+    // WPA2-PSK is the only AKM implemented, so a passphrase means WPA2-PSK.
     return WpaKeyMgmt.wpa2_psk;
 }


### PR DESCRIPTION
Migrate the linux wifi implementation to drive the kernel directly rather than pipe via the daemons (wpa_supplicant/hostapd).