### PR TITLE
Add portable PWM, ADC sampling, and GPIO interrupt drivers

### DIFF
--- a/platforms.mk
+++ b/platforms.mk
@@ -257,6 +257,10 @@ ifdef PROCESSOR
   else ifeq ($(PROCESSOR),lx6)
       ARCH  = xtensa
       MATTR = +fp,+loop,+mac16,+dfpaccel
+      # ESP32 IDF libc omits 1/2/4-byte __atomic helpers because LX6 has S32C1I; Espressif llc knows this feature but upstream LDC does not.
+      XTENSA_LLC_EXTRA_MATTR := +s32c1i
+      # Espressif LLVM 20 crashes while releasing its assumption cache when tail duplication and S32C1I atomic lowering are both enabled.
+      XTENSA_LLC_EXTRA_FLAGS := --disable-tail-duplicate
   else ifeq ($(PROCESSOR),lx7)
       ARCH  = xtensa
   else ifeq ($(PROCESSOR),k210)
@@ -642,6 +646,9 @@ ifeq ($(COMPILER),ldc)
         DFLAGS := $(DFLAGS) -mtriple=xtensa-none-elf --thread-model=single -emulated-tls \
             --align-all-functions=2 $(XTENSA_MATTR) \
             -gcc=$(XTENSA_GCC_DIR)$(XTENSA_GCC)
