### PR TITLE
spsc/mpsc: void-init queue storage

### DIFF
--- a/src/urt/sync/mpsc.d
+++ b/src/urt/sync/mpsc.d
@@ -107,7 +107,7 @@ private:
         shared uint sequence;
     }
 
-    Slot[N] _slots;
+    Slot[N] _slots = void;
     shared uint _tail;     // producer claim cursor
     uint _head;            // consumer read cursor (single consumer; non-atomic)
 }

--- a/src/urt/sync/spsc.d
+++ b/src/urt/sync/spsc.d
@@ -151,7 +151,7 @@ nothrow @nogc:
     }
 
 private:
-    T[N] _buf;
+    T[N] _buf = void;
     shared uint _head;
     shared uint _tail;
     uint _pending_tail;     // producer-only; staging cursor for uncommitted writes


### PR DESCRIPTION
The slot arrays in `SPSCRing` and `MpscQueue` are don't-care storage: slots are written before they become visible to the consumer, and `MpscQueue.init()` primes every slot sequence before first use. Initialising them is wasted work, and worse, it forces an init image when the element type has a non-zero default.

D's defaults are not zero (`char` is `0xFF`, `float`/`double` are NaN), so one NaN-bearing element type makes the whole queue non-zero-init. That is not truncated to the offending member: the entire aggregate lands in `.data` instead of `.bss`, and a standalone `__initZ` is emitted on top.

Measured on a downstream 4096-entry ring of a struct with a `double` field: 98,312 bytes of `.data` plus a 98,312-byte `__initZ`. With `= void` on the storage both disappear and the queue lands in `.bss`.

`= void` on the array only; the cursors stay zero-init so stack and heap instances remain correct by default.