### PR TITLE
Defer ESP32 WiFi events to the main task

### DIFF
--- a/src/urt/driver/bl808_m0/bl_ops.d
+++ b/src/urt/driver/bl808_m0/bl_ops.d
@@ -18,6 +18,7 @@
 module urt.driver.bl808_m0.bl_ops;
 
 import urt.attribute : section;
+import urt.atomic : MemoryOrder, atomicLoad, atomicStore;
 
 version (BL808_M0):
 
@@ -378,17 +379,21 @@ __gshared AwakenEvent  _wifi_pending_event;
 
 extern(D)
 {
-    alias WifiWakeCallback = void function() nothrow @nogc;
-    private __gshared WifiWakeCallback _wifi_wake_callback;
+    alias WifiReadyHandler = void function() nothrow @nogc;
+    private shared size_t _wifi_ready_callback_bits;
 
-    public void wifi_set_wake_callback(WifiWakeCallback cb)
+    public void wifi_set_ready_callback(WifiReadyHandler cb)
     {
-        _wifi_wake_callback = cb;
+        atomicStore!(MemoryOrder.seq)(
+            _wifi_ready_callback_bits, cast(size_t)cb);
+        if (cb !is null)
+            cb();
     }
 
     public void wifi_signal_ready()
     {
-        auto cb = _wifi_wake_callback;
+        auto cb = cast(WifiReadyHandler)
+            atomicLoad!(MemoryOrder.seq)(_wifi_ready_callback_bits);
         if (cb !is null)
             cb();
     }

--- a/src/urt/driver/bl808_m0/wifi.d
+++ b/src/urt/driver/bl808_m0/wifi.d
@@ -46,9 +46,9 @@ nothrow @nogc:
 // WiFi driver API
 // ====================================================================
 
-void wifi_hw_set_wake_callback(void function() nothrow @nogc cb)
+void wifi_hw_set_ready_callback(WifiReadyCallback cb)
 {
-    urt.driver.bl808_m0.bl_ops.wifi_set_wake_callback(cb);
+    urt.driver.bl808_m0.bl_ops.wifi_set_ready_callback(cb);
 }
 
 bool wifi_hw_open(ubyte port, ref const WifiConfig cfg)
@@ -60,6 +60,7 @@ bool wifi_hw_open(ubyte port, ref const WifiConfig cfg)
 
     if (port != 0)
         return false;
+    reset_queues();
     _configured_channel = cfg.channel;
     _current_channel = 0;
     _sta_candidate_channel = 0;
@@ -228,8 +229,7 @@ void wifi_hw_close(ubyte port)
     _event_cb = null;
     _rx_cb = null;
     _raw_rx_cb = null;
-    _wifi_evt_head = 0;
-    _wifi_evt_tail = 0;
+    reset_queues();
     _sta_ap_idx = ubyte.max;
     _sta_pending_pmk[] = 0;
     _sta_pending_pmk_hex[] = 0;
@@ -576,6 +576,15 @@ void wifi_hw_set_rx_callback(ubyte port, WifiRxCallback cb)
     _rx_cb = cb;
 }
 
+uint wifi_hw_take_rx_drops(ubyte port)
+{
+    if (port != 0)
+        return 0;
+    uint drops = _wifi_rx_drops;
+    _wifi_rx_drops = 0;
+    return drops;
+}
+
 bool wifi_hw_raw_tx(ubyte port, const(ubyte)[] frame)
 {
     return bl_send_scanu_raw_send(&_bl_hw, cast(ubyte*)frame.ptr, cast(int)frame.length) == 0;
@@ -630,13 +639,33 @@ void wifi_hw_set_event_callback(ubyte port, WifiEventCallback cb)
     _event_cb = cb;
 }
 
-void wifi_hw_poll(ubyte port)
+uint wifi_hw_take_event_drops(ubyte port)
 {
+    if (port != 0)
+        return 0;
+    uint drops = _wifi_evt_drops;
+    _wifi_evt_drops = 0;
+    return drops;
+}
+
+bool wifi_hw_service(ubyte port, size_t budget)
+{
+    if (port != 0)
+        return false;
+    if (_servicing)
+        return queues_pending();
+
+    _servicing = true;
     if (_bl_hw.is_up && _bl_hw.ipc_env !is null)
         bl_irq_bottomhalf(&_bl_hw);
     wifi_fibre_pump();
-    dispatch_queued_events();
-    ap_auth_tick();
+    uint generation = _queue_generation;
+    dispatch_queued_callbacks(budget, generation);
+    if (generation == _queue_generation)
+        ap_auth_tick();
+    bool pending = queues_pending();
+    _servicing = false;
+    return pending;
 }
 
 
@@ -656,11 +685,33 @@ struct WifiQueuedEvent
     WifiEvent event;
     ubyte[6] mac;
     bool has_mac;
+    WifiStaDisconnectInfo disconnect;
 }
 enum size_t wifi_evt_cap = 16;
 __gshared WifiQueuedEvent[wifi_evt_cap] _wifi_evt_queue;
 __gshared uint _wifi_evt_head;
 __gshared uint _wifi_evt_tail;
+__gshared uint _wifi_evt_drops;
+
+enum size_t wifi_rx_frame_max = 1518;
+// The vendor owns RX storage only until tcpip_stack_input() returns. This
+// PSRAM copy queue preserves frames for budgeted main-context delivery.
+align(4) struct WifiQueuedRx
+{
+    ubyte[wifi_rx_frame_max] data;
+    ushort length;
+    ubyte vif;
+}
+// Eight maximum-sized frames consume about 12 KiB of the 1 MiB M0 PSRAM.
+enum size_t wifi_rx_cap = 8;
+__gshared WifiQueuedRx[wifi_rx_cap] _wifi_rx_queue;
+__gshared ubyte[wifi_rx_frame_max] _wifi_rx_dispatch_buffer;
+__gshared uint _wifi_rx_head;
+__gshared uint _wifi_rx_tail;
+__gshared uint _wifi_rx_drops;
+__gshared ubyte _service_cursor;
+__gshared bool _servicing;
+__gshared uint _queue_generation;
 
 @section(".sram_data.wifi") __gshared bl_hw _bl_hw;
 
