### PR TITLE
Expose ESP32 WiFi link information

### DIFF
--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -710,6 +710,19 @@ int ow_wifi_ap_set_max_clients(uint8_t max_conn)
     return esp_wifi_set_config(WIFI_IF_AP, &cfg) == ESP_OK ? 1 : 0;
 }
 
+int ow_wifi_sta_get_ap_info(uint8_t *bssid, int *rssi)
+{
+    wifi_ap_record_t record;
+    if (esp_wifi_sta_get_ap_info(&record) != ESP_OK)
+        return 0;
+
+    if (bssid)
+        memcpy(bssid, record.bssid, sizeof(record.bssid));
+    if (rssi)
+        *rssi = record.rssi;
+    return 1;
+}
+
 // Ethernet frame RX callbacks -- one per netif (STA=0, AP=1).
 // esp_wifi_internal_reg_rxcb gives us raw Ethernet frames before lwIP,
 // so the bridge/routing layer sees all traffic.
@@ -842,6 +855,7 @@ void ow_wifi_deinit(void) {}
 int ow_wifi_sta_config(const char *s, const char *p, const uint8_t *b) { (void)s;(void)p;(void)b; return 0; }
 int ow_wifi_ap_config(const char *s, const char *p, uint8_t c, uint8_t m, uint8_t h) { (void)s;(void)p;(void)c;(void)m;(void)h; return 0; }
 int ow_wifi_ap_set_max_clients(uint8_t m) { (void)m; return 0; }
+int ow_wifi_sta_get_ap_info(uint8_t *b, int *r) { (void)b; (void)r; return 0; }
 int ow_wifi_set_rx_callback(ow_wifi_rx_cb_t cb) { (void)cb; return 0; }
 void ow_wifi_set_sta_callback(ow_wifi_event_cb_t cb) { (void)cb; }
 void ow_wifi_set_ap_callback(ow_wifi_event_cb_t cb) { (void)cb; }

--- a/src/urt/driver/esp32/wifi.d
+++ b/src/urt/driver/esp32/wifi.d
@@ -311,8 +311,19 @@ ubyte wifi_hw_get_channel(uint port)
 
 byte wifi_hw_get_rssi(uint port)
 {
-    // TODO: esp_wifi_sta_get_ap_info -> rssi
-    return -127;
+    WifiStaLinkInfo info;
+    return wifi_hw_get_sta_link_info(port, info) ? info.rssi : 0;
+}
+
+bool wifi_hw_get_sta_link_info(uint port, ref WifiStaLinkInfo info)
+{
+    if (port >= num_wifi)
+        return false;
+    int rssi;
+    if (ow_wifi_sta_get_ap_info(info.bssid.ptr, &rssi) == 0)
+        return false;
+    info.rssi = cast(byte)rssi;
+    return true;
 }
 
 bool wifi_hw_set_tx_power(uint port, byte power_dbm)
@@ -824,6 +835,7 @@ extern(C) nothrow @nogc
                       const(ubyte)* payload) nothrow @nogc cb);
     int ow_wifi_set_channel(int primary, int secondary);
     int ow_wifi_raw_tx(int ifx, const(ubyte)* frame, int len, int en_sys_seq);
+    int ow_wifi_sta_get_ap_info(ubyte* bssid, int* rssi);
 }
 
 // Direct ESP-IDF calls

--- a/src/urt/driver/wifi.d
+++ b/src/urt/driver/wifi.d
@@ -171,6 +171,12 @@ struct WifiStaInfo
     byte rssi;
 }
 
+struct WifiStaLinkInfo
+{
+    ubyte[6] bssid;
+    byte rssi;
+}
+
 // Delivered by wifi_service() when an Ethernet frame is received on a virtual
 // interface. Data includes the 14-byte Ethernet header and remains valid only
 // until the callback returns.
@@ -507,6 +513,16 @@ byte wifi_get_rssi(ref Wifi wifi)
         assert(false, "no WiFi on this platform");
     else
         return wifi_hw_get_rssi(wifi.port);
+}
+
+bool wifi_get_sta_link_info(ref Wifi wifi, ref WifiStaLinkInfo info)
+{
+    static if (num_wifi == 0)
+        return false;
+    else static if (__traits(compiles, wifi_hw_get_sta_link_info(wifi.port, info)))
+        return wifi_hw_get_sta_link_info(wifi.port, info);
+    else
+        return false;
 }
 
 Result wifi_set_tx_power(ref Wifi wifi, byte power_dbm)


### PR DESCRIPTION
## What changed

- add a shared STA link-info result containing BSSID and RSSI
- retrieve the associated AP record through the ESP-IDF C shim
- replace the ESP32 RSSI placeholder with live connection data

## Why

The ESP32 backend returned a fixed placeholder RSSI and offered no way for the OpenWatt WLAN interface to retrieve its associated BSSID. As a result, the existing read-only WLAN status properties could not be populated.

## Validation

- built the ESP32-S3 WaveShare release firmware with `BOARD=waveshare-esp32-s3-rs485-can`
- ESP-IDF completed the application, bootloader, and partition checks successfully