### PR TITLE
Add asynchronous ESP32 I2C operations

### DIFF
--- a/src/urt/driver/esp32/i2c.d
+++ b/src/urt/driver/esp32/i2c.d
@@ -1,0 +1,77 @@
+module urt.driver.esp32.i2c;
+
+import urt.driver.i2c : I2cBus, I2cBusConfig, I2cCallbackContext, I2cError, I2cOperation, I2cTransfer, i2c_complete;
+import urt.result : Result, InternalResult;
+import urt.time : Duration;
+
+nothrow @nogc:
+
+
+// Conservative compile-time upper bound. i2c_count() returns the HP controllers exposed by the ESP-IDF master driver.
+enum uint num_i2c = 2;
+
+uint i2c_count() => ow_i2c_count();
+
+bool i2c_hw_open(ref I2cBus bus, uint port, ref const I2cBusConfig config)
+{
+    if (port >= i2c_count())
+        return false;
+    bus.driver_data = ow_i2c_open(port, config.sda_gpio, config.scl_gpio, config.internal_pullups);
+    return bus.driver_data !is null;
+}
+
+void i2c_hw_close(ref I2cBus bus)
+{
+    if (bus.driver_data !is null)
+        ow_i2c_close(bus.driver_data);
+}
+
+Result i2c_hw_submit(ref I2cBus bus, ref I2cOperation operation, ref const I2cTransfer transfer)
+{
+    int result = ow_i2c_submit(bus.driver_data, transfer.address, transfer.address_mode, bus.frequency,
+        transfer.write_data.ptr, transfer.write_data.length, cast(void*)transfer.read_data.ptr, transfer.read_data.length,
+        timeout_ms(transfer.timeout), &operation_complete, &operation);
+    return result == 0 ? Result.success : InternalResult.failed;
+}
+
+Result i2c_hw_cancel(ref I2cBus, ref I2cOperation)
+{
+    return InternalResult.unsupported;
+}
+
+private:
+
+extern(C) alias I2cCompletion = bool function(void*, int);
+
+int timeout_ms(Duration timeout)
+{
+    long value = timeout.as!"msecs";
+    if (value < 1)
+        return 1;
+    if (value > int.max)
+        return int.max;
+    return cast(int)value;
+}
+
+extern(C) bool operation_complete(void* context, int result)
+{
+    I2cError error;
+    switch (result)
+    {
+        case 0: error = I2cError.none; break;
+        case 1: error = I2cError.nack; break;
+        case 2: error = I2cError.timeout; break;
+        case 3: error = I2cError.arbitration_lost; break;
+        default: error = I2cError.bus; break;
+    }
+    return i2c_complete(*cast(I2cOperation*)context, error, I2cCallbackContext.task);
+}
+
+extern(C)
+{
+    uint ow_i2c_count();
+    void* ow_i2c_open(uint port, int sda_gpio, int scl_gpio, bool internal_pullups);
+    void ow_i2c_close(void* bus);
+    int ow_i2c_submit(void* bus, ushort address, ubyte address_mode, uint frequency, const(void)* write_data, size_t write_length,
+        void* read_data, size_t read_length, int timeout_ms, I2cCompletion callback, void* callback_context);
+}

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -96,6 +96,210 @@ uint32_t ow_gpio_count(void)
     return SOC_GPIO_PIN_COUNT;
 }
 