@@ -875,10 +926,8 @@ extern(C) int tcpip_stack_input(void* swdesc, ubyte status, void* hwhdr, uint ms
         {
             _wpa_sta_rx_eapol_real(cast(ubyte*)(eth + 6), cast(ubyte*)(eth + 14), eth_len - 14);
         }
-        else if (_rx_cb !is null && eth_len <= 1518)
-        {
-            _rx_cb(Wifi(0), rx_vif, eth[0 .. eth_len]);
-        }
+        else if (_rx_cb !is null)
+            queue_rx(rx_vif, eth[0 .. eth_len]);
     }
 
     return -1;
@@ -926,31 +975,135 @@ private void install_msg_hdlrs()
 }
 
 
+private void reset_queues()
+{
+    ++_queue_generation;
+    _wifi_evt_head = 0;
+    _wifi_evt_tail = 0;
+    _wifi_evt_drops = 0;
+    _wifi_rx_head = 0;
+    _wifi_rx_tail = 0;
+    _wifi_rx_drops = 0;
+    _service_cursor = 0;
+}
+
+private bool queues_pending()
+{
+    return _wifi_evt_head != _wifi_evt_tail ||
+           _wifi_rx_head != _wifi_rx_tail;
+}
+
+private void queue_rx(WifiVif vif, const(ubyte)[] frame)
+{
+    if (frame.length > wifi_rx_frame_max ||
+        _wifi_rx_head - _wifi_rx_tail >= wifi_rx_cap)
+    {
+        ++_wifi_rx_drops;
+        wifi_signal_ready();
+        return;
+    }
+
+    auto slot = &_wifi_rx_queue[_wifi_rx_head & (wifi_rx_cap - 1)];
+    slot.data[0 .. frame.length] = frame;
+    slot.length = cast(ushort)frame.length;
+    slot.vif = cast(ubyte)vif;
+    _wifi_rx_head++;
+    wifi_signal_ready();
+}
+
 package void queue_event(WifiEvent event, const(void)* data)
 {
     if (_wifi_evt_head - _wifi_evt_tail >= wifi_evt_cap)
+    {
         _wifi_evt_tail++;
+        ++_wifi_evt_drops;
+    }
     auto slot = &_wifi_evt_queue[_wifi_evt_head & (wifi_evt_cap - 1)];
     slot.event = event;
     slot.has_mac = data !is null &&
         (event == WifiEvent.ap_sta_connected || event == WifiEvent.ap_sta_disconnected);
     if (slot.has_mac)
         slot.mac[] = (cast(const(ubyte)*)data)[0 .. 6];
+    if (event == WifiEvent.sta_disconnected)
+    {
+        slot.disconnect.reason = data is null
+            ? 0
+            : (cast(const(ushort)*)data)[1];
+        slot.disconnect.message = wifi_hw_sta_status_message(0);
+    }
     _wifi_evt_head++;
+    wifi_signal_ready();
 }
 
-private void dispatch_queued_events()
+private size_t dispatch_queued_callbacks(size_t budget, uint generation)
 {
     if (_event_cb is null)
-        return;
+        _wifi_evt_tail = _wifi_evt_head;
+    if (_rx_cb is null)
+        _wifi_rx_tail = _wifi_rx_head;
 
-    Wifi w = Wifi(0);
-    while (_wifi_evt_head != _wifi_evt_tail)
+    size_t dispatched;
+    uint empty_queues;
+    while (dispatched < budget && empty_queues < 2 &&
+           generation == _queue_generation)
     {
-        auto slot = &_wifi_evt_queue[_wifi_evt_tail & (wifi_evt_cap - 1)];
-        _wifi_evt_tail++;
-        _event_cb(w, slot.event, slot.has_mac ? slot.mac.ptr : null);
+        ubyte source = _service_cursor;
+        _service_cursor = cast(ubyte)((source + 1) % 2);
+        bool delivered = source == 0
+            ? dispatch_one_event()
+            : dispatch_one_rx();
+        if (delivered)
+        {
+            ++dispatched;
+            empty_queues = 0;
+        }
+        else
+            ++empty_queues;
     }
+    return dispatched;
+}
+
+private bool dispatch_one_event()
+{
+    auto cb = _event_cb;
+    if (cb is null)
+    {
+        _wifi_evt_tail = _wifi_evt_head;
+        return false;
+    }
+    if (_wifi_evt_head == _wifi_evt_tail)
+        return false;
+
+    auto slot = &_wifi_evt_queue[_wifi_evt_tail & (wifi_evt_cap - 1)];
+    WifiQueuedEvent queued = *slot;
+    _wifi_evt_tail++;
+    const(void)* event_data;
+    if (queued.event == WifiEvent.sta_disconnected)
+        event_data = &queued.disconnect;
+    else if (queued.has_mac)
+        event_data = queued.mac.ptr;
+    cb(Wifi(0), queued.event, event_data);
+    return true;
+}
+
+private bool dispatch_one_rx()
+{
+    auto cb = _rx_cb;
+    if (cb is null)
+    {
+        _wifi_rx_tail = _wifi_rx_head;
+        return false;
+    }
+    if (_wifi_rx_head == _wifi_rx_tail)
+        return false;
+
+    auto slot = &_wifi_rx_queue[_wifi_rx_tail & (wifi_rx_cap - 1)];
+    size_t length = slot.length;
+    WifiVif vif = cast(WifiVif)slot.vif;
+    _wifi_rx_dispatch_buffer[0 .. length] = slot.data[0 .. length];
+    _wifi_rx_tail++;
+    cb(Wifi(0), vif, _wifi_rx_dispatch_buffer[0 .. length]);
+    return true;
 }
 
 private int fw_vif_index(WifiVif vif)