+        ifdef XTENSA_LLC_EXTRA_MATTR
+            XTENSA_MATTR := $(XTENSA_MATTR) -mattr=$(XTENSA_LLC_EXTRA_MATTR)
+        endif
         ESPRESSIF_LLC := $(lastword $(sort $(wildcard $(HOME)/.espressif/tools/esp-clang/*/esp-clang/bin/llc)))
         XTENSA_TWO_STAGE := 1
     else

--- a/platforms.mk
+++ b/platforms.mk
@@ -256,7 +256,9 @@ ifdef PROCESSOR
       ARCH  = xtensa
   else ifeq ($(PROCESSOR),lx6)
       ARCH  = xtensa
-      MATTR = +fp,+loop,+mac16,+dfpaccel
+      # +miscsr unlocks the MISC0-3 scratch registers the synthesized reflex NMI handler saves into;
+      # it must ride the per-function target-features LDC emits, which override llc's -mattr.
+      MATTR = +fp,+loop,+mac16,+dfpaccel,+miscsr
       # ESP32 IDF libc omits 1/2/4-byte __atomic helpers because LX6 has S32C1I; Espressif llc knows this feature but upstream LDC does not.
       XTENSA_LLC_EXTRA_MATTR := +s32c1i
       # Espressif LLVM 20 crashes while releasing its assumption cache when tail duplication and S32C1I atomic lowering are both enabled.

--- a/src/urt/attribute.d
+++ b/src/urt/attribute.d
@@ -40,6 +40,17 @@ else
 }
 
 
+// --- Execution contracts --------------------------------
+
+// @isr_safe - function upholds the interrupt-context contract: brief,
+// non-blocking, takes no lock a non-interrupt path holds without an
+// interrupt-safe critical section, and calls only driver functions
+// documented critical-safe. Pair with @critical for SRAM residency;
+// this marker is the contract, @critical is the placement.
+// Registration points that call into interrupt context require it.
+enum isr_safe;
+
+
 // --- Memory placement -----------------------------------
 
 // @critical - code that must execute from internal SRAM.

--- a/src/urt/driver/adc.d
+++ b/src/urt/driver/adc.d
@@ -1,0 +1,144 @@
+module urt.driver.adc;
+
+import urt.result : InternalResult, Result;
+
+version (Espressif)
+    public import urt.driver.esp32.adc;
+else
+    enum uint num_adc = 0;
+
+nothrow @nogc:
+
+
+enum AdcAttenuation : ubyte
+{
+    db0,
+    db2_5,
+    db6,
+    db12,
+}
+
+enum AdcCalibrationSource : byte
+{
+    unavailable = -1,
+    factory_reference,
+    factory_two_point,
+    default_reference,
+}
+
+struct AdcConfig
+{
+    ubyte unit;
+}
+
+struct AdcInputConfig
+{
+    ubyte channel;
+    AdcAttenuation attenuation;
+    ubyte bit_width;
+    ushort default_reference_mv = 1100;
+}
+
+struct Adc
+{
+    void* handle;
+    ubyte unit = ubyte.max;
+}
+
+struct AdcInput
+{
+    void* calibration;
+    ubyte channel = ubyte.max;
+    AdcAttenuation attenuation;
+    ubyte bit_width;
+    AdcCalibrationSource calibration_source = AdcCalibrationSource.unavailable;
+}
+
+bool is_open(ref const Adc adc)
+{
+    return adc.handle !is null;
+}
+
+bool is_open(ref const AdcInput input)
+{
+    return input.channel != ubyte.max;
+}
+
+Result adc_open(ref Adc adc, ref const AdcConfig config)
+{
+    static if (num_adc == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (adc.is_open)
+            return InternalResult.already_exists;
+        if (config.unit >= num_adc)
+            return InternalResult.invalid_parameter;
+        return adc_hw_open(adc, config);
+    }
+}
+
+Result adc_input_open(ref Adc adc, ref AdcInput input, ref const AdcInputConfig config)
+{
+    static if (num_adc == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!adc.is_open || input.is_open || config.bit_width == 0)
+            return InternalResult.invalid_parameter;
+        return adc_hw_input_open(adc, input, config);
+    }
+}
+
+Result adc_read_raw(ref Adc adc, ref const AdcInput input, out uint value)
+{
+    static if (num_adc == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!adc.is_open || !input.is_open)
+            return InternalResult.invalid_parameter;
+        return adc_hw_read_raw(adc, input, value);
+    }
+}
+
+Result adc_raw_to_mv(ref const AdcInput input, uint raw, out uint millivolts)
+{
+    static if (num_adc == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!input.is_open)
+            return InternalResult.invalid_parameter;
+        return adc_hw_raw_to_mv(input, raw, millivolts);
+    }
+}
+
+Result adc_read_mv(ref Adc adc, ref const AdcInput input, out uint millivolts)
+{
+    uint raw;
+    Result result = adc_read_raw(adc, input, raw);
+    if (!result)
+        return result;
+    return adc_raw_to_mv(input, raw, millivolts);
+}
+
+void adc_input_close(ref AdcInput input)
+{
+    static if (num_adc != 0)
+    {
+        if (input.is_open)
+            adc_hw_input_close(input);
+    }
+    input = AdcInput();
+}
+
+void adc_close(ref Adc adc)
+{
+    static if (num_adc != 0)
+    {
+        if (adc.is_open)
+            adc_hw_close(adc);
+    }
+    adc = Adc();
+}

--- a/src/urt/driver/adc.d
+++ b/src/urt/driver/adc.d
@@ -1,5 +1,6 @@
 module urt.driver.adc;
 
+import urt.attribute : critical;
 import urt.result : InternalResult, Result;
 
 version (Espressif)
@@ -121,6 +122,29 @@ Result adc_read_mv(ref Adc adc, ref const AdcInput input, out uint millivolts)
     if (!result)
         return result;
     return adc_raw_to_mv(input, raw, millivolts);
+}
+
+// True when adc_read_critical works for this unit on this platform.
+bool adc_can_read_critical(ref const Adc adc)
+{
+    static if (num_adc == 0)
+        return false;
+    else
+        return adc.is_open && adc_hw_can_read_critical(adc);
+}
+
+// Raw conversion, safe from interrupt context. No calibration here:
+// adc_raw_to_mv is not critical-safe, convert later in task context.
+@critical Result adc_read_critical(ref Adc adc, ref const AdcInput input, out uint value)
+{
+    static if (num_adc == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!adc.is_open || !input.is_open)
+            return InternalResult.invalid_parameter;
+        return adc_hw_read_critical(adc, input, value);
+    }
 }
 
 void adc_input_close(ref AdcInput input)

--- a/src/urt/driver/adc.d
+++ b/src/urt/driver/adc.d
@@ -134,7 +134,7 @@ bool adc_can_read_critical(ref const Adc adc)
 }
 
 // Raw conversion, safe from interrupt context. No calibration here:
-// adc_raw_to_mv is not critical-safe, convert later in task context.
+// adc_raw_to_mv is not critical-safe, convert later in thread context.
 @critical Result adc_read_critical(ref Adc adc, ref const AdcInput input, out uint value)
 {
     static if (num_adc == 0)

--- a/src/urt/driver/can.d
+++ b/src/urt/driver/can.d
@@ -69,13 +69,13 @@ struct CanFilter
 
 enum CanCallbackContext : ubyte
 {
-    task,
+    thread,
     interrupt,
 }
 
 // Called immediately after a frame has been queued for can_receive(). The receiver must marshal work that is unsafe in the reported context, and the
-// callback must not block or call back into the CAN driver. Interrupt callbacks return whether the platform should yield to a task woken by the
-// callback; task-context backends ignore the result.
+// callback must not block or call back into the CAN driver. Interrupt callbacks return whether the platform should yield to a thread woken by the
+// callback; thread-context backends ignore the result.
 alias CanRxCallback = bool function(Can can, CanCallbackContext context) nothrow @nogc;
 
 // Called from ISR when a TX mailbox becomes free.

--- a/src/urt/driver/counter.d
+++ b/src/urt/driver/counter.d
@@ -1,0 +1,99 @@
+// Free-running peripheral counter with a programmable alarm, allocated by
+// port number. Distinct from urt.driver.timer, which owns the system
+// timebase; counters are for realtime sequencing (sample scheduling,
+// edge-relative delays). Alarm delivery is not a portable callback API;
+// alarms are consumed as events by whoever wires the backend's sink.
+//
+// Function bodies live in <soc>/counter.d. Each backend exports:
+//   Result counter_hw_open(uint port, ref const CounterConfig);
+//   Result counter_hw_arm(uint port, ulong ticks, bool periodic);
+//   void counter_hw_reload(uint port);
+//   ulong counter_hw_read(uint port);
+//   void counter_hw_close(uint port);
+module urt.driver.counter;
+
+import urt.attribute : critical;
+import urt.result : InternalResult, Result;
+
+version (Espressif)
+    public import urt.driver.esp32.counter;
+else
+    enum uint num_counters = 0;
+
+nothrow @nogc:
+
+
+struct CounterConfig
+{
+    uint resolution_hz = 1_000_000;
+}
+
+struct Counter
+{
+    ubyte port = ubyte.max;
+}
+
+bool is_open(ref const Counter counter)
+{
+    return counter.port != ubyte.max;
+}
+
+Result counter_open(ref Counter counter, ubyte port, ref const CounterConfig config)
+{
+    static if (num_counters == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (counter.is_open)
+            return InternalResult.already_exists;
+        if (port >= num_counters || config.resolution_hz == 0)
+            return InternalResult.invalid_parameter;
+        Result result = counter_hw_open(port, config);
+        if (!result)
+            return result;
+        counter.port = port;
+        return Result.success;
+    }
+}
+
+// Alarm after ticks counts from zero. Periodic alarms self-rearm; a one-shot
+// alarm fires once and is rearmed by reload().
+Result counter_arm(ref Counter counter, ulong ticks, bool periodic)
+{
+    static if (num_counters == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!counter.is_open || ticks == 0)
+            return InternalResult.invalid_parameter;
+        return counter_hw_arm(counter.port, ticks, periodic);
+    }
+}
+
+// Zero the count and rearm the armed alarm. Safe from interrupt context.
+@critical void counter_reload(ref Counter counter)
+{
+    static if (num_counters != 0)
+    {
+        if (counter.is_open)
+            counter_hw_reload(counter.port);
+    }
+}
+
+ulong counter_read(ref Counter counter)
+{
+    static if (num_counters == 0)
+        return 0;
+    else
+        return counter.is_open ? counter_hw_read(counter.port) : 0;
+}
+
+void counter_close(ref Counter counter)
+{
+    static if (num_counters != 0)
+    {
+        if (counter.is_open)
+            counter_hw_close(counter.port);
+    }
+    counter = Counter();
+}

--- a/src/urt/driver/esp32/adc.d
+++ b/src/urt/driver/esp32/adc.d
@@ -1,5 +1,6 @@
 module urt.driver.esp32.adc;
 
+import urt.attribute : critical;
 import urt.driver.adc;
 import urt.result : InternalResult, Result;
 
@@ -47,6 +48,19 @@ Result adc_hw_raw_to_mv(ref const AdcInput input, uint raw, out uint millivolts)
     return ow_adc_raw_to_mv(input.calibration, raw, &millivolts) == 0 ? Result.success : InternalResult.failed;
 }
 
+// Unit 1 only: unit 2 routes through the IDF oneshot driver, which locks.
+bool adc_hw_can_read_critical(ref const Adc adc)
+{
+    return adc.unit == 0;
+}
+
+@critical Result adc_hw_read_critical(ref Adc adc, ref const AdcInput input, out uint value)
+{
+    if (adc.unit != 0)
+        return InternalResult.unsupported;
+    return ow_adc_read_critical(input.channel, &value) == 0 ? Result.success : InternalResult.failed;
+}
+
 void adc_hw_input_close(ref AdcInput input)
 {
     ow_adc_input_close(input.calibration);
@@ -65,6 +79,7 @@ extern(C) nothrow @nogc
     int ow_adc_open(uint unit, void** handle);
     int ow_adc_input_open(void* handle, uint unit, uint channel, AdcAttenuation attenuation, uint bit_width, uint default_reference_mv, void** calibration, int* calibration_source);
     int ow_adc_read(void* handle, uint unit, uint channel, uint* raw);
+    int ow_adc_read_critical(uint channel, uint* raw);
     int ow_adc_raw_to_mv(const(void)* calibration, uint raw, uint* millivolts);
     void ow_adc_input_close(void* calibration);
     void ow_adc_close(void* handle);

--- a/src/urt/driver/esp32/adc.d
+++ b/src/urt/driver/esp32/adc.d
@@ -1,0 +1,71 @@
+module urt.driver.esp32.adc;
+
+import urt.driver.adc;
+import urt.result : InternalResult, Result;
+
+nothrow @nogc:
+
+
+version (ESP32)
+    enum uint num_adc = 2;
+else
+    enum uint num_adc = 0;
+
+Result adc_hw_open(ref Adc adc, ref const AdcConfig config)
+{
+    void* handle;
+    if (ow_adc_open(config.unit, &handle) != 0)
+        return InternalResult.failed;
+
+    adc.handle = handle;
+    adc.unit = config.unit;
+    return Result.success;
+}
+
+Result adc_hw_input_open(ref Adc adc, ref AdcInput input, ref const AdcInputConfig config)
+{
+    void* calibration;
+    int calibration_source;
+    if (ow_adc_input_open(adc.handle, adc.unit, config.channel, config.attenuation, config.bit_width, config.default_reference_mv, &calibration, &calibration_source) != 0)
+        return InternalResult.failed;
+
+    input.calibration = calibration;
+    input.channel = config.channel;
+    input.attenuation = config.attenuation;
+    input.bit_width = config.bit_width;
+    input.calibration_source = calibration_source < 0 ? AdcCalibrationSource.unavailable : cast(AdcCalibrationSource)calibration_source;
+    return Result.success;
+}
+
+Result adc_hw_read_raw(ref Adc adc, ref const AdcInput input, out uint value)
+{
+    return ow_adc_read(adc.handle, adc.unit, input.channel, &value) == 0 ? Result.success : InternalResult.failed;
+}
+
+Result adc_hw_raw_to_mv(ref const AdcInput input, uint raw, out uint millivolts)
+{
+    return ow_adc_raw_to_mv(input.calibration, raw, &millivolts) == 0 ? Result.success : InternalResult.failed;
+}
+
+void adc_hw_input_close(ref AdcInput input)
+{
+    ow_adc_input_close(input.calibration);
+}
+
+void adc_hw_close(ref Adc adc)
+{
+    ow_adc_close(adc.handle);
+}
+
+
+private:
+
+extern(C) nothrow @nogc
+{
+    int ow_adc_open(uint unit, void** handle);
+    int ow_adc_input_open(void* handle, uint unit, uint channel, AdcAttenuation attenuation, uint bit_width, uint default_reference_mv, void** calibration, int* calibration_source);
+    int ow_adc_read(void* handle, uint unit, uint channel, uint* raw);
+    int ow_adc_raw_to_mv(const(void)* calibration, uint raw, uint* millivolts);
+    void ow_adc_input_close(void* calibration);
+    void ow_adc_close(void* handle);
+}

--- a/src/urt/driver/esp32/counter.d
+++ b/src/urt/driver/esp32/counter.d
@@ -1,0 +1,55 @@
+// ESP32 counter backend over ESP-IDF gptimer through ow_shim.c.
+//
+// counter_hw_reload executes from interrupt context; the shim requires
+// CONFIG_GPTIMER_CTRL_FUNC_IN_IRAM and CONFIG_GPTIMER_ISR_CACHE_SAFE and
+// fails the C build without them.
+module urt.driver.esp32.counter;
+
+import urt.attribute : critical;
+import urt.driver.counter;
+import urt.result : InternalResult, Result;
+
+nothrow @nogc:
+
+
+version (ESP32)
+    enum uint num_counters = 4;
+else
+    enum uint num_counters = 0;
+
+Result counter_hw_open(uint port, ref const CounterConfig config)
+{
+    return ow_counter_open(port, config.resolution_hz) == 0 ? Result.success : InternalResult.failed;
+}
+
+Result counter_hw_arm(uint port, ulong ticks, bool periodic)
+{
+    return ow_counter_arm(port, ticks, periodic) == 0 ? Result.success : InternalResult.failed;
+}
+
+@critical void counter_hw_reload(uint port)
+{
+    ow_counter_reload(port);
+}
+
+ulong counter_hw_read(uint port)
+{
+    return ow_counter_read(port);
+}
+
+void counter_hw_close(uint port)
+{
+    ow_counter_close(port);
+}
+
+
+private:
+
+extern(C) nothrow @nogc
+{
+    int ow_counter_open(uint port, uint resolution_hz);
+    int ow_counter_arm(uint port, ulong ticks, bool periodic);
+    void ow_counter_reload(uint port);
+    ulong ow_counter_read(uint port);
+    void ow_counter_close(uint port);
+}

--- a/src/urt/driver/esp32/event.d
+++ b/src/urt/driver/esp32/event.d
@@ -1,0 +1,327 @@
+// ESP32 link backend. Classic ESP32 has no trigger matrix (ETM arrives
+// with C5/C6/H2/P4): interrupt-tier links lower to a maskable ISR,
+// unmaskable reflexes are synthesized onto the NMI, and the autonomous
+// tier cannot be satisfied. Slot state is published with an
+// acquire/release flag so the dispatcher never observes a half-written
+// task.
+module urt.driver.esp32.event;
+
+import urt.atomic : MemoryOrder, atomicExchange, atomicLoad, atomicStore;
+import urt.attribute : critical, naked, used;
+import urt.driver.gpio : gpio_output_set;
+import urt.driver.event;
+import urt.result : InternalResult, Result;
+
+nothrow @nogc:
+
+
+version (ESP32)
+{
+    enum uint num_links = 8;
+    enum bool has_reflex = true;
+}
+else
+{
+    enum uint num_links = 0;
+    enum bool has_reflex = false;
+}
+
+// No trigger matrix on any Xtensa or early RISC-V Espressif part; ETM arrives
+// with C5/C6/H2/P4, whose backend will answer this per event/task pair.
+bool can_route(EventKind, TaskKind) pure => false;
+
+version (ESP32):
+
+import urt.driver.esp32.counter : num_counters;
+
+Result link_hw_open(uint slot, EventSource event, Task task, LinkTier minimum, out bool hardware)
+{
+    hardware = false;
+    // Runtime opens lower to a maskable ISR; rungs above that are synthesized
+    // and only reachable through a ReflexGraph declaration.
+    if (minimum > LinkTier.interrupt)
+        return InternalResult.unsupported;
+    if (event.chip != 0 || task.chip != 0)
+        return InternalResult.unsupported;
+    if (_slots[slot].task.kind != TaskKind.none)
+        return InternalResult.already_exists;
+
+    // The event source is claimed exclusively. The gpio ISR service keeps one
+    // handler per pin and a counter has one alarm sink, so a second link on the
+    // same source would silently displace the first; refuse instead.
+    foreach (i, ref s; _slots)
+    {
+        if (i == slot || !atomicLoad!(MemoryOrder.acquire)(s.active))
+            continue;
+        if (is_gpio_kind(s.event.kind) && is_gpio_kind(event.kind) && s.event.index == event.index)
+            return InternalResult.already_exists;
+    }
+    if (event.kind == EventKind.counter_alarm && event.index < num_counters && _counter_slots[event.index] != ubyte.max)
+        return InternalResult.already_exists;
+
+    _slots[slot].event = event;
+    _slots[slot].task = task;
+    atomicStore!(MemoryOrder.release)(_slots[slot].active, true);
+
+    final switch (event.kind)
+    {
+        case EventKind.gpio_rising:
+        case EventKind.gpio_falling:
+        case EventKind.gpio_change:
+            if (ow_link_gpio_open(slot, event.index, cast(uint)(event.kind - EventKind.gpio_rising)) != 0)
+                break;
+            return Result.success;
+
+        case EventKind.counter_alarm:
+            if (event.index >= _counter_slots.length)
+                break;
+            _counter_slots[event.index] = cast(ubyte)slot;
+            ow_counter_set_callback(event.index, &link_counter_alarm);
+            return Result.success;
+
+        case EventKind.none:
+            break;
+    }
+
+    atomicStore!(MemoryOrder.release)(_slots[slot].active, false);
+    _slots[slot] = LinkSlot();
+    return InternalResult.failed;
+}
+
+void link_hw_close(uint slot)
+{
+    EventSource event = _slots[slot].event;
+    final switch (event.kind)
+    {
+        case EventKind.gpio_rising:
+        case EventKind.gpio_falling:
+        case EventKind.gpio_change:
+            ow_link_gpio_close(slot, event.index);
+            break;
+
+        case EventKind.counter_alarm:
+            ow_counter_set_callback(event.index, null);
+            _counter_slots[event.index] = ubyte.max;
+            break;
+
+        case EventKind.none:
+            break;
+    }
+    atomicStore!(MemoryOrder.release)(_slots[slot].active, false);
+    _slots[slot] = LinkSlot();
+}
+
+
+// -- Reflex synthesis ----------------------------------------------------
+//
+// Reflexes on classic ESP32 lower to the true NMI: the GPIO NMI matrix
+// source routed to CPU interrupt 14 (level 7, above every maskable level;
+// rsil cannot defer it). xt_nmi is weak in the IDF vector table and the
+// graph's synthesized handler overrides it; a second graph collides on the
+// symbol and fails to link, which is the intended budget check for the
+// chip's single NMI vector. The vector saves a0 to EXCSAVE_7; the handler
+// saves its scratch to MISC0-2, touches no stack, and reads no mutable
+// state beyond the status latch it must acknowledge (an unacknowledged
+// edge would re-enter forever). Task masks are immediates baked into the
+// code; the fired latch lives in DRAM, which is never cached on this part.
+
+extern(C) shared uint ow_reflex_fired0;
+
+extern(C) nothrow @nogc
+{
+    int ow_reflex_open(uint gpio, uint trigger);
+    void ow_reflex_close(uint gpio);
+}
+
+mixin template ReflexBackend(reflexes...)
+{
+    import urt.attribute : reflex_critical = critical, reflex_naked = naked, reflex_used = used;
+
+    static foreach (r; reflexes)
+    {
+        static assert(r.tier <= LinkTier.unmaskable,
+                      "no trigger matrix on classic ESP32: an autonomous reflex cannot lower here; unmaskable rides the NMI");
+        static assert(r.event.kind == EventKind.gpio_rising || r.event.kind == EventKind.gpio_falling ||
+                      r.event.kind == EventKind.gpio_change, "reflex events on this backend are gpio edges");
+        static assert(r.event.chip == 0 && r.event.index < 32, "reflex event pins are gpio0-31");
+        static foreach (t; r.tasks)
+        {
+            static assert(t.kind == TaskKind.gpio_set || t.kind == TaskKind.gpio_clear,
+                          "reflex tasks are immediate register writes: gpio set/clear (no isr, counter, or C calls at NMI level)");
+            static assert(t.chip == 0 && t.index < 40, "reflex task pins are gpio0-39");
+        }
+    }
+
+    // Handler synthesis is a CTFE-only immediately-invoked literal: literals
+    // infer attributes, so the string building escapes the driver-wide @nogc,
+    // which only constrains runtime code.
+    private enum string _nmi_asm = () {
+        enum uint OUT_W1TS = 0x3FF44008, OUT_W1TC = 0x3FF4400C;
+        enum uint OUT1_W1TS = 0x3FF44014, OUT1_W1TC = 0x3FF44018;
+        enum uint STATUS_W1TC = 0x3FF4404C, PCPU_NMI_INT = 0x3FF4406C;
+        enum bool multi = reflexes.length > 1;
+
+        string dec(uint value)
+        {
+            string s;
+            do
+            {
+                char digit = '0' + value % 10;
+                s = digit ~ s;
+                value /= 10;
+            }
+            while (value);
+            return s;
+        }
+
+        string write(uint reg, uint mask)
+            => "movi a2, " ~ dec(reg) ~ "\nmovi a3, " ~ dec(mask) ~ "\ns32i a3, a2, 0\n";
+
+        // Special-register moves as raw encodings: the fork's function-level
+        // inline-asm parser rejects every feature-gated SR mnemonic (module
+        // asm accepts them), so wsr/rsr are emitted as data. Byte layout is
+        // t<<4, sr, opcode with wsr = 0x13 and rsr = 0x03, verified by
+        // round-tripping through the GNU assembler.
+        string sr_op(uint opcode, uint t, uint sr)
+            => ".byte " ~ dec(t << 4) ~ ", " ~ dec(sr) ~ ", " ~ dec(opcode) ~ "\n";
+        enum uint WSR = 0x13, RSR = 0x03;
+        enum uint MISC0 = 244, MISC1 = 245, MISC2 = 246, EXCSAVE7 = 215;
+
+        string s = ".literal_position\n"
+                 ~ sr_op(WSR, 2, MISC0) ~ sr_op(WSR, 3, MISC1) ~ sr_op(WSR, 4, MISC2);
+        uint all_events;
+        static if (multi)
+            s ~= "movi a2, " ~ dec(PCPU_NMI_INT) ~ "\nl32i a4, a2, 0\n";
+        static foreach (r; reflexes)
+        {{
+            uint set0, clr0, set1, clr1;
+            foreach (t; r.tasks)
+            {
+                if (t.index < 32)
+                {
+                    if (t.kind == TaskKind.gpio_set) set0 |= 1u << t.index;
+                    else clr0 |= 1u << t.index;
+                }
+                else
+                {
+                    if (t.kind == TaskKind.gpio_set) set1 |= 1u << (t.index - 32);
+                    else clr1 |= 1u << (t.index - 32);
+                }
+            }
+            all_events |= 1u << r.event.index;
+            static if (multi)
+                s ~= "bbci a4, " ~ dec(r.event.index) ~ ", 1f\n";
+            if (clr0) s ~= write(OUT_W1TC, clr0);
+            if (set0) s ~= write(OUT_W1TS, set0);
+            if (clr1) s ~= write(OUT1_W1TC, clr1);
+            if (set1) s ~= write(OUT1_W1TS, set1);
+            static if (multi)
+                s ~= "1:\n";
+        }}
+
+        // Latch what fired for the main loop, then acknowledge the edge.
+        s ~= "movi a2, ow_reflex_fired0\nl32i a3, a2, 0\n";
+        static if (multi)
+            s ~= "or a3, a3, a4\ns32i a3, a2, 0\n" ~
+                 "movi a2, " ~ dec(STATUS_W1TC) ~ "\ns32i a4, a2, 0\n";
+        else
+            s ~= "movi a4, " ~ dec(all_events) ~ "\nor a3, a3, a4\ns32i a3, a2, 0\n" ~
+                 "movi a2, " ~ dec(STATUS_W1TC) ~ "\nmovi a3, " ~ dec(all_events) ~ "\ns32i a3, a2, 0\n";
+        s ~= "memw\n"
+           ~ sr_op(RSR, 4, MISC2) ~ sr_op(RSR, 3, MISC1) ~ sr_op(RSR, 2, MISC0) ~ sr_op(RSR, 0, EXCSAVE7)
+           ~ "rfi 7\n";
+        return s;
+    }();
+
+    // pragma(mangle) rather than relying on extern(C): inside a template
+    // instantiation extern(C) keeps D mangling, and the vector override
+    // only works if the symbol is literally xt_nmi.
+    pragma(mangle, "xt_nmi")
+    @reflex_used @reflex_naked @reflex_critical extern(C) void xt_nmi()
+    {
+        import ldc.llvmasm : __asm;
+        __asm(_nmi_asm, "");
+    }
+
+    Result open()
+    {
+        static foreach (r; reflexes)
+        {
+            if (ow_reflex_open(r.event.index, r.event.kind - EventKind.gpio_rising) != 0)
+            {
+                close();
+                return InternalResult.failed;
+            }
+        }
+        return Result.success;
+    }
+
+    void close()
+    {
+        static foreach (r; reflexes)
+            ow_reflex_close(r.event.index);
+    }
+
+    uint fired()
+    {
+        import urt.atomic : atomicExchange;
+        return atomicExchange(&ow_reflex_fired0, 0u);
+    }
+}
+
+
+private:
+
+bool is_gpio_kind(EventKind kind)
+{
+    return kind >= EventKind.gpio_rising && kind <= EventKind.gpio_change;
+}
+
+struct LinkSlot
+{
+    EventSource event;
+    Task task;
+    shared bool active;
+}
+
+__gshared LinkSlot[num_links] _slots;
+__gshared ubyte[num_counters] _counter_slots = ubyte.max;
+
+@critical extern(C) bool ow_link_fire(uint slot)
+{
+    if (slot >= num_links || !atomicLoad!(MemoryOrder.acquire)(_slots[slot].active))
+        return false;
+    Task* task = &_slots[slot].task;
+    final switch (task.kind)
+    {
+        case TaskKind.isr:
+            return task.callback(task.context, LinkContext.interrupt);
+        case TaskKind.gpio_set:
+            gpio_output_set(task.index, true);
+            return false;
+        case TaskKind.gpio_clear:
+            gpio_output_set(task.index, false);
+            return false;
+        case TaskKind.counter_reload:
+            ow_counter_reload(task.index);
+            return false;
+        case TaskKind.none:
+            return false;
+    }
+}
+
+@critical extern(C) bool link_counter_alarm(uint port)
+{
+    if (port >= _counter_slots.length)
+        return false;
+    ubyte slot = _counter_slots[port];
+    return slot != ubyte.max ? ow_link_fire(slot) : false;
+}
+
+extern(C) nothrow @nogc
+{
+    int ow_link_gpio_open(uint slot, uint gpio, uint trigger);
+    void ow_link_gpio_close(uint slot, uint gpio);
+    void ow_counter_set_callback(uint port, bool function(uint port) nothrow @nogc callback);
+    void ow_counter_reload(uint port);
+}

--- a/src/urt/driver/esp32/gpio.d
+++ b/src/urt/driver/esp32/gpio.d
@@ -10,7 +10,10 @@
 // actual SOC_GPIO_PIN_COUNT for the active chip variant.
 module urt.driver.esp32.gpio;
 
-import urt.driver.gpio : Pull, DriveMode;
+import urt.atomic : MemoryOrder, atomicLoad, atomicStore;
+import urt.attribute : critical;
+import urt.driver.gpio : DriveMode, GpioCallbackContext, GpioInterrupt, GpioInterruptCallback, GpioInterruptConfig, GpioInterruptTrigger, Pull;
+import urt.result : InternalResult, Result;
 
 nothrow @nogc:
 
@@ -21,6 +24,8 @@ enum bool has_pull_down = true;
 enum bool has_open_drain = false;
 enum bool has_pin_function_muxing = false;
 enum bool has_gpio_sampler = false;   // TODO: RMT capture
+version (ESP32) enum uint num_gpio_interrupts = 2;
+else enum uint num_gpio_interrupts = 0;
 
 
 uint gpio_count() => ow_gpio_count();
@@ -36,7 +41,7 @@ void gpio_input_init(uint pin, Pull pull = Pull.none)
     ow_gpio_input_init(int(pin), int(pull));
 }
 
-void gpio_output_set(uint pin, bool value)
+@critical void gpio_output_set(uint pin, bool value)
 {
     ow_gpio_output_set(int(pin), value ? 1 : 0);
 }
@@ -61,8 +66,47 @@ void gpio_release(uint pin)
     ow_gpio_release(int(pin));
 }
 
+Result gpio_interrupt_hw_open(uint port, ref const GpioInterruptConfig config)
+{
+    if (config.input.chip != 0)
+        return InternalResult.unsupported;
+    return ow_gpio_interrupt_open(port, config.input.line, cast(uint)config.trigger) == 0 ? Result.success : InternalResult.failed;
+}
+
+void gpio_interrupt_hw_set_callback(uint port, GpioInterruptCallback callback)
+{
+    if (callback is null)
+    {
+        ow_gpio_interrupt_set_callback(port, null);
+        atomicStore!(MemoryOrder.release)(_interrupt_callbacks[port], 0);
+    }
+    else
+    {
+        atomicStore!(MemoryOrder.release)(_interrupt_callbacks[port], cast(size_t)callback);
+        ow_gpio_interrupt_set_callback(port, &gpio_interrupt);
+    }
+}
+
+void gpio_interrupt_hw_close(uint port)
+{
+    gpio_interrupt_hw_set_callback(port, null);
+    ow_gpio_interrupt_close(port);
+}
+
 
 private:
+
+shared size_t[num_gpio_interrupts] _interrupt_callbacks;
+
+@critical extern(C) bool gpio_interrupt(uint port) nothrow @nogc
+{
+    if (port >= num_gpio_interrupts)
+        return false;
+    GpioInterruptCallback callback = cast(GpioInterruptCallback)atomicLoad!(MemoryOrder.acquire)(_interrupt_callbacks[port]);
+    return callback !is null ? callback(GpioInterrupt(cast(ubyte)port), GpioCallbackContext.interrupt) : false;
+}
+
+extern(C) alias OwGpioInterruptCallback = bool function(uint port) nothrow @nogc;
 
 extern(C) nothrow @nogc
 {
@@ -73,4 +117,7 @@ extern(C) nothrow @nogc
     void ow_gpio_set_pull(int pin, int pull);
     void ow_gpio_release(int pin);
     uint ow_gpio_count();
+    int ow_gpio_interrupt_open(uint port, uint input_gpio, uint trigger);
+    void ow_gpio_interrupt_set_callback(uint port, OwGpioInterruptCallback callback);
+    void ow_gpio_interrupt_close(uint port);
 }

--- a/src/urt/driver/esp32/i2c.d
+++ b/src/urt/driver/esp32/i2c.d
@@ -64,7 +64,7 @@ extern(C) bool operation_complete(void* context, int result)
         case 3: error = I2cError.arbitration_lost; break;
         default: error = I2cError.bus; break;
     }
-    return i2c_complete(*cast(I2cOperation*)context, error, I2cCallbackContext.task);
+    return i2c_complete(*cast(I2cOperation*)context, error, I2cCallbackContext.thread);
 }
 
 extern(C)

--- a/src/urt/driver/esp32/idf_log.c
+++ b/src/urt/driver/esp32/idf_log.c
@@ -1,0 +1,77 @@
+#include <stdarg.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "esp_log_write.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#define OW_IDF_LOG_BUFFER_CAPACITY 256
+
+typedef void (*ow_idf_log_sink_t)(void *task, const char *data, size_t length, int truncated);
+
+static _Atomic(ow_idf_log_sink_t) log_sink;
+static atomic_uint callbacks_in_flight;
+static atomic_bool capture_open;
+static vprintf_like_t previous_vprintf;
+
+static int capture_vprintf(const char *format, va_list arguments)
+{
+    atomic_fetch_add_explicit(&callbacks_in_flight, 1, memory_order_acquire);
+
+    ow_idf_log_sink_t sink = atomic_load_explicit(&log_sink, memory_order_acquire);
+    int result;
+    if (sink != NULL)
+    {
+        char buffer[OW_IDF_LOG_BUFFER_CAPACITY];
+        va_list copy;
+        va_copy(copy, arguments);
+        result = vsnprintf(buffer, sizeof(buffer), format, copy);
+        va_end(copy);
+
+        size_t length = result < 0 ? 0 : (size_t)result;
+        bool truncated = result < 0 || length >= sizeof(buffer);
+        if (length >= sizeof(buffer))
+            length = sizeof(buffer) - 1;
+        sink(xTaskGetCurrentTaskHandle(), buffer, length, truncated);
+    }
+    else
+    {
+        vprintf_like_t previous = previous_vprintf;
+        result = previous != NULL ? previous(format, arguments) : 0;
+    }
+
+    atomic_fetch_sub_explicit(&callbacks_in_flight, 1, memory_order_release);
+    return result;
+}
+
+int ow_idf_log_open(ow_idf_log_sink_t sink)
+{
+    if (sink == NULL)
+        return 0;
+
+    bool expected = false;
+    if (!atomic_compare_exchange_strong_explicit(&capture_open, &expected, true,
+                                                 memory_order_acq_rel, memory_order_acquire))
+        return 0;
+
+    atomic_store_explicit(&log_sink, sink, memory_order_release);
+    previous_vprintf = esp_log_set_vprintf(&capture_vprintf);
+    return 1;
+}
+
+void ow_idf_log_close(void)
+{
+    if (!atomic_exchange_explicit(&capture_open, false, memory_order_acq_rel))
+        return;
+
+    vprintf_like_t displaced = esp_log_set_vprintf(previous_vprintf);
+    if (displaced != &capture_vprintf)
+        esp_log_set_vprintf(displaced);
+
+    atomic_store_explicit(&log_sink, NULL, memory_order_release);
+    while (atomic_load_explicit(&callbacks_in_flight, memory_order_acquire) != 0)
+        vTaskDelay(1);
+}

--- a/src/urt/driver/esp32/idf_log.d
+++ b/src/urt/driver/esp32/idf_log.d
@@ -1,0 +1,144 @@
+module urt.driver.esp32.idf_log;
+
+import urt.atomic : MemoryOrder, atomicExchange, atomicFetchAdd, atomicLoad, atomicStore;
+import urt.sync.mpsc : MpscQueue;
+
+nothrow @nogc:
+
+
+enum size_t idf_log_chunk_capacity = 256;
+
+struct IdfLogChunk
+{
+    void* task;
+    uint drop_generation;
+    ushort length;
+    bool truncated;
+    char[idf_log_chunk_capacity] data = void;
+
+    const(char)[] text() const nothrow @nogc
+    {
+        return data[0 .. length];
+    }
+}
+
+// Invoked synchronously on an arbitrary ESP-IDF logging task. The callback
+// must only notify its consumer; it must not allocate, block, or emit a log.
+alias IdfLogReadyCallback = void function() nothrow @nogc;
+
+bool idf_log_open()
+{
+    if (_opened)
+        return false;
+
+    reset_capture();
+    if (ow_idf_log_open(&receive_chunk) == 0)
+        return false;
+    _opened = true;
+    return true;
+}
+
+void idf_log_close()
+{
+    if (!_opened)
+        return;
+    ow_idf_log_close();
+    _opened = false;
+}
+
+void idf_log_set_ready_callback(IdfLogReadyCallback callback)
+{
+    atomicStore!(MemoryOrder.release)(_ready_callback_bits, cast(size_t)callback);
+}
+
+bool idf_log_receive(out IdfLogChunk chunk)
+{
+    return _queue.dequeue(chunk);
+}
+
+uint idf_log_take_drops()
+{
+    return atomicExchange!(MemoryOrder.acq_rel)(&_drops, 0u);
+}
+
+
+private:
+
+enum uint queue_capacity = 32;
+
+__gshared bool _opened;
+__gshared MpscQueue!(IdfLogChunk, queue_capacity) _queue;
+shared size_t _ready_callback_bits;
+shared uint _drops;
+shared uint _drop_generation;
+
+static assert(IdfLogReadyCallback.sizeof == size_t.sizeof);
+
+void reset_capture()
+{
+    _queue.init();
+    atomicStore!(MemoryOrder.relaxed)(_drops, 0u);
+    atomicStore!(MemoryOrder.relaxed)(_drop_generation, 0u);
+}
+
+extern(C) void receive_chunk(void* task, const char* data, size_t length, int truncated) nothrow @nogc
+{
+    IdfLogChunk chunk = void;
+    chunk.task = task;
+    chunk.drop_generation = atomicLoad!(MemoryOrder.acquire)(_drop_generation);
+    if (length > chunk.data.length)
+    {
+        length = chunk.data.length;
+        truncated = 1;
+    }
+    chunk.length = cast(ushort)length;
+    chunk.truncated = truncated != 0;
+    if (length != 0)
+        chunk.data[0 .. length] = data[0 .. length];
+
+    if (!_queue.enqueue(chunk))
+    {
+        atomicFetchAdd!(MemoryOrder.relaxed)(_drops, 1u);
+        atomicFetchAdd!(MemoryOrder.release)(_drop_generation, 1u);
+    }
+
+    auto callback = cast(IdfLogReadyCallback)atomicLoad!(MemoryOrder.acquire)(_ready_callback_bits);
+    if (callback !is null)
+        callback();
+}
+
+extern(C) alias IdfLogSink = void function(void*, const char*, size_t, int) nothrow @nogc;
+
+extern(C) nothrow @nogc
+{
+    int ow_idf_log_open(IdfLogSink sink);
+    void ow_idf_log_close();
+}
+
+
+unittest
+{
+    reset_capture();
+    static immutable text = "idf";
+    foreach (i; 0 .. queue_capacity)
+        receive_chunk(cast(void*)i, text.ptr, text.length, i == 0);
+    receive_chunk(null, text.ptr, text.length, 0);
+
+    assert(idf_log_take_drops() == 1);
+    assert(idf_log_take_drops() == 0);
+
+    IdfLogChunk chunk;
+    assert(idf_log_receive(chunk));
+    assert(chunk.task is null);
+    assert(chunk.drop_generation == 0);
+    assert(chunk.truncated);
+    assert(chunk.text == text);
+
+    foreach (i; 1 .. queue_capacity)
+        assert(idf_log_receive(chunk));
+    assert(!idf_log_receive(chunk));
+
+    receive_chunk(null, text.ptr, text.length, 0);
+    assert(idf_log_receive(chunk));
+    assert(chunk.drop_generation == 1);
+}

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -487,6 +487,15 @@ int ow_adc_read(void *handle, unsigned unit, unsigned channel, unsigned *raw)
     return 0;
 }
 
+int IRAM_ATTR ow_adc_read_critical(unsigned channel, unsigned *raw)
+{
+    portENTER_CRITICAL_SAFE(&adc_locks[0]);
+    uint16_t value = adc1_read_isr(channel);
+    portEXIT_CRITICAL_SAFE(&adc_locks[0]);
+    *raw = value;
+    return 0;
+}
+
 int ow_adc_raw_to_mv(void *calibration, unsigned raw, unsigned *millivolts)
 {
     int value;
@@ -618,6 +627,13 @@ int ow_adc_read(void *handle, unsigned unit, unsigned channel, unsigned *raw)
 {
     (void)handle;
     (void)unit;
+    (void)channel;
+    (void)raw;
+    return -1;
+}
+
+int ow_adc_read_critical(unsigned channel, unsigned *raw)
+{
     (void)channel;
     (void)raw;
     return -1;

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -176,6 +176,202 @@ void ow_pwm_close(unsigned port)
         ledc_stop(LEDC_LOW_SPEED_MODE, (ledc_channel_t)port, 0);
 }
 
+// -- Counter wrappers --
+
+#include "driver/gptimer.h"
+
+#if defined(CONFIG_IDF_TARGET_ESP32)
+
+#if !CONFIG_GPTIMER_CTRL_FUNC_IN_IRAM || !CONFIG_GPTIMER_ISR_CACHE_SAFE
+#error "counter alarms rearm from interrupt context; enable CONFIG_GPTIMER_CTRL_FUNC_IN_IRAM and CONFIG_GPTIMER_ISR_CACHE_SAFE"
+#endif
+
+#define OW_COUNTERS 4
+
+typedef struct {
+    bool (*callback)(unsigned port);
+    gptimer_handle_t timer;
+    gptimer_alarm_config_t alarm;
+    portMUX_TYPE lock;
+    unsigned port;
+    bool started;
+    bool enabled;
+    bool open;
+} ow_counter_t;
+
+static ow_counter_t counters[OW_COUNTERS] = {
+    { .lock = portMUX_INITIALIZER_UNLOCKED },
+    { .lock = portMUX_INITIALIZER_UNLOCKED },
+    { .lock = portMUX_INITIALIZER_UNLOCKED },
+    { .lock = portMUX_INITIALIZER_UNLOCKED },
+};
+
+static bool IRAM_ATTR counter_alarm(gptimer_handle_t timer, const gptimer_alarm_event_data_t *event, void *context)
+{
+    (void)timer;
+    (void)event;
+    ow_counter_t *counter = context;
+    bool (*callback)(unsigned);
+    portENTER_CRITICAL_ISR(&counter->lock);
+    callback = counter->callback;
+    portEXIT_CRITICAL_ISR(&counter->lock);
+    return callback ? callback(counter->port) : false;
+}
+
+void ow_counter_close(unsigned port);
+
+int ow_counter_open(unsigned port, unsigned resolution_hz)
+{
+    if (port >= OW_COUNTERS || !resolution_hz)
+        return -1;
+    ow_counter_t *counter = &counters[port];
+    if (counter->open)
+        return -1;
+
+    gptimer_config_t config = {
+        .clk_src = GPTIMER_CLK_SRC_DEFAULT,
+        .direction = GPTIMER_COUNT_UP,
+        .resolution_hz = resolution_hz,
+    };
+    gptimer_event_callbacks_t callbacks = {
+        .on_alarm = counter_alarm,
+    };
+    counter->port = port;
+    counter->open = true;
+    if (gptimer_new_timer(&config, &counter->timer) != ESP_OK ||
+        gptimer_register_event_callbacks(counter->timer, &callbacks, counter) != ESP_OK)
+        goto failed;
+    if (gptimer_enable(counter->timer) != ESP_OK)
+        goto failed;
+    counter->enabled = true;
+    return 0;
+
+failed:
+    ow_counter_close(port);
+    return -1;
+}
+
+int ow_counter_arm(unsigned port, uint64_t ticks, bool periodic)
+{
+    if (port >= OW_COUNTERS || !ticks)
+        return -1;
+    ow_counter_t *counter = &counters[port];
+    if (!counter->open)
+        return -1;
+
+    portENTER_CRITICAL(&counter->lock);
+    counter->alarm = (gptimer_alarm_config_t) {
+        .alarm_count = ticks,
+        .reload_count = 0,
+        .flags.auto_reload_on_alarm = periodic,
+    };
+    gptimer_set_raw_count(counter->timer, 0);
+    esp_err_t result = gptimer_set_alarm_action(counter->timer, &counter->alarm);
+    portEXIT_CRITICAL(&counter->lock);
+    if (result != ESP_OK)
+        return -1;
+    if (!counter->started) {
+        if (gptimer_start(counter->timer) != ESP_OK)
+            return -1;
+        counter->started = true;
+    }
+    return 0;
+}
+
+void IRAM_ATTR ow_counter_reload(unsigned port)
+{
+    if (port >= OW_COUNTERS)
+        return;
+    ow_counter_t *counter = &counters[port];
+    portENTER_CRITICAL_SAFE(&counter->lock);
+    if (counter->started) {
+        gptimer_set_raw_count(counter->timer, 0);
+        gptimer_set_alarm_action(counter->timer, &counter->alarm);
+    }
+    portEXIT_CRITICAL_SAFE(&counter->lock);
+}
+
+uint64_t ow_counter_read(unsigned port)
+{
+    uint64_t value = 0;
+    if (port < OW_COUNTERS && counters[port].open)
+        gptimer_get_raw_count(counters[port].timer, &value);
+    return value;
+}
+
+void ow_counter_set_callback(unsigned port, bool (*callback)(unsigned port))
+{
+    if (port >= OW_COUNTERS)
+        return;
+    ow_counter_t *counter = &counters[port];
+    portENTER_CRITICAL(&counter->lock);
+    counter->callback = callback;
+    portEXIT_CRITICAL(&counter->lock);
+}
+
+void ow_counter_close(unsigned port)
+{
+    if (port >= OW_COUNTERS)
+        return;
+    ow_counter_t *counter = &counters[port];
+    if (counter->timer) {
+        if (counter->started)
+            gptimer_stop(counter->timer);
+        if (counter->enabled)
+            gptimer_disable(counter->timer);
+        gptimer_del_timer(counter->timer);
+    }
+    portENTER_CRITICAL(&counter->lock);
+    counter->callback = NULL;
+    counter->timer = NULL;
+    counter->alarm = (gptimer_alarm_config_t) { 0 };
+    counter->started = false;
+    counter->enabled = false;
+    counter->open = false;
+    portEXIT_CRITICAL(&counter->lock);
+}
+
+#else
+
+int ow_counter_open(unsigned port, unsigned resolution_hz)
+{
+    (void)port;
+    (void)resolution_hz;
+    return -1;
+}
+
+int ow_counter_arm(unsigned port, uint64_t ticks, bool periodic)
+{
+    (void)port;
+    (void)ticks;
+    (void)periodic;
+    return -1;
+}
+
+void ow_counter_reload(unsigned port)
+{
+    (void)port;
+}
+
+uint64_t ow_counter_read(unsigned port)
+{
+    (void)port;
+    return 0;
+}
+
+void ow_counter_set_callback(unsigned port, bool (*callback)(unsigned port))
+{
+    (void)port;
+    (void)callback;
+}
+
+void ow_counter_close(unsigned port)
+{
+    (void)port;
+}
+
+#endif
+
 #include "esp_adc/adc_cali.h"
 #include "esp_adc/adc_cali_scheme.h"
 #include "esp_adc/adc_oneshot.h"

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -7,6 +7,7 @@
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "driver/uart.h"
+#include "driver/ledc.h"
 #include "esp_rom_serial_output.h"
 #include "soc/soc_caps.h"
 #include <stdbool.h>
@@ -50,7 +51,10 @@ void ow_irq_wait(void)
 //    through this module).
 
 #include "driver/gpio.h"
+#include "esp_attr.h"
+#include "esp_intr_alloc.h"
 #include "soc/gpio_num.h"
+#include <stdint.h>
 
 // pull: 0=none, 1=up, 2=down (matches D Pull enum encoding)
 static gpio_pull_mode_t ow_pull_to_idf(int pull)
@@ -73,7 +77,7 @@ void ow_gpio_input_init(int pin, int pull)
     gpio_set_pull_mode((gpio_num_t)pin, ow_pull_to_idf(pull));
 }
 
-void ow_gpio_output_set(int pin, int value)
+void IRAM_ATTR ow_gpio_output_set(int pin, int value)
 {
     gpio_set_level((gpio_num_t)pin, value);
 }
@@ -97,6 +101,336 @@ uint32_t ow_gpio_count(void)
 {
     return SOC_GPIO_PIN_COUNT;
 }
+
+int ow_pwm_open(unsigned port, unsigned pin, unsigned frequency, unsigned resolution, unsigned initial_duty, bool inverted)
+{
+    if (port >= LEDC_TIMER_MAX || port >= LEDC_CHANNEL_MAX)
+        return -1;
+
+    ledc_timer_config_t timer = {
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .duty_resolution = (ledc_timer_bit_t)resolution,
+        .timer_num = (ledc_timer_t)port,
+        .freq_hz = frequency,
+        .clk_cfg = LEDC_AUTO_CLK,
+    };
+    ledc_channel_config_t channel = {
+        .gpio_num = pin,
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .channel = (ledc_channel_t)port,
+        .intr_type = LEDC_INTR_DISABLE,
+        .timer_sel = (ledc_timer_t)port,
+        .duty = initial_duty,
+        .hpoint = 0,
+        .flags = { .output_invert = inverted },
+    };
+    if (ledc_timer_config(&timer) != ESP_OK)
+        return -1;
+    return ledc_channel_config(&channel) == ESP_OK ? 0 : -1;
+}
+
+int ow_pwm_set_duty(unsigned port, unsigned duty)
+{
+    if (port >= LEDC_CHANNEL_MAX || ledc_set_duty(LEDC_LOW_SPEED_MODE, (ledc_channel_t)port, duty) != ESP_OK)
+        return -1;
+    return ledc_update_duty(LEDC_LOW_SPEED_MODE, (ledc_channel_t)port) == ESP_OK ? 0 : -1;
+}
+
+void ow_pwm_close(unsigned port)
+{
+    if (port < LEDC_CHANNEL_MAX)
+        ledc_stop(LEDC_LOW_SPEED_MODE, (ledc_channel_t)port, 0);
+}
+
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
+#include "esp_adc/adc_oneshot.h"
+
+#if defined(CONFIG_IDF_TARGET_ESP32)
+
+#include "soc/rtc_io_struct.h"
+#include "soc/sens_reg.h"
+#include "soc/sens_struct.h"
+
+#define OW_GPIO_INTERRUPTS 2
+
+typedef struct {
+    unsigned input_gpio;
+    bool open;
+} ow_gpio_interrupt_t;
+
+static portMUX_TYPE adc_locks[2] = {
+    portMUX_INITIALIZER_UNLOCKED,
+    portMUX_INITIALIZER_UNLOCKED,
+};
+static ow_gpio_interrupt_t gpio_interrupts[OW_GPIO_INTERRUPTS];
+static volatile uintptr_t gpio_interrupt_callbacks[OW_GPIO_INTERRUPTS];
+static unsigned gpio_isr_users;
+static bool gpio_isr_service_owned;
+
+static int gpio_isr_acquire(void)
+{
+    if (gpio_isr_users) {
+        ++gpio_isr_users;
+        return 0;
+    }
+    if (gpio_install_isr_service(ESP_INTR_FLAG_IRAM) != ESP_OK)
+        return -1;
+    gpio_isr_service_owned = true;
+    gpio_isr_users = 1;
+    return 0;
+}
+
+static void gpio_isr_release(void)
+{
+    if (!gpio_isr_users || --gpio_isr_users)
+        return;
+    if (gpio_isr_service_owned) {
+        gpio_uninstall_isr_service();
+        gpio_isr_service_owned = false;
+    }
+}
+
+static adc_atten_t adc_attenuation(unsigned attenuation)
+{
+    switch (attenuation) {
+    case 0: return ADC_ATTEN_DB_0;
+    case 1: return ADC_ATTEN_DB_2_5;
+    case 2: return ADC_ATTEN_DB_6;
+    default: return ADC_ATTEN_DB_12;
+    }
+}
+
+int ow_adc_open(unsigned unit, void **handle)
+{
+    if (!handle || unit > ADC_UNIT_2)
+        return -1;
+
+    adc_oneshot_unit_init_cfg_t config = {
+        .unit_id = (adc_unit_t)unit,
+    };
+    if (adc_oneshot_new_unit(&config, (adc_oneshot_unit_handle_t *)handle) != ESP_OK)
+        return -1;
+    return 0;
+}
+
+int ow_adc_input_open(void *handle, unsigned unit, unsigned channel, unsigned attenuation, unsigned bit_width, unsigned default_reference_mv, void **calibration, int *calibration_source)
+{
+    if (!handle || !calibration || !calibration_source || unit > ADC_UNIT_2 || bit_width == 0)
+        return -1;
+
+    adc_atten_t atten = adc_attenuation(attenuation);
+    adc_oneshot_chan_cfg_t input_config = {
+        .atten = atten,
+        .bitwidth = (adc_bitwidth_t)bit_width,
+    };
+    adc_cali_line_fitting_config_t calibration_config = {
+        .unit_id = (adc_unit_t)unit,
+        .atten = atten,
+        .bitwidth = (adc_bitwidth_t)bit_width,
+        .default_vref = default_reference_mv,
+    };
+    if (adc_oneshot_config_channel((adc_oneshot_unit_handle_t)handle, (adc_channel_t)channel, &input_config) != ESP_OK)
+        return -1;
+    if (adc_cali_create_scheme_line_fitting(&calibration_config, (adc_cali_handle_t *)calibration) != ESP_OK)
+        return -1;
+    adc_cali_line_fitting_efuse_val_t source;
+    *calibration_source = adc_cali_scheme_line_fitting_check_efuse(&source) == ESP_OK ? (int)source : -1;
+    return 0;
+}
+
+static uint16_t adc1_read_isr(unsigned channel);
+
+int ow_adc_read(void *handle, unsigned unit, unsigned channel, unsigned *raw)
+{
+    int value;
+    if (!handle || !raw || unit > ADC_UNIT_2)
+        return -1;
+    if (unit == ADC_UNIT_1) {
+        portENTER_CRITICAL(&adc_locks[unit]);
+        value = adc1_read_isr(channel);
+        portEXIT_CRITICAL(&adc_locks[unit]);
+    } else if (adc_oneshot_read((adc_oneshot_unit_handle_t)handle, (adc_channel_t)channel, &value) != ESP_OK) {
+        return -1;
+    }
+    *raw = (unsigned)value;
+    return 0;
+}
+
+int ow_adc_raw_to_mv(void *calibration, unsigned raw, unsigned *millivolts)
+{
+    int value;
+    if (!calibration || !millivolts || adc_cali_raw_to_voltage((adc_cali_handle_t)calibration, raw, &value) != ESP_OK)
+        return -1;
+    *millivolts = (unsigned)value;
+    return 0;
+}
+
+void ow_adc_input_close(void *calibration)
+{
+    if (calibration)
+        adc_cali_delete_scheme_line_fitting((adc_cali_handle_t)calibration);
+}
+
+void ow_adc_close(void *handle)
+{
+    if (handle)
+        adc_oneshot_del_unit((adc_oneshot_unit_handle_t)handle);
+}
+
+static uint16_t IRAM_ATTR adc1_read_isr(unsigned channel)
+{
+    SENS.sar_read_ctrl.sar1_dig_force = 0;
+    SENS.sar_meas_wait2.force_xpd_sar = SENS_FORCE_XPD_SAR_PU;
+    RTCIO.hall_sens.xpd_hall = false;
+    SENS.sar_meas_wait2.force_xpd_amp = SENS_FORCE_XPD_AMP_PD;
+    SENS.sar_meas_ctrl.amp_rst_fb_fsm = 0;
+    SENS.sar_meas_ctrl.amp_short_ref_fsm = 0;
+    SENS.sar_meas_ctrl.amp_short_ref_gnd_fsm = 0;
+    SENS.sar_meas_wait1.sar_amp_wait1 = 1;
+    SENS.sar_meas_wait1.sar_amp_wait2 = 1;
+    SENS.sar_meas_wait2.sar_amp_wait3 = 1;
+    SENS.sar_meas_start1.meas1_start_force = 1;
+    SENS.sar_meas_start1.sar1_en_pad_force = 1;
+    SENS.sar_touch_ctrl1.xpd_hall_force = 1;
+    SENS.sar_touch_ctrl1.hall_phase_force = 1;
+    SENS.sar_meas_start1.sar1_en_pad = 1U << channel;
+    while (SENS.sar_slave_addr1.meas_status != 0) {
+    }
+    SENS.sar_meas_start1.meas1_start_sar = 0;
+    SENS.sar_meas_start1.meas1_start_sar = 1;
+    while (SENS.sar_meas_start1.meas1_done_sar == 0) {
+    }
+    return SENS.sar_meas_start1.meas1_data_sar;
+}
+
+static void IRAM_ATTR gpio_interrupt_handler(void *context)
+{
+    unsigned port = (unsigned)(uintptr_t)context;
+    bool (*callback)(unsigned) = (bool (*)(unsigned))gpio_interrupt_callbacks[port];
+    if (callback && callback(port))
+        portYIELD_FROM_ISR();
+}
+
+void ow_gpio_interrupt_close(unsigned port);
+
+int ow_gpio_interrupt_open(unsigned port, unsigned input_gpio, unsigned trigger)
+{
+    if (port >= OW_GPIO_INTERRUPTS || input_gpio >= SOC_GPIO_PIN_COUNT || trigger > 4)
+        return -1;
+
+    ow_gpio_interrupt_t *interrupt = &gpio_interrupts[port];
+    if (interrupt->open || gpio_isr_acquire() != 0)
+        return -1;
+    static const gpio_int_type_t types[] = {
+        GPIO_INTR_POSEDGE,
+        GPIO_INTR_NEGEDGE,
+        GPIO_INTR_ANYEDGE,
+        GPIO_INTR_HIGH_LEVEL,
+        GPIO_INTR_LOW_LEVEL,
+    };
+    interrupt->input_gpio = input_gpio;
+    // Input buffer explicitly: the pin may be muxed to a peripheral output (only the output path is
+    // routed), and edge detection needs GPIO_IN regardless of who drives the pad.
+    if (gpio_input_enable((gpio_num_t)input_gpio) != ESP_OK ||
+        gpio_set_intr_type((gpio_num_t)input_gpio, types[trigger]) != ESP_OK ||
+        gpio_isr_handler_add((gpio_num_t)input_gpio, gpio_interrupt_handler, (void *)(uintptr_t)port) != ESP_OK) {
+        gpio_isr_release();
+        return -1;
+    }
+    interrupt->open = true;
+    return 0;
+}
+
+void ow_gpio_interrupt_set_callback(unsigned port, bool (*callback)(unsigned port))
+{
+    if (port >= OW_GPIO_INTERRUPTS)
+        return;
+    gpio_interrupt_callbacks[port] = (uintptr_t)callback;
+}
+
+void ow_gpio_interrupt_close(unsigned port)
+{
+    if (port >= OW_GPIO_INTERRUPTS)
+        return;
+    ow_gpio_interrupt_t *interrupt = &gpio_interrupts[port];
+    if (!interrupt->open)
+        return;
+    gpio_isr_handler_remove((gpio_num_t)interrupt->input_gpio);
+    ow_gpio_interrupt_set_callback(port, NULL);
+    interrupt->open = false;
+    gpio_isr_release();
+}
+
+#else
+
+int ow_adc_open(unsigned unit, void **handle)
+{
+    (void)unit;
+    (void)handle;
+    return -1;
+}
+
+int ow_adc_input_open(void *handle, unsigned unit, unsigned channel, unsigned attenuation, unsigned bit_width, unsigned default_reference_mv, void **calibration, int *calibration_source)
+{
+    (void)handle;
+    (void)unit;
+    (void)channel;
+    (void)attenuation;
+    (void)bit_width;
+    (void)default_reference_mv;
+    (void)calibration;
+    (void)calibration_source;
+    return -1;
+}
+
+int ow_adc_read(void *handle, unsigned unit, unsigned channel, unsigned *raw)
+{
+    (void)handle;
+    (void)unit;
+    (void)channel;
+    (void)raw;
+    return -1;
+}
+
+int ow_adc_raw_to_mv(void *calibration, unsigned raw, unsigned *millivolts)
+{
+    (void)calibration;
+    (void)raw;
+    (void)millivolts;
+    return -1;
+}
+
+void ow_adc_input_close(void *calibration)
+{
+    (void)calibration;
+}
+
+void ow_adc_close(void *handle)
+{
+    (void)handle;
+}
+
+int ow_gpio_interrupt_open(unsigned port, unsigned input_gpio, unsigned trigger)
+{
+    (void)port;
+    (void)input_gpio;
+    (void)trigger;
+    return -1;
+}
+
+void ow_gpio_interrupt_set_callback(unsigned port, bool (*callback)(unsigned port))
+{
+    (void)port;
+    (void)callback;
+}
+
+void ow_gpio_interrupt_close(unsigned port)
+{
+    (void)port;
+}
+
+#endif
 
 // -- I2C master wrappers --
 

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -88,6 +88,8 @@ void ow_irq_wait(void)
 #include "esp_attr.h"
 #include "esp_intr_alloc.h"
 #include "soc/gpio_num.h"
+#include "soc/gpio_struct.h"
+#include "soc/interrupts.h"
 #include <stdint.h>
 
 // pull: 0=none, 1=up, 2=down (matches D Pull enum encoding)
@@ -601,6 +603,93 @@ void ow_gpio_interrupt_close(unsigned port)
     gpio_isr_release();
 }
 
+// -- Link fabric gpio events (dispatcher lives in D: ow_link_fire) --
+
+extern bool ow_link_fire(unsigned slot);
+
+static void IRAM_ATTR link_gpio_handler(void *context)
+{
+    if (ow_link_fire((unsigned)(uintptr_t)context))
+        portYIELD_FROM_ISR();
+}
+
+int ow_link_gpio_open(unsigned slot, unsigned gpio, unsigned trigger)
+{
+    static const gpio_int_type_t types[] = {
+        GPIO_INTR_POSEDGE,
+        GPIO_INTR_NEGEDGE,
+        GPIO_INTR_ANYEDGE,
+    };
+    if (gpio >= SOC_GPIO_PIN_COUNT || trigger > 2)
+        return -1;
+    if (gpio_isr_acquire() != 0)
+        return -1;
+    // Input buffer explicitly: the pin may be muxed to a peripheral output (only the output path is
+    // routed), and edge detection needs GPIO_IN regardless of who drives the pad.
+    if (gpio_input_enable((gpio_num_t)gpio) != ESP_OK ||
+        gpio_set_intr_type((gpio_num_t)gpio, types[trigger]) != ESP_OK ||
+        gpio_isr_handler_add((gpio_num_t)gpio, link_gpio_handler, (void *)(uintptr_t)slot) != ESP_OK) {
+        gpio_isr_release();
+        return -1;
+    }
+    return 0;
+}
+
+void ow_link_gpio_close(unsigned slot, unsigned gpio)
+{
+    (void)slot;
+    if (gpio >= SOC_GPIO_PIN_COUNT)
+        return;
+    gpio_isr_handler_remove((gpio_num_t)gpio);
+    gpio_isr_release();
+}
+
+// -- Reflex NMI routing (the handler itself is synthesized in D: xt_nmi) --
+
+static intr_handle_t reflex_nmi_handle;
+static unsigned reflex_users;
+
+int ow_reflex_open(unsigned gpio, unsigned trigger)
+{
+    static const gpio_int_type_t types[] = {
+        GPIO_INTR_POSEDGE,
+        GPIO_INTR_NEGEDGE,
+        GPIO_INTR_ANYEDGE,
+    };
+    if (gpio >= 32 || trigger > 2)
+        return -1;
+    if (!reflex_users) {
+        // Route the GPIO NMI matrix source to CPU interrupt 14 (level 7). High-level
+        // allocation requires a NULL handler; the vector dispatches to xt_nmi directly.
+        if (esp_intr_alloc(ETS_GPIO_NMI_SOURCE, ESP_INTR_FLAG_NMI, NULL, NULL, &reflex_nmi_handle) != ESP_OK)
+            return -1;
+    }
+    if (gpio_input_enable((gpio_num_t)gpio) != ESP_OK ||
+        gpio_set_intr_type((gpio_num_t)gpio, types[trigger]) != ESP_OK) {
+        if (!reflex_users) {
+            esp_intr_free(reflex_nmi_handle);
+            reflex_nmi_handle = NULL;
+        }
+        return -1;
+    }
+    ++reflex_users;
+    // Per-pin register and the pin is claimed exclusively, so the RMW races nothing.
+    GPIO.pin[gpio].int_ena |= BIT(3);   /* PRO CPU NMI */
+    return 0;
+}
+
+void ow_reflex_close(unsigned gpio)
+{
+    if (gpio >= 32 || !reflex_users)
+        return;
+    GPIO.pin[gpio].int_ena &= ~BIT(3);
+    gpio_set_intr_type((gpio_num_t)gpio, GPIO_INTR_DISABLE);
+    if (--reflex_users == 0 && reflex_nmi_handle) {
+        esp_intr_free(reflex_nmi_handle);
+        reflex_nmi_handle = NULL;
+    }
+}
+
 #else
 
 int ow_adc_open(unsigned unit, void **handle)
@@ -674,6 +763,32 @@ void ow_gpio_interrupt_set_callback(unsigned port, bool (*callback)(unsigned por
 void ow_gpio_interrupt_close(unsigned port)
 {
     (void)port;
+}
+
+int ow_link_gpio_open(unsigned slot, unsigned gpio, unsigned trigger)
+{
+    (void)slot;
+    (void)gpio;
+    (void)trigger;
+    return -1;
+}
+
+void ow_link_gpio_close(unsigned slot, unsigned gpio)
+{
+    (void)slot;
+    (void)gpio;
+}
+
+int ow_reflex_open(unsigned gpio, unsigned trigger)
+{
+    (void)gpio;
+    (void)trigger;
+    return -1;
+}
+
+void ow_reflex_close(unsigned gpio)
+{
+    (void)gpio;
 }
 
 #endif

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -13,6 +13,8 @@
 #include <stdbool.h>
 #include <stdatomic.h>
 #include <string.h>
+#include <sys/types.h>
+#include <reent.h>
 #ifdef OW_USE_LWIP
 #include "lwip/netdb.h"
 #endif
@@ -30,6 +32,38 @@ void esp_rom_uart_putc(char c) { esp_rom_output_tx_one_char(c); }
 int *ow_errno_location(void)
 {
     return &errno;
+}
+
+// IDF's no-VFS syscall adapter also dispatches high file descriptors to lwIP.
+// Internal-IP builds wrap those entry points so ordinary C stdio stays on the
+// console without retaining the socket adapter and, through it, the full stack.
+extern ssize_t _write_r_console(struct _reent *r, int fd, const void *data, size_t size);
+extern ssize_t _read_r_console(struct _reent *r, int fd, void *data, size_t size);
+
+ssize_t __wrap__write_r(struct _reent *r, int fd, const void *data, size_t size)
+{
+    return _write_r_console(r, fd, data, size);
+}
+
+ssize_t __wrap__read_r(struct _reent *r, int fd, void *data, size_t size)
+{
+    return _read_r_console(r, fd, data, size);
+}
+
+int __wrap__close_r(struct _reent *r, int fd)
+{
+    (void)fd;
+    __errno_r(r) = ENOSYS;
+    return -1;
+}
+
+int __wrap__fcntl_r(struct _reent *r, int fd, int cmd, int arg)
+{
+    (void)fd;
+    (void)cmd;
+    (void)arg;
+    __errno_r(r) = ENOSYS;
+    return -1;
 }
 
 // -- WFI shim --

--- a/src/urt/driver/esp32/pwm.d
+++ b/src/urt/driver/esp32/pwm.d
@@ -1,0 +1,66 @@
+module urt.driver.esp32.pwm;
+
+import urt.driver.pwm : PwmConfig;
+import urt.result : InternalResult, Result;
+
+nothrow @nogc:
+
+
+enum uint num_pwm = 4;
+
+Result pwm_hw_open(uint port, ref const PwmConfig config)
+{
+    ubyte resolution = resolution_bits(config.period);
+    if (port >= num_pwm || resolution == 0)
+        return InternalResult.invalid_parameter;
+    if (_open[port])
+        return InternalResult.already_exists;
+
+    if (config.output.chip != 0)
+        return InternalResult.unsupported;
+    if (ow_pwm_open(port, config.output.line, config.frequency, resolution, config.initial_duty, config.inverted) != 0)
+        return InternalResult.failed;
+
+    _open[port] = true;
+    return Result.success;
+}
+
+Result pwm_hw_set_duty(uint port, uint duty)
+{
+    if (port >= num_pwm || !_open[port])
+        return InternalResult.invalid_parameter;
+    return ow_pwm_set_duty(port, duty) == 0 ? Result.success : InternalResult.failed;
+}
+
+void pwm_hw_close(uint port)
+{
+    if (port >= num_pwm || !_open[port])
+        return;
+    ow_pwm_close(port);
+    _open[port] = false;
+}
+
+private:
+
+__gshared bool[num_pwm] _open;
+
+ubyte resolution_bits(uint period)
+{
+    if (period < 2 || (period & (period - 1)) != 0)
+        return 0;
+
+    ubyte bits;
+    while (period > 1)
+    {
+        period >>= 1;
+        ++bits;
+    }
+    return bits;
+}
+
+extern(C) nothrow @nogc
+{
+    int ow_pwm_open(uint port, uint gpio, uint frequency, uint resolution, uint initial_duty, bool inverted);
+    int ow_pwm_set_duty(uint port, uint duty);
+    void ow_pwm_close(uint port);
+}

--- a/src/urt/driver/esp32/uart.d
+++ b/src/urt/driver/esp32/uart.d
@@ -114,7 +114,7 @@ extern(C) void rx_ready(uint port, size_t available)
     auto callback = cast(UartRxCallback)
         atomicLoad!(MemoryOrder.acquire)(_rx_callback_bits[port]);
     if (callback !is null)
-        callback(Uart(cast(ubyte)port), available, UartCallbackContext.task);
+        callback(Uart(cast(ubyte)port), available, UartCallbackContext.thread);
 }
 
 extern(C) nothrow @nogc

--- a/src/urt/driver/event.d
+++ b/src/urt/driver/event.d
@@ -1,0 +1,257 @@
+// Peripheral event interconnect. Peripherals publish events and accept tasks; a
+// link joins one event to one task, and every link states the minimum
+// guarantee it needs from the LinkTier ladder:
+//
+//   interrupt   a maskable ISR performs the task. Fine for most links:
+//               entry is prompt, and sampling a level (rather than an
+//               edge or a slope) tolerates the jitter.
+//   unmaskable  the task fires despite any critical section or wedged
+//               scheduler: a true NMI, or better.
+//   autonomous  the task fires without the CPU at all: a hardware
+//               trigger matrix (ETM, DPPI, EVSYS).
+//
+// The backend lowers each link to the cheapest rung that satisfies its
+// minimum, or refuses. Rungs above interrupt restrict the task
+// vocabulary to immediate register writes: that is the contract the
+// hardware fabric imposes, and the NMI rung is a stand-in for it, so
+// both are expressed and checked the same way.
+//
+// Links whose minimum is interrupt are opened at runtime with link_open
+// and may carry runtime state (isr_task contexts, pins from config).
+// Links above that are declared in a ReflexGraph: their lowering is
+// synthesized, so the graph needs the whole set with pins as
+// compile-time constants (D also cannot pass function pointers as
+// template values, which rules isr_task out of the graph regardless).
+//
+// isr_task sinks custom logic into the fabric. The handler runs in
+// interrupt context and must be @isr_safe (and @critical for SRAM
+// residency); it may trigger further tasks through critical-safe driver
+// calls, and returns whether it woke a higher-priority task.
+//
+// The event source is claimed exclusively: one link (or one GpioInterrupt)
+// per pin or counter, not both.
+//
+// Function bodies live in <soc>/event.d. Each backend exports:
+//   Result link_hw_open(uint slot, EventSource, Task, LinkTier, out bool hardware);
+//   void link_hw_close(uint slot);
+module urt.driver.event;
+
+import urt.driver.counter : Counter;
+import urt.driver.gpio : GpioInterruptTrigger, GpioLine;
+import urt.result : InternalResult, Result;
+
+version (Espressif)
+    public import urt.driver.esp32.event;
+else
+{
+    enum uint num_links = 0;
+    enum bool has_reflex = false;
+
+    bool can_route(EventKind, TaskKind) pure nothrow @nogc => false;
+}
+
+nothrow @nogc:
+
+
+enum LinkTier : ubyte
+{
+    interrupt,
+    unmaskable,
+    autonomous,
+}
+
+enum LinkContext : ubyte
+{
+    task,
+    interrupt,
+}
+
+alias LinkCallback = bool function(void* context, LinkContext where) nothrow @nogc;
+
+enum EventKind : ubyte
+{
+    none,
+    gpio_rising,
+    gpio_falling,
+    gpio_change,
+    counter_alarm,
+}
+
+enum TaskKind : ubyte
+{
+    none,
+    isr,
+    gpio_set,
+    gpio_clear,
+    counter_reload,
+}
+
+struct EventSource
+{
+    EventKind kind;
+    uint chip;              // gpio chip for gpio events, 0 otherwise
+    uint index = uint.max;  // gpio line, or counter port
+}
+
+struct Task
+{
+    TaskKind kind;
+    uint chip;
+    uint index = uint.max;
+    LinkCallback callback;
+    void* context;      // isr tasks only; hardware routing carries no context
+}
+
+struct Link
+{
+    ubyte slot = ubyte.max;
+    bool hardware;
+}
+
+// Level triggers are not events; high/low yield an invalid EventSource.
+EventSource gpio_event(GpioLine line, GpioInterruptTrigger trigger)
+{
+    EventKind kind;
+    final switch (trigger)
+    {
+        case GpioInterruptTrigger.rising:   kind = EventKind.gpio_rising;   break;
+        case GpioInterruptTrigger.falling:  kind = EventKind.gpio_falling;  break;
+        case GpioInterruptTrigger.change:   kind = EventKind.gpio_change;   break;
+        case GpioInterruptTrigger.high:
+        case GpioInterruptTrigger.low:      return EventSource();
+    }
+    return EventSource(kind, line.chip, line.line);
+}
+
+EventSource counter_event(ref const Counter counter)
+{
+    return EventSource(EventKind.counter_alarm, 0, counter.port);
+}
+
+Task gpio_task(GpioLine line, bool level)
+{
+    return Task(level ? TaskKind.gpio_set : TaskKind.gpio_clear, line.chip, line.line);
+}
+
+Task counter_task(ref const Counter counter)
+{
+    return Task(TaskKind.counter_reload, 0, counter.port);
+}
+
+Task isr_task(alias handler)(void* context = null)
+    if (is(typeof(&handler) : LinkCallback))
+{
+    static assert(is_isr_safe!handler, "link ISR handlers must be marked @isr_safe (and @critical)");
+    return Task(TaskKind.isr, 0, 0, &handler, context);
+}
+
+bool is_open(ref const Link link)
+{
+    return link.slot != ubyte.max;
+}
+
+bool is_hardware(ref const Link link)
+{
+    return link.hardware;
+}
+
+Result link_open(ref Link link, ubyte slot, EventSource event, Task task, LinkTier minimum = LinkTier.interrupt)
+{
+    static if (num_links == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (link.is_open)
+            return InternalResult.already_exists;
+        if (slot >= num_links || event.kind == EventKind.none || event.index == uint.max ||
+            task.kind == TaskKind.none || (task.kind == TaskKind.isr) != (task.callback !is null))
+            return InternalResult.invalid_parameter;
+
+        bool hardware;
+        Result result = link_hw_open(slot, event, task, minimum, hardware);
+        if (!result)
+            return result;
+        link.slot = slot;
+        link.hardware = hardware;
+        return Result.success;
+    }
+}
+
+void link_close(ref Link link)
+{
+    static if (num_links != 0)
+    {
+        if (link.is_open)
+            link_hw_close(link.slot);
+    }
+    link = Link();
+}
+
+
+// A reflex is a link whose minimum tier is above interrupt: it must act even
+// when normal control flow cannot. Its tasks are restricted to immediate
+// register writes and its fault domain is the executor's own resident code
+// and literals. No stack, no locks, no C. The default minimum is unmaskable;
+// pass LinkTier.autonomous to also refuse the NMI stand-in and demand the
+// hardware fabric.
+//
+// The program's whole reflex set is declared in one ReflexGraph so the backend
+// can synthesize a single vector handler for whatever lands on the NMI rung,
+// disambiguating sources only when there is more than one. The graph provides:
+//   Result open();   // claim sources and arm; call once from task context
+//   void close();
+//   uint fired();    // read-and-clear latch of event pins observed to trip,
+//                    // as a gpio bitmask; poll from the main loop
+// One graph per program: a second instantiation collides on the vector symbol
+// and fails to link.
+template Reflex(EventSource ev, tasks_...)
+{
+    enum LinkTier tier = LinkTier.unmaskable;
+    enum EventSource event = ev;
+    enum Task[] tasks = [tasks_];
+}
+
+template Reflex(LinkTier minimum, EventSource ev, tasks_...)
+{
+    static assert(minimum > LinkTier.interrupt,
+                  "interrupt-tier links carry runtime state; open them with link_open");
+    enum LinkTier tier = minimum;
+    enum EventSource event = ev;
+    enum Task[] tasks = [tasks_];
+}
+
+template ReflexGraph(reflexes...)
+    if (reflexes.length > 0)
+{
+    static if (!has_reflex)
+    {
+        Result open() { return InternalResult.unsupported; }
+        void close() {}
+        uint fired() { return 0; }
+    }
+    else
+        mixin ReflexBackend!(reflexes);
+}
+
+
+unittest
+{
+    // can_route must be usable in a static assert; graph validation depends on it.
+    static assert(!can_route(EventKind.none, TaskKind.none) || can_route(EventKind.none, TaskKind.none));
+
+    // Level triggers are not edges, so they do not yield an event.
+    assert(gpio_event(GpioLine(0, 4), GpioInterruptTrigger.high).kind == EventKind.none);
+    assert(gpio_event(GpioLine(0, 4), GpioInterruptTrigger.rising).kind == EventKind.gpio_rising);
+}
+
+
+private:
+
+enum bool is_isr_safe(alias f) = () {
+    import urt.attribute : isr_safe;
+    bool found;
+    static foreach (attr; __traits(getAttributes, f))
+        static if (__traits(isSame, attr, isr_safe))
+            found = true;
+    return found;
+}();

--- a/src/urt/driver/event.d
+++ b/src/urt/driver/event.d
@@ -62,7 +62,7 @@ enum LinkTier : ubyte
 
 enum LinkContext : ubyte
 {
-    task,
+    thread,
     interrupt,
 }
 
@@ -198,7 +198,7 @@ void link_close(ref Link link)
 // The program's whole reflex set is declared in one ReflexGraph so the backend
 // can synthesize a single vector handler for whatever lands on the NMI rung,
 // disambiguating sources only when there is more than one. The graph provides:
-//   Result open();   // claim sources and arm; call once from task context
+//   Result open();   // claim sources and arm; call once from thread context
 //   void close();
 //   uint fired();    // read-and-clear latch of event pins observed to trip,
 //                    // as a gpio bitmask; poll from the main loop

--- a/src/urt/driver/gpio.d
+++ b/src/urt/driver/gpio.d
@@ -37,6 +37,8 @@
 // implicit chip (chip == 0), line is the offset on it.
 module urt.driver.gpio;
 
+import urt.result : InternalResult, Result;
+
 version (Bouffalo)
     public import urt.driver.bl_common.gpio;
 else version (Beken)
@@ -57,6 +59,9 @@ else
     uint gpio_count() nothrow @nogc => 0;
 }
 
+version (Espressif) {}
+else enum uint num_gpio_interrupts = 0;
+
 nothrow @nogc:
 
 enum Pull : ubyte
@@ -70,6 +75,85 @@ enum DriveMode : ubyte
 {
     push_pull,
     open_drain,
+}
+
+struct GpioLine
+{
+    uint chip;
+    uint line = uint.max;
+}
+
+enum GpioInterruptTrigger : ubyte
+{
+    rising,
+    falling,
+    change,
+    high,
+    low,
+}
+
+struct GpioInterruptConfig
+{
+    GpioLine input;
+    GpioInterruptTrigger trigger;
+}
+
+struct GpioInterrupt
+{
+    ubyte port = ubyte.max;
+}
+
+enum GpioCallbackContext : ubyte
+{
+    task,
+    interrupt,
+}
+
+alias GpioInterruptCallback = bool function(GpioInterrupt interrupt, GpioCallbackContext context) nothrow @nogc;
+
+// Backends retain this plain function pointer in static driver state; an interrupt-context callback must reside in local instruction memory.
+bool is_open(ref const GpioInterrupt interrupt)
+{
+    return interrupt.port != ubyte.max;
+}
+
+Result gpio_interrupt_open(ref GpioInterrupt interrupt, ubyte port, ref const GpioInterruptConfig config)
+{
+    static if (num_gpio_interrupts == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (interrupt.is_open)
+            return InternalResult.already_exists;
+        if (port >= num_gpio_interrupts || config.input.line == uint.max || config.trigger > GpioInterruptTrigger.low)
+            return InternalResult.invalid_parameter;
+        Result result = gpio_interrupt_hw_open(port, config);
+        if (!result)
+            return result;
+        interrupt.port = port;
+        return Result.success;
+    }
+}
+
+void gpio_interrupt_set_callback(ref GpioInterrupt interrupt, GpioInterruptCallback callback)
+{
+    static if (num_gpio_interrupts == 0)
+        assert(false, "no GPIO interrupts on this platform");
+    else
+    {
+        assert(interrupt.is_open, "GPIO interrupt is not open");
+        gpio_interrupt_hw_set_callback(interrupt.port, callback);
+    }
+}
+
+void gpio_interrupt_close(ref GpioInterrupt interrupt)
+{
+    static if (num_gpio_interrupts != 0)
+    {
+        if (interrupt.is_open)
+            gpio_interrupt_hw_close(interrupt.port);
+    }
+    interrupt = GpioInterrupt();
 }
 
 enum GpioDrainStatus : ubyte

--- a/src/urt/driver/gpio.d
+++ b/src/urt/driver/gpio.d
@@ -105,7 +105,7 @@ struct GpioInterrupt
 
 enum GpioCallbackContext : ubyte
 {
-    task,
+    thread,
     interrupt,
 }
 

--- a/src/urt/driver/i2c.d
+++ b/src/urt/driver/i2c.d
@@ -33,7 +33,7 @@ enum I2cError : ubyte
 
 enum I2cCallbackContext : ubyte
 {
-    task,
+    thread,
     interrupt,
 }
 
@@ -68,8 +68,8 @@ struct I2cOperation
 {
 nothrow @nogc:
     // Completion is published and the callback runs immediately in the backend's completion context. The receiver must marshal work that is unsafe in
-    // that context, and the callback must not block. An interrupt callback returns whether the platform should yield to a task woken by the callback;
-    // task-context backends ignore the result. Other threads must first observe is_done, which performs an acquire load, before reading the result or
+    // that context, and the callback must not block. An interrupt callback returns whether the platform should yield to a thread woken by the callback;
+    // thread-context backends ignore the result. Other threads must first observe is_done, which performs an acquire load, before reading the result or
     // reusing the operation, its buffers, or its bus. Completion state is published and bus ownership is released before the callback begins.
     alias Callback = bool function(ref I2cOperation operation, I2cCallbackContext context) nothrow @nogc;
 
@@ -242,17 +242,17 @@ unittest
     operation._bus = &bus;
     atomicStore!(MemoryOrder.release)(operation._state, I2cOperationState.pending);
 
-    assert(!i2c_complete(operation, I2cError.nack, I2cCallbackContext.task));
+    assert(!i2c_complete(operation, I2cError.nack, I2cCallbackContext.thread));
     assert(operation.state == I2cOperationState.error);
     assert(operation.error == I2cError.nack);
     assert(operation._bus is null);
     assert(bus._operation is null);
-    assert(!i2c_complete(operation, I2cError.none, I2cCallbackContext.task));
+    assert(!i2c_complete(operation, I2cError.none, I2cCallbackContext.thread));
 
     operation.reset();
     bus._operation = &operation;
     operation._bus = &bus;
     atomicStore!(MemoryOrder.release)(operation._state, I2cOperationState.pending);
-    assert(!i2c_complete(operation, I2cOperationState.cancelled, I2cError.none, I2cCallbackContext.task));
+    assert(!i2c_complete(operation, I2cOperationState.cancelled, I2cError.none, I2cCallbackContext.thread));
     assert(operation.state == I2cOperationState.cancelled);
 }

--- a/src/urt/driver/pwm.d
+++ b/src/urt/driver/pwm.d
@@ -1,0 +1,83 @@
+module urt.driver.pwm;
+
+import urt.driver.gpio : GpioLine;
+import urt.result : InternalResult, Result;
+
+version (Espressif)
+    public import urt.driver.esp32.pwm;
+else
+    enum uint num_pwm = 0;
+
+nothrow @nogc:
+
+
+struct PwmConfig
+{
+    GpioLine output;
+    uint frequency;
+    uint period; // Duty values range from zero through period.
+    uint initial_duty;
+    bool inverted;
+}
+
+struct Pwm
+{
+    ubyte port = ubyte.max;
+    uint period;
+}
+
+bool is_open(ref const Pwm pwm)
+{
+    return pwm.port != ubyte.max;
+}
+
+Result pwm_open(ref Pwm pwm, ubyte port, ref const PwmConfig config)
+{
+    static if (num_pwm == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (pwm.is_open)
+            return InternalResult.already_exists;
+        if (port >= num_pwm || config.output.line == uint.max || config.frequency == 0 || config.period == 0 || config.initial_duty > config.period)
+            return InternalResult.invalid_parameter;
+
+        Result result = pwm_hw_open(port, config);
+        if (!result)
+            return result;
+
+        pwm.port = port;
+        pwm.period = config.period;
+        return Result.success;
+    }
+}
+
+Result pwm_set_duty(ref Pwm pwm, uint duty)
+{
+    static if (num_pwm == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!pwm.is_open || duty > pwm.period)
+            return InternalResult.invalid_parameter;
+        return pwm_hw_set_duty(pwm.port, duty);
+    }
+}
+
+void pwm_close(ref Pwm pwm)
+{
+    static if (num_pwm != 0)
+    {
+        if (pwm.is_open)
+            pwm_hw_close(pwm.port);
+    }
+    pwm.port = ubyte.max;
+    pwm.period = 0;
+}
+
+
+unittest
+{
+    Pwm pwm;
+    assert(!pwm.is_open);
+}

--- a/src/urt/driver/uart.d
+++ b/src/urt/driver/uart.d
@@ -101,7 +101,7 @@ struct UartConfig
 
 enum UartCallbackContext : ubyte
 {
-    task,
+    thread,
     interrupt,
 }
 
@@ -110,7 +110,7 @@ enum UartCallbackContext : ubyte
 // callback only signals the consumer and uart_read() owns delivery/draining.
 // It must be non-blocking and must not call back into the UART driver.
 // Interrupt-context callbacks return whether the interrupted platform should
-// yield to a woken task. Task-context backends ignore the return value.
+// yield to a woken thread. Thread-context backends ignore the return value.
 alias UartRxCallback = bool function(Uart uart, size_t rx_avail,
                                      UartCallbackContext context) nothrow @nogc;
 

--- a/src/urt/sync/mpsc.d
+++ b/src/urt/sync/mpsc.d
@@ -107,7 +107,7 @@ private:
         shared uint sequence;
     }
 
