### PR TITLE
Drive ESP32 CAN receive from TWAI events

### DIFF
--- a/src/urt/driver/can.d
+++ b/src/urt/driver/can.d
@@ -36,8 +36,9 @@ struct CanConfig
 {
     uint bitrate = 500_000;     // nominal bitrate (bits/s)
     uint data_bitrate;          // FD data phase bitrate (0 = classic CAN only)
-    ubyte tx_gpio = ubyte.max;  // GPIO pin for TX (max = platform default)
-    ubyte rx_gpio = ubyte.max;  // GPIO pin for RX (max = platform default)
+    // ubyte.max requests a platform default and is rejected by backends that do not define one.
+    ubyte tx_gpio = ubyte.max;  // GPIO pin for TX
+    ubyte rx_gpio = ubyte.max;  // GPIO pin for RX
 
     // Bit timing (0 = auto-calculate from bitrate)
     ubyte sjw;          // synchronization jump width (1-4 TQ)
@@ -66,8 +67,16 @@ struct CanFilter
     bool match_all;     // ignore id/mask, accept everything (default)
 }
 
-// Called from ISR when a frame has been received.
-alias CanRxCallback = void function(Can can, ref const CanFrame frame) nothrow @nogc;
+enum CanCallbackContext : ubyte
+{
+    task,
+    interrupt,
+}
+
+// Called immediately after a frame has been queued for can_receive(). The receiver must marshal work that is unsafe in the reported context, and the
+// callback must not block or call back into the CAN driver. Interrupt callbacks return whether the platform should yield to a task woken by the
+// callback; task-context backends ignore the result.
+alias CanRxCallback = bool function(Can can, CanCallbackContext context) nothrow @nogc;
 
 // Called from ISR when a TX mailbox becomes free.
 alias CanTxCallback = void function(Can can) nothrow @nogc;
@@ -153,8 +162,9 @@ Result can_open(ref Can can, ubyte port, ref const CanConfig cfg, CanRxCallback 
         if (port >= num_can)
             return InternalResult.invalid_parameter;
 
-        if (!can_hw_open(port, cfg))
-            return InternalResult.failed;
+        Result result = can_hw_open(port, cfg, rx_cb);
+        if (!result)
+            return result;
 
         can.port = port;
         return Result.success;
@@ -196,19 +206,22 @@ Result can_transmit(ref Can can, ref const CanFrame frame, CanTxOp* op = null)
     }
 }
 
-void can_tx_abort(ref Can can, CanTxOp* op)
+Result can_tx_abort(ref Can can, CanTxOp* op)
 {
     static if (num_can == 0)
         assert(false, "no CAN on this platform");
     else
     {
-        can_hw_tx_abort(can.port);
+        Result result = can_hw_tx_abort(can.port);
+        if (!result)
+            return result;
         if (op !is null)
         {
             op.status = CanTxOp.Status.cancelled;
             if (op.cb !is null)
                 op.cb(&can, *op);
         }
+        return Result.success;
     }
 }
 
@@ -289,6 +302,14 @@ CanError can_check_errors(ref Can can)
         return can_hw_check_errors(can.port);
 }
 
+uint can_take_rx_drops(ref Can can)
+{
+    static if (num_can == 0)
+        assert(false, "no CAN on this platform");
+    else
+        return can_hw_take_rx_drops(can.port);
+}
+
 // Bus recovery
 
 Result can_bus_recover(ref Can can)
@@ -307,7 +328,10 @@ Result can_bus_recover(ref Can can)
 
 void can_set_rx_callback(ref Can can, CanRxCallback cb)
 {
-    assert(false, "TODO: can_set_rx_callback");
+    static if (num_can == 0)
+        assert(false, "no CAN on this platform");
+    else
+        can_hw_set_rx_callback(can.port, cb);
 }
 
 void can_set_tx_callback(ref Can can, CanTxCallback cb)
@@ -319,17 +343,6 @@ void can_set_bus_state_callback(ref Can can, CanBusStateCallback cb)
 {
     assert(false, "TODO: can_set_bus_state_callback");
 }
-
-// Poll (for polled mode - check HW FIFOs and invoke callbacks)
-
-void can_poll(ref Can can)
-{
-    static if (num_can == 0)
-        assert(false, "no CAN on this platform");
-    else
-        can_hw_poll(can.port);
-}
-
 
 // ════════════════════════════════════════════════════════════════════
 // Tests
@@ -357,8 +370,6 @@ unittest
             assert(r2, "can_open failed");
             assert(port.is_open);
             assert(port.port == p);
-
-            can_poll(port);
 
             assert(can_check_errors(port) == CanError.none);
 

--- a/src/urt/driver/esp32/can.d
+++ b/src/urt/driver/esp32/can.d
@@ -1,26 +1,29 @@
-// ESP32 CAN (TWAI) driver -- thin D layer over ESP-IDF _v2 handle API
+// ESP32 CAN (TWAI) driver.
 //
-// Only ow_can_open is a C shim (bitrate table + config construction).
-// All other calls go directly to the ESP-IDF twai_*_v2 functions.
+// ESP-IDF v6 exposes received frames only from its ISR callback. The C shim copies them into a bounded ring there, then this layer presents the
+// portable can_receive() API to main-thread consumers.
 //
 // Controller count per chip (ESP-IDF v6.0):