--- a/src/urt/driver/bl808_m0/wifi_lmac.d
+++ b/src/urt/driver/bl808_m0/wifi_lmac.d
@@ -238,7 +238,7 @@ void bl_irq_bottomhalf(bl_hw* bl_hw);
 int  bl_shim_ipc_init(bl_hw* bl_hw, ipc_shared_env_tag* shared_mem);
 
 // libwifi.a entry point. Long-lived task; we spawn it on a fibre and pump
-// it from wifi_hw_poll. Param is unused by the blob (vendor SDK passes NULL).
+// it from wifi_hw_service. Param is unused by the blob (vendor SDK passes NULL).
 void wifi_main(void* param);
 
 struct phy_channel_info

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -393,20 +393,22 @@ int ow_wifi_ap_set_max_clients(uint8_t max_conn)
 // esp_wifi_internal_reg_rxcb gives us raw Ethernet frames before lwIP,
 // so the bridge/routing layer sees all traffic.
 
-typedef void (*ow_wifi_rx_cb_t)(const uint8_t *data, int len, int iface);
+// Return non-zero when the callback retains eb and assumes responsibility for
+// releasing it with ow_wifi_free_rx_buffer().
+typedef int (*ow_wifi_rx_cb_t)(const uint8_t *data, int len, int iface, void *eb);
 
 static ow_wifi_rx_cb_t ow_wifi_rx_callback;
 
 static esp_err_t ow_wifi_sta_rx(void *buffer, uint16_t len, void *eb)
 {
+    int retained = 0;
     if (ow_wifi_rx_callback)
-        ow_wifi_rx_callback((const uint8_t *)buffer, len, 0);
+        retained = ow_wifi_rx_callback((const uint8_t *)buffer, len, 0, eb);
 #ifdef OW_USE_LWIP
+    (void)retained;
     return esp_netif_receive(ow_wifi_netif_sta, buffer, len, eb);
 #else
-    // Internal stack consumes via ow_wifi_rx_callback; we own the eb buffer
-    // (esp_netif_receive normally frees it).
-    if (eb)
+    if (eb && !retained)
         esp_wifi_internal_free_rx_buffer(eb);
     return ESP_OK;
 #endif
@@ -414,15 +416,23 @@ static esp_err_t ow_wifi_sta_rx(void *buffer, uint16_t len, void *eb)
 
 static esp_err_t ow_wifi_ap_rx(void *buffer, uint16_t len, void *eb)
 {
+    int retained = 0;
     if (ow_wifi_rx_callback)
-        ow_wifi_rx_callback((const uint8_t *)buffer, len, 1);
+        retained = ow_wifi_rx_callback((const uint8_t *)buffer, len, 1, eb);
 #ifdef OW_USE_LWIP
+    (void)retained;
     return esp_netif_receive(ow_wifi_netif_ap, buffer, len, eb);
 #else
-    if (eb)
+    if (eb && !retained)
         esp_wifi_internal_free_rx_buffer(eb);
     return ESP_OK;
 #endif
+}
+
+void ow_wifi_free_rx_buffer(void *eb)
+{
+    if (eb)
+        esp_wifi_internal_free_rx_buffer(eb);
 }
 
 int ow_wifi_set_rx_callback(ow_wifi_rx_cb_t cb)
@@ -459,7 +469,8 @@ static ow_wifi_promisc_cb_t ow_wifi_promisc_callback;
 
 static void ow_wifi_promisc_trampoline(void *buf, wifi_promiscuous_pkt_type_t type)
 {
-    if (!ow_wifi_promisc_callback || !buf)
+    // ESP-IDF reports WIFI_PKT_MISC with metadata but no payload.
+    if (!ow_wifi_promisc_callback || !buf || type == WIFI_PKT_MISC)
         return;
     const wifi_promiscuous_pkt_t *pkt = (const wifi_promiscuous_pkt_t *)buf;
     const wifi_pkt_rx_ctrl_t *rx = &pkt->rx_ctrl;

--- a/src/urt/driver/esp32/wifi.d
+++ b/src/urt/driver/esp32/wifi.d
@@ -4,8 +4,8 @@
 //   - ow_wifi_init/deinit: WIFI_INIT_CONFIG_DEFAULT macro, netif creation,
 //     event handler registration
 //   - ow_wifi_sta_config/ap_config: wifi_config_t struct construction
-//   - ow_wifi_set_rx_callback: RX trampolines that forward to D AND to
-//     esp_netif_receive (so lwIP still works)
+//   - ow_wifi_set_rx_callback: RX trampolines that queue frames for D AND
+//     forward to esp_netif_receive (so lwIP still works)
 //
 // Everything else (mode, connect, disconnect, tx, mac, channel, power)
 // calls ESP-IDF directly.
@@ -13,6 +13,7 @@
 // ESP32 has one WiFi port (port 0).
 module urt.driver.esp32.wifi;
 
+import urt.atomic : MemoryOrder, atomicExchange, atomicFetchAdd, atomicLoad, atomicStore;
 import urt.driver.wifi;
 
 nothrow @nogc:
@@ -35,9 +36,10 @@ static if (num_wifi > 0):
 
 bool wifi_hw_open(uint port, ref const WifiConfig cfg)
 {
-    if (_opened)
+    if (port >= num_wifi || _opened)
         return false;
 
+    reset_queues();
     if (ow_wifi_init() != 0)
         return false;
 
@@ -61,17 +63,18 @@ void wifi_hw_close(uint port)
 {
     if (!_opened)
         return;
-    ow_wifi_set_rx_callback(null);
-    ow_wifi_set_sta_callback(null);
-    ow_wifi_set_ap_callback(null);
-    esp_wifi_stop();
-    ow_wifi_deinit();
-    _opened = false;
     _event_cb = null;
     _rx_cb = null;
     _raw_rx_cb = null;
-    _wifi_evt_head = 0;
-    _wifi_evt_tail = 0;
+    ow_wifi_set_rx_callback(null);
+    ow_wifi_set_sta_callback(null);
+    ow_wifi_set_ap_callback(null);
+    ow_wifi_set_promiscuous_callback(null);
+    ow_wifi_set_promiscuous(0, 0);
+    reset_queues();
+    esp_wifi_stop();
+    ow_wifi_deinit();
+    _opened = false;
 }
 
 bool wifi_hw_set_mode(uint port, WifiMode mode)
@@ -137,13 +140,14 @@ const(char)[] wifi_hw_sta_status_message(uint port)
 {
     if (_sta_status_message.length != 0)
         return _sta_status_message;
-    return esp_wifi_sta_reason_message(_sta_disconnect_reason);
+    return esp_wifi_sta_reason_message(
+        atomicLoad!(MemoryOrder.acquire)(_sta_disconnect_reason));
 }
 
 bool wifi_hw_sta_connect(uint port)
 {
     _sta_status_message = null;
-    _sta_disconnect_reason = 0;
+    atomicStore!(MemoryOrder.release)(_sta_disconnect_reason, 0);
     auto rc = esp_wifi_connect();
     if (rc == ESP_OK)
         return true;
@@ -217,6 +221,20 @@ void wifi_hw_set_rx_callback(uint port, WifiRxCallback cb)
     ow_wifi_set_rx_callback(cb !is null ? &rx_trampoline : null);
 }
 
+uint wifi_hw_take_rx_drops(uint port)
+{
+    if (port >= num_wifi)
+        return 0;
+    return atomicExchange!(MemoryOrder.relaxed)(&_wifi_rx_drops, 0u);
+}
+
+uint wifi_hw_take_event_drops(uint port)
+{
+    if (port >= num_wifi)
+        return 0;
+    return atomicExchange!(MemoryOrder.relaxed)(&_wifi_evt_drops, 0u);
+}
+
 // Raw 802.11 TX/RX
 
 bool wifi_hw_raw_tx(uint port, const(ubyte)[] frame)
@@ -247,6 +265,24 @@ void wifi_hw_set_raw_rx_callback(uint port, WifiRawRxCallback cb)
     // correctly but content is wrong".
     enum uint WIFI_PROMIS_FILTER_MASK_ALL_WITH_FCSFAIL = 0xE00000FF;
     ow_wifi_set_promiscuous(1, WIFI_PROMIS_FILTER_MASK_ALL_WITH_FCSFAIL);
+}
+
+uint wifi_hw_take_raw_rx_drops(uint port)
+{
+    if (port >= num_wifi)
+        return 0;
+    return atomicExchange!(MemoryOrder.relaxed)(&_wifi_raw_rx_drops, 0u);
+}
+
+void wifi_hw_set_ready_callback(WifiReadyCallback cb)
+{
+    atomicStore!(MemoryOrder.seq)(_ready_cb_bits, cast(size_t)cb);
+
+    // Registration is itself a readiness edge. This closes the startup race
+    // where ESP-IDF can post STA_START before the frontend installs its
+    // callback; an empty service pass is harmless.
+    if (cb !is null)
+        cb();
 }
 
 bool wifi_hw_set_channel(uint port, ubyte primary)
@@ -291,22 +327,120 @@ void wifi_hw_set_event_callback(uint port, WifiEventCallback cb)
     _event_cb = cb;
 }
 
-void wifi_hw_poll(uint port)
+bool wifi_hw_service(uint port, size_t budget)
 {
-    if (_event_cb is null)
-        return;
+    if (port >= num_wifi)
+        return false;
+    // Callback code may initiate shutdown. Keep the entry published until the
+    // callback returns, block recursive consumers, and only advance its tail
+    // if shutdown did not reset the queues underneath this service pass.
+    if (_servicing)
+        return queues_pending();
 
-    Wifi w = Wifi(0);
-    while (_wifi_evt_head != _wifi_evt_tail)
+    _servicing = true;
+    uint generation = atomicLoad!(MemoryOrder.acquire)(_queue_generation);
+    Wifi w = Wifi(cast(ubyte)port);
+    size_t serviced;
+    uint empty_queues;
+
+    while (serviced < budget && empty_queues < 3 &&
+           generation == atomicLoad!(MemoryOrder.acquire)(_queue_generation))
     {
-        auto slot = &_wifi_evt_queue[_wifi_evt_tail & (wifi_evt_cap - 1)];
-        _wifi_evt_tail++;
-        _event_cb(w, slot.event, slot.has_mac ? slot.mac.ptr : null);
+        bool dispatched;
+        final switch (_service_cursor)
+        {
+            case 0:
+                dispatched = dispatch_one_event(w);
+                break;
+            case 1:
+                dispatched = dispatch_one_rx(w);
+                break;
+            case 2:
+                dispatched = dispatch_one_raw_rx(w);
+                break;
+        }
+        _service_cursor = cast(ubyte)((_service_cursor + 1) % 3);
+        if (dispatched)
+        {
+            ++serviced;
+            empty_queues = 0;
+        }
+        else
+            ++empty_queues;
     }
+
+    _servicing = false;
+    return queues_pending();
 }
 
-
 private:
+
+bool dispatch_one_event(Wifi wifi)
+{
+    uint tail = atomicLoad!(MemoryOrder.relaxed)(_wifi_evt_tail);
+    if (tail == atomicLoad!(MemoryOrder.acquire)(_wifi_evt_head))
+        return false;
+    auto slot = &_wifi_evt_queue[tail & (wifi_evt_cap - 1)];
+    WifiQueuedEvent queued = *slot;
+    uint generation = atomicLoad!(MemoryOrder.acquire)(_queue_generation);
+    if (_event_cb !is null)
+    {
+        const(void)* data;
+        if (queued.event == WifiEvent.sta_disconnected)
+            data = &queued.disconnect;
+        else if (queued.has_mac)
+            data = queued.mac.ptr;
+        _event_cb(wifi, queued.event, data);
+    }
+    if (generation == atomicLoad!(MemoryOrder.acquire)(_queue_generation))
+        atomicStore!(MemoryOrder.release)(_wifi_evt_tail, tail + 1);
+    return true;
+}
+
+bool dispatch_one_rx(Wifi wifi)
+{
+    uint tail = atomicLoad!(MemoryOrder.relaxed)(_wifi_rx_tail);
+    if (tail == atomicLoad!(MemoryOrder.acquire)(_wifi_rx_head))
+        return false;
+    auto slot = &_wifi_rx_queue[tail & (wifi_rx_cap - 1)];
+    version (UseInternalIPStack)
+    {
+        ubyte[wifi_rx_frame_max] frame = void;
+        size_t length = slot.length;
+        WifiVif vif = cast(WifiVif)slot.vif;
+        void* eb = slot.eb;
+        if (_rx_cb !is null)
+            frame[0 .. length] = slot.data[0 .. length];
+        slot.eb = null;
+        atomicStore!(MemoryOrder.release)(_wifi_rx_tail, tail + 1);
+        ow_wifi_free_rx_buffer(eb);
+        if (_rx_cb !is null)
+            _rx_cb(wifi, vif, frame[0 .. length]);
+    }
+    else
+    {
+        uint generation = atomicLoad!(MemoryOrder.acquire)(_queue_generation);
+        if (_rx_cb !is null)
+            _rx_cb(wifi, cast(WifiVif)slot.vif, slot.data[0 .. slot.length]);
+        if (generation == atomicLoad!(MemoryOrder.acquire)(_queue_generation))
+            atomicStore!(MemoryOrder.release)(_wifi_rx_tail, tail + 1);
+    }
+    return true;
+}
+
+bool dispatch_one_raw_rx(Wifi wifi)
+{
+    uint tail = atomicLoad!(MemoryOrder.relaxed)(_wifi_raw_rx_tail);
+    if (tail == atomicLoad!(MemoryOrder.acquire)(_wifi_raw_rx_head))
+        return false;
+    auto slot = &_wifi_raw_rx_queue[tail & (wifi_raw_rx_cap - 1)];
+    uint generation = atomicLoad!(MemoryOrder.acquire)(_queue_generation);
+    if (_raw_rx_cb !is null)
+        _raw_rx_cb(wifi, slot.data[0 .. slot.length], slot.rssi, slot.channel);
+    if (generation == atomicLoad!(MemoryOrder.acquire)(_queue_generation))
+        atomicStore!(MemoryOrder.release)(_wifi_raw_rx_tail, tail + 1);
+    return true;
+}
 
 enum int ESP_OK = 0;
 
@@ -327,45 +461,164 @@ __gshared bool _opened;
 __gshared WifiEventCallback _event_cb;
 __gshared WifiRxCallback _rx_cb;
 __gshared WifiRawRxCallback _raw_rx_cb;
-__gshared int _sta_disconnect_reason;
+shared size_t _ready_cb_bits;
+shared int _sta_disconnect_reason;
 __gshared const(char)[] _sta_status_message;
+__gshared ubyte _service_cursor;
+__gshared bool _servicing;
+shared uint _queue_generation;
 
+// ESP-IDF serialises each source onto one producer task: system events use
+// the default event task, while Ethernet and promiscuous RX use the WiFi
+// driver task. Each queue therefore has one producer and the OpenWatt reactor
+// is its sole consumer.
 struct WifiQueuedEvent
 {
     WifiEvent event;
     ubyte[6] mac;
     bool has_mac;
+    WifiStaDisconnectInfo disconnect;
 }
 enum size_t wifi_evt_cap = 8;
 __gshared WifiQueuedEvent[wifi_evt_cap] _wifi_evt_queue;
-__gshared uint _wifi_evt_head;
-__gshared uint _wifi_evt_tail;
+shared uint _wifi_evt_head;
+shared uint _wifi_evt_tail;
+shared uint _wifi_evt_drops;
 
-void push_wifi_evt(WifiEvent event, const ubyte* mac = null) nothrow @nogc
+enum size_t wifi_rx_frame_max = 1518;
+version (UseInternalIPStack)
 {
-    if (_wifi_evt_head - _wifi_evt_tail >= wifi_evt_cap)
-        _wifi_evt_tail++;
-    auto slot = &_wifi_evt_queue[_wifi_evt_head & (wifi_evt_cap - 1)];
+    // Descriptors retain ESP-IDF RX buffers, so queue depth is cheap and
+    // backpressure is governed by the driver's configured RX-buffer pool.
+    struct WifiQueuedRx
+    {
+        const(ubyte)* data;
+        void* eb;
+        ushort length;
+        ubyte vif;
+    }
+    enum size_t wifi_rx_cap = 32;
+}
+else
+{
+    // lwIP consumes the ESP-IDF buffer immediately, so this fallback owns a
+    // small aligned copy ring instead.
+    align(4) struct WifiQueuedRx
+    {
+        ubyte[wifi_rx_frame_max] data;
+        ushort length;
+        ubyte vif;
+    }
+    enum size_t wifi_rx_cap = 8;
+}
+__gshared WifiQueuedRx[wifi_rx_cap] _wifi_rx_queue;
+shared uint _wifi_rx_head;
+shared uint _wifi_rx_tail;
+shared uint _wifi_rx_drops;
+
+// sig_len is a 12-bit ESP-IDF field and includes the FCS.
+enum size_t wifi_raw_rx_frame_max = 4095;
+align(4) struct WifiQueuedRawRx
+{
+    ubyte[wifi_raw_rx_frame_max] data;
+    ushort length;
+    byte rssi;
+    ubyte channel;
+}
+// Two maximum-sized monitor frames consume 8.2 KiB. Promiscuous capture is a
+// sampled diagnostic stream; overruns are reported through raw RX drops.
+enum size_t wifi_raw_rx_cap = 2;
+__gshared WifiQueuedRawRx[wifi_raw_rx_cap] _wifi_raw_rx_queue;
+shared uint _wifi_raw_rx_head;
+shared uint _wifi_raw_rx_tail;
+shared uint _wifi_raw_rx_drops;
+
+void reset_queues() nothrow @nogc
+{
+    atomicFetchAdd!(MemoryOrder.acq_rel)(_queue_generation, 1u);
+    atomicStore!(MemoryOrder.relaxed)(_wifi_evt_head, 0u);
+    atomicStore!(MemoryOrder.relaxed)(_wifi_evt_tail, 0u);
+    atomicStore!(MemoryOrder.relaxed)(_wifi_evt_drops, 0u);
+    version (UseInternalIPStack)
+    {
+        uint tail = atomicLoad!(MemoryOrder.relaxed)(_wifi_rx_tail);
+        uint head = atomicLoad!(MemoryOrder.acquire)(_wifi_rx_head);
+        while (tail != head)
+        {
+            auto slot = &_wifi_rx_queue[tail & (wifi_rx_cap - 1)];
+            void* eb = slot.eb;
+            slot.eb = null;
+            ow_wifi_free_rx_buffer(eb);
+            ++tail;
+        }
+    }
+    atomicStore!(MemoryOrder.relaxed)(_wifi_rx_head, 0u);
+    atomicStore!(MemoryOrder.relaxed)(_wifi_rx_tail, 0u);
+    atomicStore!(MemoryOrder.relaxed)(_wifi_rx_drops, 0u);
+    atomicStore!(MemoryOrder.relaxed)(_wifi_raw_rx_head, 0u);
+    atomicStore!(MemoryOrder.relaxed)(_wifi_raw_rx_tail, 0u);
+    atomicStore!(MemoryOrder.relaxed)(_wifi_raw_rx_drops, 0u);
+    _service_cursor = 0;
+}
+
+bool queues_pending() nothrow @nogc
+{
+    return atomicLoad!(MemoryOrder.acquire)(_wifi_evt_head) !=
+               atomicLoad!(MemoryOrder.relaxed)(_wifi_evt_tail) ||
+           atomicLoad!(MemoryOrder.acquire)(_wifi_rx_head) !=
+               atomicLoad!(MemoryOrder.relaxed)(_wifi_rx_tail) ||
+           atomicLoad!(MemoryOrder.acquire)(_wifi_raw_rx_head) !=
+               atomicLoad!(MemoryOrder.relaxed)(_wifi_raw_rx_tail);
+}
+
+void notify_ready() nothrow @nogc
+{
+    auto cb = cast(WifiReadyCallback)
+        atomicLoad!(MemoryOrder.seq)(_ready_cb_bits);
+    if (cb !is null)
+        cb();
+}
+
+void push_wifi_evt(WifiEvent event, const ubyte* mac = null,
+                   const WifiStaDisconnectInfo* disconnect = null) nothrow @nogc
+{
+    uint head = atomicLoad!(MemoryOrder.relaxed)(_wifi_evt_head);
+    uint tail = atomicLoad!(MemoryOrder.acquire)(_wifi_evt_tail);
+    if (head - tail >= wifi_evt_cap)
+    {
+        atomicFetchAdd!(MemoryOrder.relaxed)(_wifi_evt_drops, 1u);
+        notify_ready();
+        return;
+    }
+    auto slot = &_wifi_evt_queue[head & (wifi_evt_cap - 1)];
     slot.event = event;
     slot.has_mac = mac !is null;
     if (mac !is null)
         slot.mac[] = mac[0 .. 6];
-    _wifi_evt_head++;
+    if (disconnect !is null)
+        slot.disconnect = *disconnect;
+    atomicStore!(MemoryOrder.release)(_wifi_evt_head, head + 1);
+    notify_ready();
 }
 
 extern(C) void sta_event_trampoline(int event_id, void*, int data_len) nothrow @nogc
 {
-    if (event_id == WIFI_EVENT_STA_CONNECTED)
+    if (event_id == WIFI_EVENT_STA_START)
+        push_wifi_evt(WifiEvent.sta_started);
+    else if (event_id == WIFI_EVENT_STA_STOP)
+        push_wifi_evt(WifiEvent.sta_stopped);
+    else if (event_id == WIFI_EVENT_STA_CONNECTED)
     {
-        _sta_status_message = null;
-        _sta_disconnect_reason = 0;
+        atomicStore!(MemoryOrder.release)(_sta_disconnect_reason, 0);
         push_wifi_evt(WifiEvent.sta_connected);
     }
     else if (event_id == WIFI_EVENT_STA_DISCONNECTED)
     {
-        _sta_disconnect_reason = data_len;
-        _sta_status_message = null;
-        push_wifi_evt(WifiEvent.sta_disconnected);
+        atomicStore!(MemoryOrder.release)(_sta_disconnect_reason, data_len);
+        WifiStaDisconnectInfo info;
+        info.reason = data_len;
+        info.message = esp_wifi_sta_reason_message(data_len);
+        push_wifi_evt(WifiEvent.sta_disconnected, null, &info);
     }
 }
 
@@ -459,29 +712,96 @@ extern(C) void ap_event_trampoline(int event_id, void* event_data, int) nothrow 
 
 // RX trampoline -- called from C shim's esp_wifi_internal_reg_rxcb handler.
 // The C shim also forwards to esp_netif_receive so lwIP still gets frames.
-extern(C) void rx_trampoline(const(ubyte)* data, int len, int iface) nothrow @nogc
+extern(C) int rx_trampoline(const(ubyte)* data, int len, int iface,
+                            void* eb) nothrow @nogc
 {
-    if (_rx_cb !is null && len > 0)
-        _rx_cb(Wifi(0), cast(WifiVif)iface, data[0 .. len]);
+    if (_rx_cb is null)
+        return 0;
+    if (data is null || len <= 0 || iface < 0 || iface > 1)
+    {
+        atomicFetchAdd!(MemoryOrder.relaxed)(_wifi_rx_drops, 1u);
+        notify_ready();
+        return 0;
+    }
+    if (len > wifi_rx_frame_max)
+    {
+        atomicFetchAdd!(MemoryOrder.relaxed)(_wifi_rx_drops, 1u);
+        notify_ready();
+        return 0;
+    }
+    version (UseInternalIPStack)
+    {
+        if (eb is null)
+        {
+            atomicFetchAdd!(MemoryOrder.relaxed)(_wifi_rx_drops, 1u);
+            notify_ready();
+            return 0;
+        }
+    }
+
+    uint head = atomicLoad!(MemoryOrder.relaxed)(_wifi_rx_head);
+    uint tail = atomicLoad!(MemoryOrder.acquire)(_wifi_rx_tail);
+    if (head - tail >= wifi_rx_cap)
+    {
+        atomicFetchAdd!(MemoryOrder.relaxed)(_wifi_rx_drops, 1u);
+        notify_ready();
+        return 0;
+    }
+
+    auto slot = &_wifi_rx_queue[head & (wifi_rx_cap - 1)];
+    slot.length = cast(ushort)len;
+    slot.vif = cast(ubyte)iface;
+    version (UseInternalIPStack)
+    {
+        slot.data = data;
+        slot.eb = eb;
+    }
+    else
+        slot.data[0 .. len] = data[0 .. len];
+    atomicStore!(MemoryOrder.release)(_wifi_rx_head, head + 1);
+    notify_ready();
+    version (UseInternalIPStack)
+        return 1;
+    else
+        return 0;
 }
 
 // Promiscuous trampoline -- called from C shim for every 802.11 frame the
 // radio decodes (including FCS-fail frames when the filter bit is set).
-// rx_state non-zero == FCS failed; we forward unchanged and let the
-// subscriber decide what to do with broken frames.
 extern(C) void promisc_trampoline(int type, int rssi, int channel,
                                   int rate, int fcs_fail, int len,
                                   const(ubyte)* payload) nothrow @nogc
 {
     if (_raw_rx_cb is null || len <= 0 || payload is null)
         return;
-    // Drop FCS-fail frames for now -- the raw RX callback signature has no
-    // place to surface the bad-FCS flag yet, and forwarding garbage frames
-    // confuses subscribers that assume valid framing. The driver-level RX
-    // dropped counter is bumped at the iface layer instead.
+    // The raw callback cannot surface bad-FCS frames without confusing
+    // subscribers that assume valid framing. This is deliberate filtering,
+    // not queue loss, so it does not contribute to the drop counter.
     if (fcs_fail)
         return;
-    _raw_rx_cb(Wifi(0), payload[0 .. len], cast(byte)rssi, cast(ubyte)channel);
+    if (len > wifi_raw_rx_frame_max)
+    {
+        atomicFetchAdd!(MemoryOrder.relaxed)(_wifi_raw_rx_drops, 1u);
+        notify_ready();
+        return;
+    }
+
+    uint head = atomicLoad!(MemoryOrder.relaxed)(_wifi_raw_rx_head);
+    uint tail = atomicLoad!(MemoryOrder.acquire)(_wifi_raw_rx_tail);
+    if (head - tail >= wifi_raw_rx_cap)
+    {
+        atomicFetchAdd!(MemoryOrder.relaxed)(_wifi_raw_rx_drops, 1u);
+        notify_ready();
+        return;
+    }
+
+    auto slot = &_wifi_raw_rx_queue[head & (wifi_raw_rx_cap - 1)];
+    slot.length = cast(ushort)len;
+    slot.rssi = cast(byte)rssi;
+    slot.channel = cast(ubyte)channel;
+    slot.data[0 .. len] = payload[0 .. len];
+    atomicStore!(MemoryOrder.release)(_wifi_raw_rx_head, head + 1);
+    notify_ready();
 }
 
 // C shim functions (ow_shim.c) -- needed for macros, complex structs, netif
@@ -492,7 +812,9 @@ extern(C) nothrow @nogc
     int ow_wifi_sta_config(const(char)* ssid, const(char)* password, const(ubyte)* bssid);
     int ow_wifi_ap_config(const(char)* ssid, const(char)* password, ubyte channel, ubyte max_conn, ubyte hidden);
     int ow_wifi_ap_set_max_clients(ubyte max_conn);
-    int ow_wifi_set_rx_callback(void function(const(ubyte)*, int, int) nothrow @nogc cb);
+    int ow_wifi_set_rx_callback(
+        int function(const(ubyte)*, int, int, void*) nothrow @nogc cb);
+    void ow_wifi_free_rx_buffer(void* eb);
     void ow_wifi_set_sta_callback(void function(int, void*, int) nothrow @nogc);
     void ow_wifi_set_ap_callback(void function(int, void*, int) nothrow @nogc);
     int ow_wifi_set_promiscuous(int enable, uint filter_mask);

--- a/src/urt/driver/wifi.d
+++ b/src/urt/driver/wifi.d
@@ -15,12 +15,18 @@ nothrow @nogc:
 static if (!__traits(compiles, wifi_max_ap_clients))
     enum ubyte wifi_max_ap_clients = ubyte.max;
 
-alias WifiWakeCallback = void function() nothrow @nogc;
+// May be called from task or interrupt context after deferred work becomes
+// ready, and synchronously during registration. The callback must be IRQ-safe,
+// non-blocking, @nogc, and nothrow. It may only signal or schedule service; it
+// must not call wifi_service or re-enter the driver. Calls may be repeated,
+// coalesced, or spurious. Registration is backend-global and remains active
+// across port close/open cycles until explicitly replaced or cleared.
+alias WifiReadyCallback = void function() nothrow @nogc;
 
-void wifi_set_wake_callback(WifiWakeCallback cb)
+void wifi_set_ready_callback(WifiReadyCallback cb)
 {
-    static if (__traits(compiles, wifi_hw_set_wake_callback(cb)))
-        wifi_hw_set_wake_callback(cb);
+    static if (__traits(compiles, wifi_hw_set_ready_callback(cb)))
+        wifi_hw_set_ready_callback(cb);
 }
 
 
@@ -93,6 +99,17 @@ enum WifiEvent : ubyte
     ap_sta_connected,     // a client joined our AP
     ap_sta_disconnected,  // a client left our AP
     scan_done,
+    sta_started,
+    sta_stopped,
+}
+
+static assert(WifiEvent.sta_connected == 0);
+static assert(WifiEvent.scan_done == 6);
+
+struct WifiStaDisconnectInfo
+{
+    int reason;
+    const(char)[] message;
 }
 
 struct WifiConfig