-    Slot[N] _slots;
+    Slot[N] _slots = void;
     shared uint _tail;     // producer claim cursor
     uint _head;            // consumer read cursor (single consumer; non-atomic)
 }
@@ -115,7 +115,7 @@ private:
 
 unittest
 {
-    MpscQueue!(int, 4) q;
+    MpscQueue!(int, 4) q = void;
     q.init();
 
     int v;

--- a/src/urt/sync/spsc.d
+++ b/src/urt/sync/spsc.d
@@ -19,6 +19,13 @@ struct SPSCRing(T, uint N)
 nothrow @nogc:
     static assert(N >= 2 && is_power_of_2(N), "N must be a power of two >= 2");
 
+    void init()
+    {
+        atomicStore!(MemoryOrder.relaxed)(_head, cast(uint)0);
+        atomicStore!(MemoryOrder.relaxed)(_tail, cast(uint)0);
+        _pending_tail = 0;
+    }
+
     size_t pending() const
     {
         uint h = atomicLoad!(MemoryOrder.relaxed)(_head);
@@ -151,8 +158,24 @@ nothrow @nogc:
     }
 
 private:
-    T[N] _buf;
+    T[N] _buf = void;
     shared uint _head;
     shared uint _tail;
     uint _pending_tail;     // producer-only; staging cursor for uncommitted writes
+}
+
+unittest
+{
+    SPSCRing!(double, 4) ring = void;
+    ring.init();
+    assert(ring.empty);
+
+    double* slot = ring.reserve();
+    assert(slot);
+    *slot = 1.5;
+    ring.commit();
+
+    assert(*ring.peek() == 1.5);
+    ring.pop(1);
+    assert(ring.empty);
 }