-//   ESP32, S3, C3, H2: 1    C5, C6: 2    P4: 3    S2, C2, C61: 0
+//   ESP32, S2, S3, C3, H2: 1    C5, C6: 2    P4: 3    C2, C61: 0
 module urt.driver.esp32.can;
 
-import urt.driver.can : CanConfig, CanFrame, CanError, CanBusState;
+import urt.atomic : atomicLoad, atomicStore, MemoryOrder;
+import urt.driver.can : Can, CanBusState, CanCallbackContext, CanConfig, CanError, CanFrame, CanRxCallback;
+import urt.result : Result, InternalResult;
 
 nothrow @nogc:
 
 
 // SOC_TWAI_CONTROLLER_NUM per chip variant (ESP-IDF v6.0 soc_caps.h)
 version (ESP32)         enum uint num_can = 1;
+else version (ESP32_S2) enum uint num_can = 1;
 else version (ESP32_S3) enum uint num_can = 1;
 else version (ESP32_P4) enum uint num_can = 3;
 else version (ESP32_C3) enum uint num_can = 1;
 else version (ESP32_C5) enum uint num_can = 2;
 else version (ESP32_C6) enum uint num_can = 2;
 else version (ESP32_H2) enum uint num_can = 1;
-else                    enum uint num_can = 0; // S2, C2, C61
+else                    enum uint num_can = 0; // C2, C61
 
 // SOC_TWAI_FD_SUPPORTED (ESP-IDF v6.0 soc_caps.h)
 version (ESP32_C5) enum bool has_can_fd = true;
@@ -30,54 +33,61 @@ else               enum bool has_can_fd = false;
 static if (num_can > 0):
 
 
-bool can_hw_open(uint port, ref const CanConfig cfg)
+Result can_hw_open(uint port, ref const CanConfig cfg, CanRxCallback rx_cb)
 {
-    if (port >= num_can)
-        return false;
+    if (port >= num_can || cfg.tx_gpio == ubyte.max || cfg.rx_gpio == ubyte.max)
+        return InternalResult.invalid_parameter;
     if (_handles[port] !is null)
-        return true;
-    int tx = cfg.tx_gpio == ubyte.max ? -1 : cast(int)cfg.tx_gpio;
-    int rx = cfg.rx_gpio == ubyte.max ? -1 : cast(int)cfg.rx_gpio;
-    _handles[port] = ow_can_open(port, cfg.bitrate, tx, rx,
-        cfg.sjw, cfg.tseg1, cfg.tseg2, cfg.brp);
-    return _handles[port] !is null;
+    {
+        if (_configs[port] != cfg)
+            return InternalResult.already_exists;
+        can_hw_set_rx_callback(port, rx_cb);
+        return Result.success;
+    }
+    can_hw_set_rx_callback(port, rx_cb);
+    _handles[port] = ow_can_open(port, cfg.bitrate, cfg.tx_gpio, cfg.rx_gpio, cfg.sjw, cfg.tseg1, cfg.tseg2, cfg.brp, &rx_ready_trampoline);
+    if (_handles[port] is null)
+    {
+        can_hw_set_rx_callback(port, null);
+        return InternalResult.failed;
+    }
+    _configs[port] = cfg;
+    return Result.success;
 }
 
 void can_hw_close(uint port)
 {
     if (port >= num_can || _handles[port] is null)
         return;
-    twai_stop_v2(_handles[port]);
-    twai_driver_uninstall_v2(_handles[port]);
+    can_hw_set_rx_callback(port, null);
+    ow_can_close(_handles[port]);
     _handles[port] = null;
+    _configs[port] = CanConfig.init;
 }
 
 bool can_hw_transmit(uint port, ref const CanFrame frame)
 {
-    if (port >= num_can || _handles[port] is null)
+    if (port >= num_can || _handles[port] is null || frame.dlc > 8)
         return false;
-    twai_message_t msg;
-    msg.flags = cast(uint)frame.extended | (cast(uint)frame.rtr << 1);
-    msg.identifier = frame.id;
-    msg.data_length_code = frame.dlc;
-    if (frame.dlc > 0)
-        msg.data[0 .. frame.dlc] = frame.data[0 .. frame.dlc];
-    return twai_transmit_v2(_handles[port], &msg, 0) == ESP_OK;
+    ubyte flags = (frame.extended ? 1 : 0) | (frame.rtr ? 2 : 0) | (frame.fd ? 4 : 0) | (frame.brs ? 8 : 0);
+    return ow_can_transmit(_handles[port], frame.id, flags, frame.dlc, frame.data.ptr);
 }
 
 bool can_hw_receive(uint port, out CanFrame frame)
 {
     if (port >= num_can || _handles[port] is null)
         return false;
-    twai_message_t msg;
-    if (twai_receive_v2(_handles[port], &msg, 0) != ESP_OK)
+    OwCanFrame raw;
+    if (!ow_can_receive(_handles[port], &raw))
         return false;
-    frame.id = msg.identifier;
-    frame.extended = (msg.flags & 1) != 0;
-    frame.rtr = (msg.flags & 2) != 0;
-    frame.dlc = msg.data_length_code;
-    if (msg.data_length_code > 0)
-        frame.data[0 .. msg.data_length_code] = msg.data[0 .. msg.data_length_code];
+    frame.id = raw.id;
+    frame.extended = (raw.flags & 1) != 0;
+    frame.rtr = (raw.flags & 2) != 0;
+    frame.fd = (raw.flags & 4) != 0;
+    frame.brs = (raw.flags & 8) != 0;
+    frame.dlc = raw.dlc;
+    if (raw.dlc > 0)
+        frame.data[0 .. raw.dlc] = raw.data[0 .. raw.dlc];
     return true;
 }
 