@@ -154,18 +171,21 @@ struct WifiStaInfo
     byte rssi;
 }
 
-// Called from ISR/driver when an Ethernet frame is received on a
-// virtual interface. Data includes the 14-byte Ethernet header.
+// Delivered by wifi_service() when an Ethernet frame is received on a virtual
+// interface. Data includes the 14-byte Ethernet header and remains valid only
+// until the callback returns.
 alias WifiRxCallback = void function(Wifi wifi, WifiVif vif, const(ubyte)[] data) nothrow @nogc;
 
-// Called from ISR/driver when a raw 802.11 frame is received
-// (promiscuous/monitor tap). Data is the full 802.11 frame
-// starting at the MAC header. Delivered independently of the
-// Ethernet RX callback - both can be active simultaneously.
+// Delivered by wifi_service() for a promiscuous/monitor frame. Data starts at
+// the 802.11 MAC header and remains valid only until the callback returns.
+// Raw and Ethernet RX can be active simultaneously.
 alias WifiRawRxCallback = void function(Wifi wifi, const(ubyte)[] frame, byte rssi, ubyte channel) nothrow @nogc;
 
 // Called when a wifi event occurs. Replaces per-event callbacks
 // to match the single-callback pattern used by the router layer.
+// data points to WifiStaDisconnectInfo for sta_disconnected, six MAC bytes
+// for AP station join/leave events, and is null for other events. Its lifetime
+// ends when the callback returns.
 alias WifiEventCallback = void function(Wifi wifi, WifiEvent event, const(void)* data) nothrow @nogc;
 
 struct Wifi