+// -- I2C master wrappers --
+
+#include "driver/i2c_master.h"
+
+#ifdef SOC_HP_I2C_NUM
+#define OW_I2C_COUNT SOC_HP_I2C_NUM
+#else
+#define OW_I2C_COUNT SOC_I2C_NUM
+#endif
+#define I2C_REQUEST_QUEUE_SIZE 1
+#define I2C_WORKER_STACK 3072
+
+typedef bool (*ow_i2c_callback_t)(void *context, int result);
+
+typedef struct {
+    uint16_t address;
+    uint32_t frequency;
+    uint8_t address_mode;
+    const void *write_data;
+    size_t write_length;
+    void *read_data;
+    size_t read_length;
+    int timeout_ms;
+    ow_i2c_callback_t callback;
+    void *callback_context;
+} ow_i2c_request_t;
+
+typedef struct {
+    i2c_master_bus_handle_t bus;
+    i2c_master_dev_handle_t device;
+    uint16_t address;
+    uint32_t frequency;
+    uint8_t address_mode;
+    QueueHandle_t queue;
+    TaskHandle_t worker;
+    SemaphoreHandle_t worker_done;
+    StaticSemaphore_t worker_done_storage;
+    atomic_bool initialized;
+} ow_i2c_context_t;
+
+static ow_i2c_context_t i2c_contexts[OW_I2C_COUNT];
+
+static bool ow_i2c_configure_device(ow_i2c_context_t *context, uint16_t address, uint8_t address_mode, uint32_t frequency)
+{
+    if (context->device && context->address == address && context->address_mode == address_mode && context->frequency == frequency)
+        return true;
+
+    if (context->device) {
+        if (i2c_master_bus_rm_device(context->device) != ESP_OK)
+            return false;
+        context->device = NULL;
+    }
+
+    i2c_device_config_t device_config = {
+        .dev_addr_length = address_mode ? I2C_ADDR_BIT_LEN_10 : I2C_ADDR_BIT_LEN_7,
+        .device_address = address,
+        .scl_speed_hz = frequency,
+    };
+    if (i2c_master_bus_add_device(context->bus, &device_config, &context->device) != ESP_OK)
+        return false;
+
+    context->address = address;
+    context->address_mode = address_mode;
+    context->frequency = frequency;
+    return true;
+}
+
+static int ow_i2c_result(esp_err_t result)
+{
+    if (result == ESP_OK)
+        return 0;
+    // ESP-IDF 6.0 i2c_master_transmit(), i2c_master_receive(), and i2c_master_transmit_receive() return this result when a transaction receives NACK.
+    if (result == ESP_ERR_INVALID_RESPONSE)
+        return 1;
+    if (result == ESP_ERR_TIMEOUT)
+        return 2;
+    return 4;
+}
+
+static void ow_i2c_worker(void *argument)
+{
+    ow_i2c_context_t *context = argument;
+    ow_i2c_request_t request;
+
+    while (xQueueReceive(context->queue, &request, portMAX_DELAY) == pdTRUE) {
+        if (!request.callback)
+            break;
+
+        esp_err_t result = ESP_FAIL;
+        if (ow_i2c_configure_device(context, request.address, request.address_mode, request.frequency)) {
+            if (request.write_length && request.read_length)
+                result = i2c_master_transmit_receive(context->device, request.write_data, request.write_length,
+                                                     request.read_data, request.read_length, request.timeout_ms);
+            else if (request.write_length)
+                result = i2c_master_transmit(context->device, request.write_data, request.write_length, request.timeout_ms);
+            else
+                result = i2c_master_receive(context->device, request.read_data, request.read_length, request.timeout_ms);
+        }
+        request.callback(request.callback_context, ow_i2c_result(result));
+    }
+
+    xSemaphoreGive(context->worker_done);
+    vTaskDelete(NULL);
+}
+
+uint32_t ow_i2c_count(void)
+{
+    return OW_I2C_COUNT;
+}
+
+void *ow_i2c_open(unsigned port, int sda_gpio, int scl_gpio, bool internal_pullups)
+{
+    if (port >= OW_I2C_COUNT)
+        return NULL;
+
+    ow_i2c_context_t *context = &i2c_contexts[port];
+    if (atomic_exchange_explicit(&context->initialized, true, memory_order_acq_rel))
+        return NULL;
+
+    i2c_master_bus_config_t bus_config = {
+        .i2c_port = port,
+        .sda_io_num = sda_gpio,
+        .scl_io_num = scl_gpio,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = internal_pullups,
+    };
+    if (i2c_new_master_bus(&bus_config, &context->bus) != ESP_OK)
+        goto fail;
+
+    context->queue = xQueueCreate(I2C_REQUEST_QUEUE_SIZE, sizeof(ow_i2c_request_t));
+    if (!context->queue)
+        goto fail;
+
+    if (!context->worker_done)
+        context->worker_done = xSemaphoreCreateBinaryStatic(&context->worker_done_storage);
+    if (!context->worker_done)
+        goto fail;
+    xSemaphoreTake(context->worker_done, 0);
+
+    if (xTaskCreate(ow_i2c_worker, "ow-i2c", I2C_WORKER_STACK, context, tskIDLE_PRIORITY + 2, &context->worker) != pdPASS)
+        goto fail;
+    return context;
+
+fail:
+    if (context->queue) {
+        vQueueDelete(context->queue);
+        context->queue = NULL;
+    }
+    if (context->bus) {
+        i2c_del_master_bus(context->bus);
+        context->bus = NULL;
+    }
+    atomic_store_explicit(&context->initialized, false, memory_order_release);
+    return NULL;
+}
+
+void ow_i2c_close(void *context_ptr)
+{
+    ow_i2c_context_t *context = context_ptr;
+    if (!context || !atomic_exchange_explicit(&context->initialized, false, memory_order_acq_rel))
+        return;
+
+    configASSERT(xTaskGetCurrentTaskHandle() != context->worker);
+    ow_i2c_request_t request = {0};
+    xQueueSend(context->queue, &request, portMAX_DELAY);
+    xSemaphoreTake(context->worker_done, portMAX_DELAY);
+    context->worker = NULL;
+
+    if (context->device) {
+        i2c_master_bus_rm_device(context->device);
+        context->device = NULL;
+    }
+    if (context->bus) {
+        i2c_del_master_bus(context->bus);
+        context->bus = NULL;
+    }
+    vQueueDelete(context->queue);
+    context->queue = NULL;
+}
+
+int ow_i2c_submit(void *context_ptr, uint16_t address, uint8_t address_mode, uint32_t frequency, const void *write_data, size_t write_length,
+                  void *read_data, size_t read_length, int timeout_ms, ow_i2c_callback_t callback, void *callback_context)
+{
+    ow_i2c_context_t *context = context_ptr;
+    if (!context || !atomic_load_explicit(&context->initialized, memory_order_acquire) || !callback ||
+        (write_length == 0 && read_length == 0))
+        return -1;
+
+    ow_i2c_request_t request = {
+        .address = address,
+        .frequency = frequency,
+        .address_mode = address_mode,
+        .write_data = write_data,
+        .write_length = write_length,
+        .read_data = read_data,
+        .read_length = read_length,
+        .timeout_ms = timeout_ms,
+        .callback = callback,
+        .callback_context = callback_context,
+    };
+    return xQueueSend(context->queue, &request, 0) == pdTRUE ? 0 : -1;
+}
+
 
 // -- UART driver wrappers --
 