### PR DESCRIPTION
## Summary

- add portable PWM and ADC driver APIs with ESP32 backends
- add periodic and GPIO-edge-relative ADC sampling into a caller-owned ring
- add optional ISR notification callbacks with coherent sample generations
- add a generic GPIO interrupt callback API with rising, falling, change, high, and low triggers
- keep ESP32 callback slots in static internal RAM and ISR trampolines in IRAM
- mark the ESP32 GPIO output path for IRAM execution
- add the ESP32 platform capability flags required by the new drivers

## Why

The SmartEVSE board port needs phase-locked control-pilot sampling, PWM generation, and an ISR-safe residual-current input without placing board policy in uRT. These APIs expose the underlying hardware capabilities so board code can compose the required behavior while remaining portable to other backends.

## Impact

Existing GPIO APIs remain unchanged. The new APIs are currently implemented for the classic ESP32 target; unsupported platforms report zero capability until they add a backend.

## Validation

- `make BOARD=smartevse-v30 CONFIG=release`
- `make esp-idf-build BOARD=smartevse-v30 CONFIG=release`
- full ESP-IDF image linked successfully at 1,728,992 bytes
- linked ELF inspection confirmed callback tables and fault state in internal DRAM, with GPIO ISR, D trampoline, GPIO output wrapper, and callback code in IRAM
- `git diff --check origin/master...HEAD`