@@ -392,6 +412,26 @@ void wifi_set_rx_callback(ref Wifi wifi, WifiRxCallback cb)
         wifi_hw_set_rx_callback(wifi.port, cb);
 }
 
+uint wifi_take_rx_drops(ref Wifi wifi)
+{
+    static if (num_wifi == 0)
+        assert(false, "no WiFi on this platform");
+    else static if (__traits(compiles, wifi_hw_take_rx_drops(wifi.port)))
+        return wifi_hw_take_rx_drops(wifi.port);
+    else
+        return 0;
+}
+
+uint wifi_take_event_drops(ref Wifi wifi)
+{
+    static if (num_wifi == 0)
+        assert(false, "no WiFi on this platform");
+    else static if (__traits(compiles, wifi_hw_take_event_drops(wifi.port)))
+        return wifi_hw_take_event_drops(wifi.port);
+    else
+        return 0;
+}
+
 // Raw 802.11 frame TX/RX (monitor/promiscuous)
 
 // Transmit a raw 802.11 frame. Data must include the full MAC header.
@@ -414,6 +454,16 @@ void wifi_set_raw_rx_callback(ref Wifi wifi, WifiRawRxCallback cb)
         assert(false, "no WiFi on this platform");
     else
         wifi_hw_set_raw_rx_callback(wifi.port, cb);