--- a/src/urt/driver/i2c.d
+++ b/src/urt/driver/i2c.d
@@ -1,0 +1,257 @@
+module urt.driver.i2c;
+
+import urt.atomic;
+import urt.result : Result, InternalResult;
+import urt.time;
+
+// num_i2c is a compile-time upper bound used to remove unsupported backends. i2c_count() returns the actual number of usable controllers.
+version (Espressif)
+    public import urt.driver.esp32.i2c;
+else
+{
+    enum uint num_i2c = 0;
+    uint i2c_count() nothrow @nogc => 0;
+}
+
+nothrow @nogc:
+
+
+enum I2cAddressMode : ubyte
+{
+    seven_bit,
+    ten_bit,
+}
+
+enum I2cError : ubyte
+{
+    none,
+    nack,
+    timeout,
+    arbitration_lost,
+    bus,
+}
+
+enum I2cCallbackContext : ubyte
+{
+    task,
+    interrupt,
+}
+
+enum I2cOperationState : uint
+{
+    idle,
+    pending,
+    complete,
+    cancelled,
+    error,
+}
+
+struct I2cBusConfig
+{
+    uint frequency = 100_000;
+    ubyte sda_gpio = ubyte.max;
+    ubyte scl_gpio = ubyte.max;
+    bool internal_pullups;
+}
+
+struct I2cTransfer
+{
+    // The operation and both buffers must remain alive and unmoved until completion. The write buffer must not be modified while pending.
+    ushort address;
+    I2cAddressMode address_mode;
+    const(void)[] write_data;
+    void[] read_data;
+    Duration timeout = 100.msecs;
+}
+
+struct I2cOperation
+{
+nothrow @nogc:
+    // Completion runs in the reported backend context and must not block. An interrupt callback returns whether the platform should yield to a task
+    // woken by the callback; task-context backends ignore the result. The callback may reset and reuse the operation immediately. Other threads
+    // must first observe is_done, which performs an acquire load, before reading the result or reusing the operation, its buffers, or its bus.
+    alias Callback = bool function(ref I2cOperation operation, I2cCallbackContext context) nothrow @nogc;
+
+    void* user_data;
+    Callback callback;
+
+    I2cOperationState state() const
+        => cast(I2cOperationState)atomicLoad!(MemoryOrder.acquire)(_state);
+
+    I2cError error() const
+    {
+        assert(state != I2cOperationState.pending);
+        return _error;
+    }
+
+    bool is_pending() const
+        => state == I2cOperationState.pending;
+
+    bool is_done() const
+        => state >= I2cOperationState.complete;
+
+    void reset()
+    {
+        assert(state != I2cOperationState.pending);
+        assert(_bus is null);
+        _error = I2cError.none;
+        atomicStore!(MemoryOrder.release)(_state, I2cOperationState.idle);
+    }
+
+private:
+    shared uint _state;
+    I2cError _error;
+    I2cBus* _bus;
+}
+
+struct I2cBus
+{
+nothrow @nogc:
+    ubyte port = ubyte.max;
+    void* driver_data;
+    uint frequency;
+
+private:
+    I2cOperation* _operation;
+}
+
+bool is_open(ref const I2cBus bus)
+{
+    return bus.port != ubyte.max;
+}
+
+Result i2c_open(ref I2cBus bus, ubyte port, ref const I2cBusConfig config)
+{
+    static if (num_i2c == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (port >= i2c_count() || config.sda_gpio == ubyte.max || config.scl_gpio == ubyte.max || config.sda_gpio == config.scl_gpio ||
+            config.frequency == 0)
+            return InternalResult.invalid_parameter;
+        if (bus.is_open)
+            return InternalResult.already_exists;
+        if (!i2c_hw_open(bus, port, config))
+            return InternalResult.failed;
+        bus.port = port;
+        bus.frequency = config.frequency;
+        return Result.success;
+    }
+}
+
+void i2c_close(ref I2cBus bus)
+{
+    assert(bus._operation is null, "an I2C bus cannot close while an operation is pending");
+    if (bus._operation !is null)
+        return;
+
+    static if (num_i2c != 0)
+    {
+        if (bus.is_open)
+            i2c_hw_close(bus);
+    }
+    bus.port = ubyte.max;
+    bus.driver_data = null;
+    bus.frequency = 0;
+}
+
+Result i2c_submit(ref I2cBus bus, ref I2cOperation operation, ref const I2cTransfer transfer)
+{
+    static if (num_i2c == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!bus.is_open || operation.state != I2cOperationState.idle || bus._operation !is null ||
+            (transfer.write_data.length == 0 && transfer.read_data.length == 0) || transfer.timeout <= Duration.zero)
+            return InternalResult.invalid_parameter;
+
+        final switch (transfer.address_mode)
+        {
+            case I2cAddressMode.seven_bit:
+                if (transfer.address > 0x7F)
+                    return InternalResult.invalid_parameter;
+                break;
+            case I2cAddressMode.ten_bit:
+                if (transfer.address > 0x3FF)
+                    return InternalResult.invalid_parameter;
+                break;
+        }
+
+        operation._error = I2cError.none;
+        operation._bus = &bus;
+        bus._operation = &operation;
+        atomicStore!(MemoryOrder.release)(operation._state, I2cOperationState.pending);
+        Result result = i2c_hw_submit(bus, operation, transfer);
+        if (!result)
+        {
+            bus._operation = null;
+            operation._bus = null;
+            operation._error = I2cError.bus;
+            atomicStore!(MemoryOrder.release)(operation._state, I2cOperationState.idle);
+        }
+        return result;
+    }
+}
+
+Result i2c_cancel(ref I2cBus bus, ref I2cOperation operation)
+{
+    static if (num_i2c == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!bus.is_open || !operation.is_pending || operation._bus !is &bus)
+            return InternalResult.invalid_parameter;
+        return i2c_hw_cancel(bus, operation);
+    }
+}
+
+package bool i2c_complete(ref I2cOperation operation, I2cError error, I2cCallbackContext context)
+{
+    I2cOperationState state = error == I2cError.none
+        ? I2cOperationState.complete : I2cOperationState.error;
+    return i2c_complete(operation, state, error, context);
+}
+
+package bool i2c_complete(ref I2cOperation operation, I2cOperationState completion_state, I2cError error, I2cCallbackContext context)
+{
+    if (!operation.is_pending)
+        return false;
+    assert(completion_state == I2cOperationState.complete || completion_state == I2cOperationState.cancelled ||
+           completion_state == I2cOperationState.error);
+
+    I2cBus* bus = operation._bus;
+    assert(bus !is null && bus._operation is &operation);
+    if (bus !is null && bus._operation is &operation)
+        bus._operation = null;
+    operation._bus = null;
+    operation._error = error;
+    atomicStore!(MemoryOrder.release)(operation._state, completion_state);
+    return operation.callback ? operation.callback(operation, context) : false;
+}
+
+
+unittest
+{
+    static assert(is(typeof(num_i2c) == uint));
+    i2c_count();
+
+    I2cBus bus;
+    I2cOperation operation;
+    bus._operation = &operation;
+    operation._bus = &bus;
+    atomicStore!(MemoryOrder.release)(operation._state, I2cOperationState.pending);
+
+    assert(!i2c_complete(operation, I2cError.nack, I2cCallbackContext.task));
+    assert(operation.state == I2cOperationState.error);
+    assert(operation.error == I2cError.nack);
+    assert(operation._bus is null);
+    assert(bus._operation is null);
+    assert(!i2c_complete(operation, I2cError.none, I2cCallbackContext.task));
+
+    operation.reset();
+    bus._operation = &operation;
+    operation._bus = &bus;
+    atomicStore!(MemoryOrder.release)(operation._state, I2cOperationState.pending);
+    assert(!i2c_complete(operation, I2cOperationState.cancelled, I2cError.none, I2cCallbackContext.task));
+    assert(operation.state == I2cOperationState.cancelled);
+}