@@ -85,138 +95,114 @@ CanError can_hw_check_errors(uint port)
 {
     if (port >= num_can || _handles[port] is null)
         return CanError.none;
-    uint alerts;
-    twai_read_alerts_v2(_handles[port], &alerts, 0);
-    CanError err = CanError.none;
-    if (alerts & 0x0200) // TWAI_ALERT_BUS_ERROR
-        err |= CanError.bit;
-    if (alerts & 0x4800) // TWAI_ALERT_RX_FIFO_OVERRUN | RX_QUEUE_FULL
-        err |= CanError.overrun;
-    if (alerts & 0x0400) // TWAI_ALERT_TX_FAILED
-        err |= CanError.ack;
-    return err;
+    return cast(CanError)ow_can_check_errors(_handles[port]);
+}
+
+uint can_hw_take_rx_drops(uint port)
+{
+    if (port >= num_can || _handles[port] is null)
+        return 0;
+    return ow_can_take_rx_drops(_handles[port]);
 }
 
 CanBusState can_hw_bus_state(uint port)
 {
     if (port >= num_can || _handles[port] is null)
         return CanBusState.bus_off;
-    twai_status_info_t info;
-    if (twai_get_status_info_v2(_handles[port], &info) != ESP_OK)
-        return CanBusState.bus_off;
-    if (info.state >= 2) // BUS_OFF or RECOVERING
-        return CanBusState.bus_off;
-    if (info.tx_error_counter >= 128 || info.rx_error_counter >= 128)
-        return CanBusState.error_passive;
-    if (info.tx_error_counter >= 96 || info.rx_error_counter >= 96)
-        return CanBusState.error_warning;
-    return CanBusState.error_active;
+    return cast(CanBusState)ow_can_bus_state(_handles[port]);
 }
 
 ubyte can_hw_tx_error_count(uint port)
 {
     if (port >= num_can || _handles[port] is null)
         return 0;
-    twai_status_info_t info;
-    if (twai_get_status_info_v2(_handles[port], &info) != ESP_OK)
-        return 0;
-    return info.tx_error_counter > 255 ? 255 : cast(ubyte)info.tx_error_counter;
+    uint count = ow_can_tx_error_count(_handles[port]);
+    return count > 255 ? 255 : cast(ubyte)count;
 }
 
 ubyte can_hw_rx_error_count(uint port)
 {
     if (port >= num_can || _handles[port] is null)
         return 0;
-    twai_status_info_t info;
-    if (twai_get_status_info_v2(_handles[port], &info) != ESP_OK)
-        return 0;
-    return info.rx_error_counter > 255 ? 255 : cast(ubyte)info.rx_error_counter;
+    uint count = ow_can_rx_error_count(_handles[port]);
+    return count > 255 ? 255 : cast(ubyte)count;
 }
 
 size_t can_hw_rx_available(uint port)
 {
     if (port >= num_can || _handles[port] is null)
         return 0;
-    twai_status_info_t info;
-    if (twai_get_status_info_v2(_handles[port], &info) != ESP_OK)
-        return 0;
-    return cast(size_t)info.msgs_to_rx;
+    return ow_can_rx_available(_handles[port]);
 }
 
 void can_hw_rx_flush(uint port)
 {
     if (port >= num_can || _handles[port] is null)
         return;
-    twai_clear_receive_queue_v2(_handles[port]);
+    ow_can_rx_flush(_handles[port]);
 }
 
-void can_hw_tx_abort(uint port)
+Result can_hw_tx_abort(uint port)
 {
     if (port >= num_can || _handles[port] is null)
-        return;
-    twai_clear_transmit_queue_v2(_handles[port]);
+        return InternalResult.invalid_parameter;
+
+    // ESP-IDF's node API has no queue-clear operation. Disabling and re-enabling preserves queued frame pointers, so releasing their
+    // caller-owned slots here would permit the driver to transmit through reused storage.
+    return InternalResult.unsupported;
 }
 
 bool can_hw_bus_recover(uint port)
 {
     if (port >= num_can || _handles[port] is null)
         return false;
-    return twai_initiate_recovery_v2(_handles[port]) == ESP_OK;
+    return ow_can_bus_recover(_handles[port]);
 }
 