+}
+
+uint wifi_take_raw_rx_drops(ref Wifi wifi)
+{
+    static if (num_wifi == 0)
+        assert(false, "no WiFi on this platform");
+    else static if (__traits(compiles, wifi_hw_take_raw_rx_drops(wifi.port)))
+        return wifi_hw_take_raw_rx_drops(wifi.port);
+    else
+        return 0;
 }
 
 // Queries
@@ -481,14 +531,19 @@ void wifi_set_event_callback(ref Wifi wifi, WifiEventCallback cb)
         wifi_hw_set_event_callback(wifi.port, cb);
 }
 
-// Poll (for platforms without native event delivery)
+// Service deferred backend work in caller context. budget limits the number of
+// consumer callbacks delivered in one pass; platform bookkeeping may also run.
+// Returns true when work remains, in which case the caller must schedule
+// another pass without waiting for a new hardware event. Event, Ethernet RX,
+// and raw RX are independent sources, so their callbacks have no cross-source
+// order guarantee.
 
-void wifi_poll(ref Wifi wifi)
+bool wifi_service(ref Wifi wifi, size_t budget = 32)
 {
     static if (num_wifi == 0)
         assert(false, "no WiFi on this platform");
     else
-        wifi_hw_poll(wifi.port);
+        return wifi_hw_service(wifi.port, budget);
 }
 
 
@@ -519,7 +574,7 @@ unittest
             assert(port.is_open);
             assert(port.port == p);
 
-            wifi_poll(port);
+            wifi_service(port);
 
             wifi_close(port);
             assert(!port.is_open);


### PR DESCRIPTION
Queue ingress and interface-state changes for task-context dispatch, expose readiness callbacks, and report exact deferred frame and event losses through the shared WiFi driver API.