### PR DESCRIPTION
## Summary

Add a shared caller-owned I2C request/completion API and an ESP32 backend for write, read, and repeated-start write/read transfers.

The ESP32 implementation executes ESP-IDF's synchronous transaction API on a dedicated per-bus worker task. OpenWatt's main task never blocks, while NACK and timeout status are reported reliably. ESP-IDF's experimental callback mode is deliberately not used because ESP-IDF 6.0 does not invoke `on_trans_done` for its NACK/timeout termination paths.

## API contract

- one operation may be active on a bus at a time
- operation and transfer buffers remain caller-owned and must stay alive and unmoved until completion
- completion identifies task versus interrupt context
- other threads must acquire-observe completion through `state`/`is_done` before reading results or reusing the operation, buffers, or bus
- `num_i2c` is a compile-time upper bound; `i2c_count()` is the exact runtime controller count
- accepted cancellation remains asynchronous; ESP32 currently reports cancellation as unsupported
- no polling hook is exposed by the ESP32 backend

## Review changes

- rebased onto current uRT master
- replaced the experimental ESP-IDF ISR callback path with the worker-task backend
- made NACK and timeout completion reliable
- added explicit completion context and bus/operation ownership tracking
- prevented close while an operation is pending
- made the cancellation completion state reachable for future backends
- sourced the ESP32 runtime port count from `SOC_HP_I2C_NUM`, excluding LP-I2C controllers unsupported by the master driver
- documented ESP-IDF 6.0's `ESP_ERR_INVALID_RESPONSE` NACK mapping and the cross-thread acquire contract
- audited all three PR files to a roughly 150-column wrap width
- added operation state/completion unit coverage
- split the unrelated FreeRTOS ISR notification wrapper into #191
- removed the incorrect `tskNO_AFFINITY` change for ESP-IDF's SMP kernel

## Validation

- `git diff --check origin/master HEAD`
- native unittest binary: 63/63 modules passed
- forced `make PLATFORM=esp32-s3 CONFIG=unittest`
- compiled `ow_shim.c` with the exact ESP-IDF 6.0 ESP32-S3 compile command and modular UART/I2C driver headers
- all three PR files contain no lines over 150 columns
- GitHub Actions CI passes

## Hardware validation still required

- successful write, read, and write/read against the PCF85063
- NACK from an absent address completes with `I2cError.nack`
- timeout/stuck-bus behavior completes without wedging the operation
- close/reopen cycles and address switching on one bus
- sustained operation alongside WiFi and BLE