-void can_hw_poll(uint port)
+void can_hw_set_rx_callback(uint port, CanRxCallback cb)
 {
-    // TWAI driver buffers RX internally
+    if (port < num_can)
+        atomicStore!(MemoryOrder.release)(_rx_callback_bits[port], cast(size_t)cb);
 }
-
 
 private:
 
-enum int ESP_OK = 0;
+struct twai_node_t {}
+alias twai_node_handle_t = twai_node_t*;
 
-// Opaque ESP-IDF TWAI handle
-struct twai_obj_t {}
-alias twai_handle_t = twai_obj_t*;
-
-// ESP-IDF twai_message_t (flags union flattened to uint)
-struct twai_message_t
+struct OwCanFrame
 {
-    uint flags;             // bit 0: extd, bit 1: rtr, bit 2: ss, bit 3: self
-    uint identifier;
-    ubyte data_length_code;
+    uint id;
+    ubyte flags;
+    ubyte dlc;
     ubyte[8] data;
 }
 
-// ESP-IDF twai_status_info_t
-struct twai_status_info_t
-{
-    int state;              // 0=STOPPED, 1=RUNNING, 2=BUS_OFF, 3=RECOVERING
-    uint msgs_to_tx;
-    uint msgs_to_rx;
-    uint tx_error_counter;
-    uint rx_error_counter;
-    uint tx_failed_count;
-    uint rx_missed_count;
-    uint rx_overrun_count;
-    uint arb_lost_count;
-    uint bus_error_count;
-}
+__gshared twai_node_handle_t[num_can] _handles;
+__gshared CanConfig[num_can] _configs;
+shared size_t[num_can] _rx_callback_bits;
 
-__gshared twai_handle_t[num_can] _handles;
+extern(C) bool rx_ready_trampoline(uint port) nothrow @nogc
+{
+    if (port >= num_can)
+        return false;
+    auto cb = cast(CanRxCallback)atomicLoad!(MemoryOrder.acquire)(_rx_callback_bits[port]);
+    return cb !is null ? cb(Can(cast(ubyte)port), CanCallbackContext.interrupt) : false;
+}
 
 extern(C) nothrow @nogc
 {
-    // Shim -- bitrate table + config construction + install + start
-    twai_handle_t ow_can_open(uint port, uint bitrate, int tx_gpio, int rx_gpio, ubyte sjw, ubyte tseg1, ubyte tseg2, ushort brp);
-
-    // Direct ESP-IDF v2 calls
-    int twai_stop_v2(twai_handle_t handle);
-    int twai_driver_uninstall_v2(twai_handle_t handle);
-    int twai_transmit_v2(twai_handle_t handle, const(twai_message_t)* message, uint ticks_to_wait);
-    int twai_receive_v2(twai_handle_t handle, twai_message_t* message, uint ticks_to_wait);
-    int twai_read_alerts_v2(twai_handle_t handle, uint* alerts, uint ticks_to_wait);
-    int twai_get_status_info_v2(twai_handle_t handle, twai_status_info_t* status_info);
-    int twai_initiate_recovery_v2(twai_handle_t handle);
-    int twai_clear_receive_queue_v2(twai_handle_t handle);
-    int twai_clear_transmit_queue_v2(twai_handle_t handle);
+    twai_node_handle_t ow_can_open(uint port, uint bitrate, int tx_gpio, int rx_gpio, ubyte sjw, ubyte tseg1, ubyte tseg2, ushort brp,
+                                   bool function(uint) nothrow @nogc rx_cb);
+    void ow_can_close(twai_node_handle_t handle);
+    bool ow_can_transmit(twai_node_handle_t handle, uint id, ubyte flags, ubyte dlc, const(ubyte)* data);
+    bool ow_can_receive(twai_node_handle_t handle, OwCanFrame* frame);
+    uint ow_can_check_errors(twai_node_handle_t handle);
+    uint ow_can_take_rx_drops(twai_node_handle_t handle);
+    uint ow_can_bus_state(twai_node_handle_t handle);
+    uint ow_can_tx_error_count(twai_node_handle_t handle);
+    uint ow_can_rx_error_count(twai_node_handle_t handle);
+    size_t ow_can_rx_available(twai_node_handle_t handle);
+    void ow_can_rx_flush(twai_node_handle_t handle);
+    bool ow_can_bus_recover(twai_node_handle_t handle);
 }

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -9,7 +9,9 @@
 #include "driver/uart.h"
 #include "esp_rom_serial_output.h"
 #include "soc/soc_caps.h"
+#include <stdbool.h>
 #include <stdatomic.h>
+#include <string.h>
 #ifdef OW_USE_LWIP
 #include "lwip/netdb.h"
 #endif
@@ -891,84 +893,338 @@ int ow_ble_deinit(void) { return 0; }
 #endif // CONFIG_BT_NIMBLE_ENABLED
 
 // -- CAN (TWAI) driver --
-//
-// Only ow_can_open lives here -- it builds the timing/general/filter config
-// structs and does install+start.  Everything else is called directly from D
-// via the ESP-IDF _v2 handle API.
 
-#include "soc/soc_caps.h"
 #if SOC_TWAI_SUPPORTED
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcpp"
-#include "driver/twai.h"
-#pragma GCC diagnostic pop
+#include "esp_twai.h"
+#include "esp_twai_onchip.h"
 
-twai_handle_t ow_can_open(unsigned port, uint32_t bitrate, int tx_gpio, int rx_gpio, uint8_t sjw, uint8_t tseg1, uint8_t tseg2, uint16_t brp)
+#define OW_CAN_RX_CAP 32
+#define OW_CAN_TX_CAP 16
+
+_Static_assert((OW_CAN_RX_CAP & (OW_CAN_RX_CAP - 1)) == 0, "CAN RX capacity must be a power of two");
+_Static_assert(OW_CAN_TX_CAP <= 32, "CAN TX capacity exceeds the ownership bitmap");
+
+typedef bool (*ow_can_rx_cb_t)(unsigned port);
+
+typedef struct {
+    uint32_t id;
+    uint8_t flags;
+    uint8_t dlc;
+    uint8_t data[8];
+} ow_can_frame_t;
+
+typedef struct {
+    twai_frame_t frame;
+    uint8_t data[8];
+} ow_can_tx_slot_t;
+
+typedef struct {
+    twai_node_handle_t handle;
+    unsigned port;
+    ow_can_rx_cb_t rx_cb;
+    _Atomic uint32_t rx_head;
+    _Atomic uint32_t rx_tail;
+    _Atomic uint32_t rx_drops;
+    _Atomic uint32_t errors;
+    _Atomic uint32_t tx_used;
+    ow_can_frame_t rx[OW_CAN_RX_CAP];
+    ow_can_tx_slot_t tx[OW_CAN_TX_CAP];
+} ow_can_context_t;
+
+static ow_can_context_t ow_can_contexts[SOC_TWAI_CONTROLLER_NUM];
+
+static ow_can_context_t *ow_can_find(twai_node_handle_t handle)
 {
-    if (port >= SOC_TWAI_CONTROLLER_NUM)
+    if (!handle)
+        return NULL;
+    for (unsigned i = 0; i < SOC_TWAI_CONTROLLER_NUM; ++i)
+        if (ow_can_contexts[i].handle == handle)
+            return &ow_can_contexts[i];
+    return NULL;
+}
+
+static bool ow_can_rx_done(twai_node_handle_t handle, const twai_rx_done_event_data_t *edata, void *user_ctx)
+{
+    (void)edata;
+    ow_can_context_t *ctx = (ow_can_context_t *)user_ctx;
+    uint8_t data[64];
+    twai_frame_t frame = {
+        .buffer = data,
+        .buffer_len = sizeof(data),
+    };
+    if (twai_node_receive_from_isr(handle, &frame) != ESP_OK)
+        return false;
+
+    uint16_t length = twaifd_dlc2len(frame.header.dlc);
+    uint32_t head = atomic_load_explicit(&ctx->rx_head, memory_order_relaxed);
+    uint32_t tail = atomic_load_explicit(&ctx->rx_tail, memory_order_acquire);
+    if (length > sizeof(ctx->rx[0].data))
+    {
+        // The portable frame carries only classic-CAN payloads. Account unsupported FD frames as drops, not queue overruns.
+        atomic_fetch_add_explicit(&ctx->rx_drops, 1, memory_order_relaxed);
+        return false;
+    }
+    if (head - tail >= OW_CAN_RX_CAP)
+    {
+        atomic_fetch_add_explicit(&ctx->rx_drops, 1, memory_order_relaxed);
+        atomic_fetch_or_explicit(&ctx->errors, 1u << 5, memory_order_relaxed);
+        return false;
+    }
+
+    ow_can_frame_t *slot = &ctx->rx[head & (OW_CAN_RX_CAP - 1)];
+    slot->id = frame.header.id;
+    slot->flags = (frame.header.ide ? 1 : 0) | (frame.header.rtr ? 2 : 0) | (frame.header.fdf ? 4 : 0) | (frame.header.brs ? 8 : 0);
+    slot->dlc = (uint8_t)length;
+    if (frame.header.rtr)
+        memset(slot->data, 0, sizeof(slot->data));
+    else if (length > 0)
+        memcpy(slot->data, data, length);
+    atomic_store_explicit(&ctx->rx_head, head + 1, memory_order_release);
+    return ctx->rx_cb ? ctx->rx_cb(ctx->port) : false;
+}
+
+static bool ow_can_tx_done(twai_node_handle_t handle, const twai_tx_done_event_data_t *edata, void *user_ctx)
+{
+    (void)handle;
+    ow_can_context_t *ctx = (ow_can_context_t *)user_ctx;
+    if (!edata->is_tx_success)
+        atomic_fetch_or_explicit(&ctx->errors, 1u << 4, memory_order_relaxed);
+    if (edata->done_tx_frame)
+    {
+        ow_can_tx_slot_t *slot = (ow_can_tx_slot_t *)edata->done_tx_frame;
+        unsigned index = (unsigned)(slot - ctx->tx);
+        if (index < OW_CAN_TX_CAP)
+            atomic_fetch_and_explicit(&ctx->tx_used, ~(1u << index), memory_order_release);
+    }
+    return false;
+}
+
+static bool ow_can_error(twai_node_handle_t handle, const twai_error_event_data_t *edata, void *user_ctx)
+{
+    (void)handle;
+    ow_can_context_t *ctx = (ow_can_context_t *)user_ctx;
+    uint32_t errors = 0;
+    // ESP-IDF 6.0 exposes arbitration, bit, form, stuff, and ACK flags here, but no CRC flag.
+    if (edata->err_flags.bit_err)
+        errors |= 1u << 0;
+    if (edata->err_flags.stuff_err)
+        errors |= 1u << 1;
+    if (edata->err_flags.form_err)
+        errors |= 1u << 3;
+    if (edata->err_flags.ack_err)
+        errors |= 1u << 4;
+    atomic_fetch_or_explicit(&ctx->errors, errors, memory_order_relaxed);
+    return false;
+}
+
+twai_node_handle_t ow_can_open(unsigned port, uint32_t bitrate, int tx_gpio, int rx_gpio, uint8_t sjw, uint8_t tseg1, uint8_t tseg2,
+                               uint16_t brp, ow_can_rx_cb_t rx_cb)
+{
+    if (port >= SOC_TWAI_CONTROLLER_NUM || bitrate == 0 || tx_gpio < 0 || rx_gpio < 0)
         return NULL;
 
-    twai_timing_config_t timing;
+    ow_can_context_t *ctx = &ow_can_contexts[port];
+    if (ctx->handle)
+        return ctx->handle;
+
+    twai_onchip_node_config_t config = {
+        .io_cfg = {
+            .tx = tx_gpio,
+            .rx = rx_gpio,
+            .quanta_clk_out = -1,
+            .bus_off_indicator = -1,
+        },
+        .bit_timing = {
+            .bitrate = bitrate,
+        },
+        .fail_retry_cnt = -1,
+        .tx_queue_depth = OW_CAN_TX_CAP,
+    };
+
+    twai_node_handle_t handle = NULL;
+    if (twai_new_node_onchip(&config, &handle) != ESP_OK)
+        return NULL;
+
     if (brp > 0)
     {
-        memset(&timing, 0, sizeof(timing));
-        timing.clk_src = TWAI_CLK_SRC_DEFAULT;
-        timing.brp = brp;
-        timing.tseg_1 = tseg1;
-        timing.tseg_2 = tseg2;
-        timing.sjw = sjw;
-    }
-    else
-    {
-        switch (bitrate)
+        twai_timing_advanced_config_t timing = {
+            .brp = brp,
+            .tseg_1 = tseg1,
+            .tseg_2 = tseg2,
+            .sjw = sjw,
+        };
+        if (twai_node_reconfig_timing(handle, &timing, NULL) != ESP_OK)
         {
-        case 1000:    timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_1KBITS();     break;
-        case 5000:    timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_5KBITS();     break;
-        case 10000:   timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_10KBITS();    break;
-        case 12500:   timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_12_5KBITS();  break;
-        case 16000:   timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_16KBITS();    break;
-        case 20000:   timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_20KBITS();    break;
-        case 25000:   timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_25KBITS();    break;
-        case 50000:   timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_50KBITS();    break;
-        case 100000:  timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_100KBITS();   break;
-        case 125000:  timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_125KBITS();   break;
-        case 250000:  timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_250KBITS();   break;
-        case 500000:  timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_500KBITS();   break;
-        case 800000:  timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_800KBITS();   break;
-        case 1000000: timing = (twai_timing_config_t)TWAI_TIMING_CONFIG_1MBITS();     break;
-        default: return NULL;
+            twai_node_delete(handle);
+            return NULL;
         }
     }
 
-    twai_general_config_t general = TWAI_GENERAL_CONFIG_DEFAULT_V2(
-        port, tx_gpio, rx_gpio, TWAI_MODE_NORMAL);
-    general.alerts_enabled = TWAI_ALERT_BUS_ERROR | TWAI_ALERT_ERR_PASS
-        | TWAI_ALERT_ERR_ACTIVE | TWAI_ALERT_BUS_OFF | TWAI_ALERT_ABOVE_ERR_WARN
-        | TWAI_ALERT_BELOW_ERR_WARN | TWAI_ALERT_RX_FIFO_OVERRUN
-        | TWAI_ALERT_RX_QUEUE_FULL | TWAI_ALERT_ARB_LOST | TWAI_ALERT_TX_FAILED;
-    twai_filter_config_t filter = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->handle = handle;
+    ctx->port = port;
+    ctx->rx_cb = rx_cb;
 
-    twai_handle_t handle = NULL;
-    if (twai_driver_install_v2(&general, &timing, &filter, &handle) != ESP_OK)
-        return NULL;
-
-    if (twai_start_v2(handle) != ESP_OK)
+    const twai_event_callbacks_t callbacks = {
+        .on_tx_done = &ow_can_tx_done,
+        .on_rx_done = &ow_can_rx_done,
+        .on_error = &ow_can_error,
+    };
+    if (twai_node_register_event_callbacks(handle, &callbacks, ctx) != ESP_OK || twai_node_enable(handle) != ESP_OK)
     {
-        twai_driver_uninstall_v2(handle);
+        ctx->handle = NULL;
+        twai_node_delete(handle);
         return NULL;
     }
-
     return handle;
+}
+
+void ow_can_close(twai_node_handle_t handle)
+{
+    ow_can_context_t *ctx = ow_can_find(handle);
+    if (!ctx)
+        return;
+    twai_node_disable(handle);
+    twai_node_delete(handle);
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+bool ow_can_transmit(twai_node_handle_t handle, uint32_t id, uint8_t flags, uint8_t dlc, const uint8_t *data)
+{
+    ow_can_context_t *ctx = ow_can_find(handle);
+    if (!ctx || dlc > 8 || (!data && dlc > 0))
+        return false;
+
+    uint32_t used = atomic_load_explicit(&ctx->tx_used, memory_order_relaxed);
+    unsigned index;
+    for (;;)
+    {
+        for (index = 0; index < OW_CAN_TX_CAP; ++index)
+            if (!(used & (1u << index)))
+                break;
+        if (index == OW_CAN_TX_CAP)
+            return false;
+        uint32_t desired = used | (1u << index);
+        if (atomic_compare_exchange_weak_explicit(&ctx->tx_used, &used, desired, memory_order_acquire, memory_order_relaxed))
+            break;
+    }
+
+    ow_can_tx_slot_t *slot = &ctx->tx[index];
+    memset(slot, 0, sizeof(*slot));
+    slot->frame.header.id = id;
+    slot->frame.header.dlc = dlc;
+    slot->frame.header.ide = (flags & 1) != 0;
+    slot->frame.header.rtr = (flags & 2) != 0;
+    slot->frame.header.fdf = (flags & 4) != 0;
+    slot->frame.header.brs = (flags & 8) != 0;
+    slot->frame.buffer = slot->data;
+    slot->frame.buffer_len = dlc;
+    if (!(flags & 2) && dlc > 0)
+        memcpy(slot->data, data, dlc);
+
+    if (twai_node_transmit(handle, &slot->frame, 0) != ESP_OK)
+    {
+        atomic_fetch_and_explicit(&ctx->tx_used, ~(1u << index), memory_order_release);
+        return false;
+    }
+    return true;
+}
+
+bool ow_can_receive(twai_node_handle_t handle, ow_can_frame_t *frame)
+{
+    ow_can_context_t *ctx = ow_can_find(handle);
+    if (!ctx || !frame)
+        return false;
+    uint32_t tail = atomic_load_explicit(&ctx->rx_tail, memory_order_relaxed);
+    uint32_t head = atomic_load_explicit(&ctx->rx_head, memory_order_acquire);
+    if (tail == head)
+        return false;
+    *frame = ctx->rx[tail & (OW_CAN_RX_CAP - 1)];
+    atomic_store_explicit(&ctx->rx_tail, tail + 1, memory_order_release);
+    return true;
+}
+
+uint32_t ow_can_check_errors(twai_node_handle_t handle)
+{
+    ow_can_context_t *ctx = ow_can_find(handle);
+    return ctx ? atomic_exchange_explicit(&ctx->errors, 0, memory_order_relaxed) : 0;
+}
+
+uint32_t ow_can_take_rx_drops(twai_node_handle_t handle)
+{
+    ow_can_context_t *ctx = ow_can_find(handle);
+    return ctx ? atomic_exchange_explicit(&ctx->rx_drops, 0, memory_order_relaxed) : 0;
+}
+
+uint32_t ow_can_bus_state(twai_node_handle_t handle)
+{
+    twai_node_status_t status;
+    return twai_node_get_info(handle, &status, NULL) == ESP_OK ? (uint32_t)status.state : (uint32_t)TWAI_ERROR_BUS_OFF;
+}
+
+uint32_t ow_can_tx_error_count(twai_node_handle_t handle)
+{
+    twai_node_status_t status;
+    return twai_node_get_info(handle, &status, NULL) == ESP_OK ? status.tx_error_count : 0;
+}
+
+uint32_t ow_can_rx_error_count(twai_node_handle_t handle)
+{
+    twai_node_status_t status;
+    return twai_node_get_info(handle, &status, NULL) == ESP_OK ? status.rx_error_count : 0;
+}
+
+size_t ow_can_rx_available(twai_node_handle_t handle)
+{
+    ow_can_context_t *ctx = ow_can_find(handle);
+    if (!ctx)
+        return 0;
+    uint32_t head = atomic_load_explicit(&ctx->rx_head, memory_order_acquire);
+    uint32_t tail = atomic_load_explicit(&ctx->rx_tail, memory_order_relaxed);
+    return head - tail;
+}
+
+void ow_can_rx_flush(twai_node_handle_t handle)
+{
+    ow_can_context_t *ctx = ow_can_find(handle);
+    if (!ctx)
+        return;
+    uint32_t head = atomic_load_explicit(&ctx->rx_head, memory_order_acquire);
+    atomic_store_explicit(&ctx->rx_tail, head, memory_order_release);
+}
+
+bool ow_can_bus_recover(twai_node_handle_t handle)
+{
+    return twai_node_recover(handle) == ESP_OK;
 }
 
 #else // !SOC_TWAI_SUPPORTED
 
-typedef struct twai_obj_t *twai_handle_t;
+typedef struct twai_node_base *twai_node_handle_t;
+typedef bool (*ow_can_rx_cb_t)(unsigned);
+typedef struct {
+    uint32_t id;
+    uint8_t flags;
+    uint8_t dlc;
+    uint8_t data[8];
+} ow_can_frame_t;
 
-twai_handle_t ow_can_open(unsigned, uint32_t, int, int, uint8_t, uint8_t, uint8_t, uint16_t)
+twai_node_handle_t ow_can_open(unsigned port, uint32_t bitrate, int tx_gpio, int rx_gpio, uint8_t sjw, uint8_t tseg1, uint8_t tseg2,
+                               uint16_t brp, ow_can_rx_cb_t rx_cb)
 {
-    return (twai_handle_t)0;
+    return NULL;
 }
+void ow_can_close(twai_node_handle_t handle) {}
+bool ow_can_transmit(twai_node_handle_t handle, uint32_t id, uint8_t flags, uint8_t dlc, const uint8_t *data) { return false; }
+bool ow_can_receive(twai_node_handle_t handle, ow_can_frame_t *frame) { return false; }
+uint32_t ow_can_check_errors(twai_node_handle_t handle) { return 0; }
+uint32_t ow_can_take_rx_drops(twai_node_handle_t handle) { return 0; }
+uint32_t ow_can_bus_state(twai_node_handle_t handle) { return 3; } // CanBusState.bus_off
+uint32_t ow_can_tx_error_count(twai_node_handle_t handle) { return 0; }
+uint32_t ow_can_rx_error_count(twai_node_handle_t handle) { return 0; }
+size_t ow_can_rx_available(twai_node_handle_t handle) { return 0; }
+void ow_can_rx_flush(twai_node_handle_t handle) {}
+bool ow_can_bus_recover(twai_node_handle_t handle) { return false; }
 
 #endif // SOC_TWAI_SUPPORTED
 


### PR DESCRIPTION
## Summary

Move ESP32 CAN receive to ESP-IDF 6.0's interrupt-driven TWAI node API. The ISR copies frames into a bounded SPSC ring and signals the consumer immediately after every successful enqueue. The receiver is responsible for marshalling ISR work and may coalesce its own task/event notification; the driver never relies on a racy empty-to-nonempty observation.

Expose deferred RX drop accounting through the portable CAN API and retain internal transmit storage until ESP-IDF reports completion.

## API contract

- `CanRxCallback` reports task versus interrupt context
- callbacks signal readiness only; `can_receive()` owns frame delivery and draining
- callbacks run immediately in the backend completion context and the receiver marshals work that is unsafe there
- callbacks must not block or call back into the CAN driver
- interrupt callbacks return whether the platform should yield to a woken task
- `can_take_rx_drops()` atomically returns and clears deferred-ring drop counts and is a required backend hook
- ESP-IDF's node API cannot safely clear its queued TX frame pointers, so `can_tx_abort()` reports unsupported instead of releasing live storage
- the obsolete polling API has been removed; consumers adapt to readiness callbacks when updating uRT

## Review changes

- rebased the single commit onto current uRT master
- made callback replacement atomic across the main task and TWAI ISR
- added explicit task/interrupt callback context, matching the reviewed UART and I2C contracts
- notify after every successful ISR enqueue, eliminating the empty-to-nonempty lost-wakeup race
- return `invalid_parameter` for missing ESP32 TX/RX pins because ESP-IDF defines no platform-default route
- return `already_exists` when a reopen configuration differs from the active controller
- document that unsupported FD payloads count as drops rather than overruns
- document that ESP-IDF 6.0's error flags do not expose CRC errors
- corrected ESP32-S2 support to one TWAI controller from IDF 6.0's `soc_caps.h`
- removed unsafe TX-abort emulation that could reuse slots still referenced by ESP-IDF
- made RTR ring payload storage deterministic rather than exposing stale slot bytes
- added compile-time capacity checks for the RX mask and TX ownership bitmap
- removed the no-op `can_poll()`/`can_hw_poll()` surface
- audited all three PR files to a roughly 150-column wrap width

## Validation

- `git diff --check origin/master HEAD`
- forced ESP32-S3 unittest cross-build
- forced ESP32-S2 unittest cross-build
- forced ESP32-C5 unittest cross-build
- compiled `ow_shim.c` with the exact ESP-IDF 6.0 ESP32-S3 compile command and modular UART/I2C/TWAI driver headers
- native unittest binary builds; execution currently stops at the repository's pre-existing `urt.file` assertion before reaching CAN
- all three PR files contain no lines over 150 columns; remaining wraps exceed the target width when joined or are structural initializers

## Hardware validation still required

- interrupt-driven receive and main-task draining under sustained CAN traffic
- per-frame ISR readiness without missed or stranded frames
- exact RX drop accounting under deliberate ring overflow and unsupported FD input
- transmit slot reuse after success and failure callbacks
- bus error, bus-off, and recovery behavior
- close/reopen cycles while traffic is present