### PR TITLE
Add ESP NVS driver

### DIFF
--- a/src/urt/driver/esp32/nvs.d
+++ b/src/urt/driver/esp32/nvs.d
@@ -107,13 +107,7 @@ private:
 
 enum NvsType : ubyte
 {
-    u8 = 0x01,
-    u16 = 0x02,
-    u32 = 0x04,
     u64 = 0x08,
-    i8 = 0x11,
-    i16 = 0x12,
-    i32 = 0x14,
     i64 = 0x18,
     string_ = 0x21,
     blob = 0x42,
@@ -141,24 +135,26 @@ struct EncodedNumber
 
 Result get_integer(uint handle, ref const char[16] key, NvsType type, out Variant value)
 {
-    ulong bits;
-    int result;
     switch (type)
     {
-        case NvsType.i8:  result = esp_nvs_get_i8(handle, key.ptr, cast(byte*)&bits); break;
-        case NvsType.u8:  result = esp_nvs_get_u8(handle, key.ptr, cast(ubyte*)&bits); break;
-        case NvsType.i16: result = esp_nvs_get_i16(handle, key.ptr, cast(short*)&bits); break;
-        case NvsType.u16: result = esp_nvs_get_u16(handle, key.ptr, cast(ushort*)&bits); break;
-        case NvsType.i32: result = esp_nvs_get_i32(handle, key.ptr, cast(int*)&bits); break;
-        case NvsType.u32: result = esp_nvs_get_u32(handle, key.ptr, cast(uint*)&bits); break;
-        case NvsType.i64: result = esp_nvs_get_i64(handle, key.ptr, cast(long*)&bits); break;
-        case NvsType.u64: result = esp_nvs_get_u64(handle, key.ptr, &bits); break;
+        case NvsType.i64:
+        {
+            long number;
+            Result result = map_result(esp_nvs_get_i64(handle, key.ptr, &number));
+            if (result)
+                value = Variant(number);
+            return result;
+        }
+        case NvsType.u64:
+        {
+            ulong number;
+            Result result = map_result(esp_nvs_get_u64(handle, key.ptr, &number));
+            if (result)
+                value = Variant(number);
+            return result;
+        }
         default: return nvs_result(NvsError.type_mismatch);
     }
-    if (result != ESP_OK)
-        return map_result(result);
-
-    return decode_number(type, bits, value);
 }
 
 Result get_buffer(uint handle, ref const char[16] key, NvsType type, out Variant value)
@@ -254,21 +250,8 @@ Result set_string(uint handle, ref const char[16] key, const(char)[] value)
 
 Result set_integer(uint handle, ref const char[16] key, ref const Variant value)
 {
-    EncodedNumber number = encode_number(value);
-    int result;
-    switch (number.type)
-    {
-        case NvsType.i8:  result = esp_nvs_set_i8(handle, key.ptr, cast(byte)number.bits); break;
-        case NvsType.u8:  result = esp_nvs_set_u8(handle, key.ptr, cast(ubyte)number.bits); break;
-        case NvsType.i16: result = esp_nvs_set_i16(handle, key.ptr, cast(short)number.bits); break;
-        case NvsType.u16: result = esp_nvs_set_u16(handle, key.ptr, cast(ushort)number.bits); break;
-        case NvsType.i32: result = esp_nvs_set_i32(handle, key.ptr, cast(int)number.bits); break;
-        case NvsType.u32: result = esp_nvs_set_u32(handle, key.ptr, cast(uint)number.bits); break;
-        case NvsType.i64: result = esp_nvs_set_i64(handle, key.ptr, cast(long)number.bits); break;
-        case NvsType.u64: result = esp_nvs_set_u64(handle, key.ptr, number.bits); break;
-        default: return nvs_result(NvsError.type_mismatch);
-    }
-    return map_result(result);
+    return value.isUlong ? map_result(esp_nvs_set_u64(handle, key.ptr, value.asUlong))
+                         : map_result(esp_nvs_set_i64(handle, key.ptr, value.asLong));
 }
 
 Result set_float(uint handle, ref const char[16] key, ref const Variant value)
@@ -343,15 +326,10 @@ Result get_number(NvsType type, const(ubyte)[] payload, out Variant value)
 
 Result decode_number(NvsType type, ulong bits, out Variant value)
 {
-    size_t size = number_size(type);
-    ubyte kind = cast(ubyte)type & 0xf0;
-    if (kind == 0x00)
+    if (type == NvsType.u64)
         value = Variant(bits);
-    else if (kind == 0x10)
-    {
-        uint shift = cast(uint)((ulong.sizeof - size) * 8);
-        value = Variant(cast(long)(bits << shift) >> shift);
-    }
+    else if (type == NvsType.i64)
+        value = Variant(cast(long)bits);
     else if (type == NvsType.f32)
     {
         uint float_bits = cast(uint)bits;
@@ -440,23 +418,15 @@ EncodedNumber encode_number(ref const Variant value)
     }
 
     if (value.isUlong)
+    {
         result.bits = value.asUlong;
+        result.type = NvsType.u64;
+    }
     else
     {
-        long number = value.asLong;
-        result.bits = cast(ulong)number;
-        if (number < 0)
-        {
-            result.type = number >= byte.min ? NvsType.i8 :
-                          number >= short.min ? NvsType.i16 :
-                          number >= int.min ? NvsType.i32 : NvsType.i64;
-            return result;
-        }
+        result.bits = cast(ulong)value.asLong;
+        result.type = NvsType.i64;
     }
-
-    result.type = result.bits <= ubyte.max ? NvsType.u8 :
-                  result.bits <= ushort.max ? NvsType.u16 :
-                  result.bits <= uint.max ? NvsType.u32 : NvsType.u64;
     return result;
 }
 
@@ -467,11 +437,7 @@ size_t number_size(NvsType type)
 
 bool is_integer_type(NvsType type)
 {
-    ubyte code = cast(ubyte)type;
-    ubyte size = code & 0x0f;
-    ubyte kind = code & 0xf0;
-    return (kind == 0x00 || kind == 0x10) &&
-           (size == 1 || size == 2 || size == 4 || size == 8);
+    return type == NvsType.i64 || type == NvsType.u64;
 }
 
 bool valid_number_type(NvsType type)
@@ -565,22 +531,10 @@ extern(C) nothrow @nogc
     pragma(mangle, "nvs_close") void esp_nvs_close(uint handle);
     pragma(mangle, "nvs_commit") int esp_nvs_commit(uint handle);
     pragma(mangle, "nvs_find_key") int esp_nvs_find_key(uint handle, const(char)* key, int* type);
-    pragma(mangle, "nvs_get_i8") int esp_nvs_get_i8(uint handle, const(char)* key, byte* value);
-    pragma(mangle, "nvs_get_u8") int esp_nvs_get_u8(uint handle, const(char)* key, ubyte* value);
-    pragma(mangle, "nvs_get_i16") int esp_nvs_get_i16(uint handle, const(char)* key, short* value);
-    pragma(mangle, "nvs_get_u16") int esp_nvs_get_u16(uint handle, const(char)* key, ushort* value);
-    pragma(mangle, "nvs_get_i32") int esp_nvs_get_i32(uint handle, const(char)* key, int* value);
-    pragma(mangle, "nvs_get_u32") int esp_nvs_get_u32(uint handle, const(char)* key, uint* value);
     pragma(mangle, "nvs_get_i64") int esp_nvs_get_i64(uint handle, const(char)* key, long* value);
     pragma(mangle, "nvs_get_u64") int esp_nvs_get_u64(uint handle, const(char)* key, ulong* value);
     pragma(mangle, "nvs_get_str") int esp_nvs_get_str(uint handle, const(char)* key, char* value, size_t* length);
     pragma(mangle, "nvs_get_blob") int esp_nvs_get_blob(uint handle, const(char)* key, void* value, size_t* length);
-    pragma(mangle, "nvs_set_i8") int esp_nvs_set_i8(uint handle, const(char)* key, byte value);
-    pragma(mangle, "nvs_set_u8") int esp_nvs_set_u8(uint handle, const(char)* key, ubyte value);
-    pragma(mangle, "nvs_set_i16") int esp_nvs_set_i16(uint handle, const(char)* key, short value);
-    pragma(mangle, "nvs_set_u16") int esp_nvs_set_u16(uint handle, const(char)* key, ushort value);
-    pragma(mangle, "nvs_set_i32") int esp_nvs_set_i32(uint handle, const(char)* key, int value);
-    pragma(mangle, "nvs_set_u32") int esp_nvs_set_u32(uint handle, const(char)* key, uint value);
     pragma(mangle, "nvs_set_i64") int esp_nvs_set_i64(uint handle, const(char)* key, long value);
     pragma(mangle, "nvs_set_u64") int esp_nvs_set_u64(uint handle, const(char)* key, ulong value);
     pragma(mangle, "nvs_set_str") int esp_nvs_set_str(uint handle, const(char)* key, const(char)* value);

--- a/src/urt/driver/esp32/nvs.d
+++ b/src/urt/driver/esp32/nvs.d
@@ -1,0 +1,575 @@
+module urt.driver.esp32.nvs;
+
+import urt.driver.nvs : Nvs, NvsError, NvsOpenMode;
+import urt.endian : littleEndianToNative, nativeToLittleEndian;
+import urt.mem.allocator : defaultAllocator;
+import urt.result : Result, SizeResult;
+import urt.si.unit : ScaledUnit;
+import urt.typereg : find_type_by_name, find_type_details, TypeDetails;
+import urt.variant : Variant;
+
+nothrow @nogc:
+
+
+Result nvs_hw_open(ref Nvs nvs, const(char)[] namespace_, NvsOpenMode mode)
+{
+    char[16] name = void;
+    terminate(namespace_, name);
+    uint handle;
+    int result = esp_nvs_open(name.ptr, cast(int)mode, &handle);
+    if (result == ESP_OK)
+        nvs.driver_handle = handle;
+    return map_result(result);
+}
+
+void nvs_hw_close(ref Nvs nvs)
+{
+    esp_nvs_close(nvs.driver_handle);
+}
+
+Result nvs_hw_commit(ref Nvs nvs)
+{
+    return map_result(esp_nvs_commit(nvs.driver_handle));
+}
+
+Result nvs_hw_get(ref Nvs nvs, const(char)[] key, ref Variant value)
+{
+    char[16] name = void;
+    terminate(key, name);
+
+    int raw_type;
+    Result result = map_result(esp_nvs_find_key(nvs.driver_handle, name.ptr, &raw_type));
+    if (!result)
+        return result;
+
+    switch (cast(NvsType)raw_type)
+    {
+        case NvsType.i8:  return get_integer!byte(nvs.driver_handle, name, value);
+        case NvsType.u8:  return get_integer!ubyte(nvs.driver_handle, name, value);
+        case NvsType.i16: return get_integer!short(nvs.driver_handle, name, value);
+        case NvsType.u16: return get_integer!ushort(nvs.driver_handle, name, value);
+        case NvsType.i32: return get_integer!int(nvs.driver_handle, name, value);
+        case NvsType.u32: return get_integer!uint(nvs.driver_handle, name, value);
+        case NvsType.i64: return get_integer!long(nvs.driver_handle, name, value);
+        case NvsType.u64: return get_integer!ulong(nvs.driver_handle, name, value);
+        case NvsType.string_: return get_string(nvs.driver_handle, name, value);
+        case NvsType.blob: return get_blob(nvs.driver_handle, name, value);
+        default: return nvs_result(NvsError.type_mismatch);
+    }
+}
+
+Result nvs_hw_set(ref Nvs nvs, const(char)[] key, ref const Variant value)
+{
+    char[16] name = void;
+    terminate(key, name);
+
+    if (value.isNull)
+        return set_typed_blob(nvs.driver_handle, name, BlobType.null_, 0, null);
+    if (value.isBool)
+        return set_typed_blob(nvs.driver_handle, name, BlobType.boolean, value.asBool, null);
+    if (value.isString)
+        return set_typed_blob(nvs.driver_handle, name, BlobType.string_, 0, value.asString);
+    if (value.isBuffer)
+        return map_result(esp_nvs_set_blob(nvs.driver_handle, name.ptr, value.asBuffer.ptr, value.asBuffer.length));
+    if (!value.isNumber)
+        return value.isUserType ? set_user(nvs.driver_handle, name, value) : nvs_result(NvsError.unsupported);
+    if (value.is_enum)
+        return nvs_result(NvsError.unsupported);
+    if (value.isQuantity)
+        return set_quantity(nvs.driver_handle, name, value);
+    if (value.isDouble)
+        return value.isFloat ? set_float(nvs.driver_handle, name, value.asFloat)
+                             : set_float(nvs.driver_handle, name, value.asDouble);
+    return value.isUlong ? set_integer(nvs.driver_handle, name, value.asUlong)
+                         : set_integer(nvs.driver_handle, name, value.asLong);
+}
+
+Result nvs_hw_get_size(ref Nvs nvs, const(char)[] key, out size_t length)
+{
+    char[16] name = void;
+    terminate(key, name);
+    return map_result(esp_nvs_get_blob(nvs.driver_handle, name.ptr, null, &length));
+}
+
+SizeResult nvs_hw_read(ref Nvs nvs, const(char)[] key, void[] value)
+{
+    char[16] name = void;
+    terminate(key, name);
+    size_t length = value.length;
+    void* destination = value.length ? value.ptr : null;
+    Result result = map_result(esp_nvs_get_blob(nvs.driver_handle, name.ptr, destination, &length));
+    return result ? SizeResult(length) : SizeResult(result);
+}
+
+Result nvs_hw_write(ref Nvs nvs, const(char)[] key, const(void)[] value)
+{
+    char[16] name = void;
+    terminate(key, name);
+    return map_result(esp_nvs_set_blob(nvs.driver_handle, name.ptr, value.ptr, value.length));
+}
+
+
+private:
+
+enum NvsType : ubyte
+{
+    u8 = 0x01,
+    u16 = 0x02,
+    u32 = 0x04,
+    u64 = 0x08,
+    i8 = 0x11,
+    i16 = 0x12,
+    i32 = 0x14,
+    i64 = 0x18,
+    string_ = 0x21,
+    blob = 0x42,
+    f32 = 0x44,
+    f64 = 0x48,
+}
+
+enum BlobType : ubyte
+{
+    boolean,
+    float_,
+    string_,
+    quantity,
+    user,
+    null_,
+}
+
+enum ubyte blob_guard = 0xa5;
+enum size_t blob_header_length = 8;
+
+Result get_integer(T)(uint handle, ref const char[16] key, ref Variant value)
+{
+    T number;
+    Result result = get_native(handle, key.ptr, number);
+    if (result)
+        value = Variant(number);
+    return result;
+}
+
+Result get_string(uint handle, ref const char[16] key, ref Variant value)
+{
+    size_t length;
+    Result result = map_result(esp_nvs_get_str(handle, key.ptr, null, &length));
+    if (!result)
+        return result;
+    if (length == 0)
+        return nvs_result(NvsError.corrupt);
+
+    void[] bytes = defaultAllocator.alloc(length);
+    if (!bytes.ptr)
+        return nvs_result(NvsError.no_memory);
+    scope(exit) defaultAllocator.free(bytes);
+
+    result = map_result(esp_nvs_get_str(handle, key.ptr, cast(char*)bytes.ptr, &length));
+    if (!result)
+        return result;
+    if (length == 0 || (cast(char*)bytes.ptr)[length - 1] != 0)
+        return nvs_result(NvsError.corrupt);
+    value = Variant(cast(const(char)[])bytes[0 .. length - 1]);
+    return Result.success;
+}
+
+Result get_blob(uint handle, ref const char[16] key, ref Variant value)
+{
+    size_t length;
+    Result result = map_result(esp_nvs_get_blob(handle, key.ptr, null, &length));
+    if (!result)
+        return result;
+    if (length == 0)
+    {
+        value = Variant();
+        return Result.success;
+    }
+
+    void[] bytes = defaultAllocator.alloc(length);
+    if (!bytes.ptr)
+        return nvs_result(NvsError.no_memory);
+    scope(exit) defaultAllocator.free(bytes);
+
+    result = map_result(esp_nvs_get_blob(handle, key.ptr, bytes.ptr, &length));
+    if (!result)
+        return result;
+    if (length != bytes.length)
+        return nvs_result(NvsError.corrupt);
+    if (!valid_header(bytes))
+    {
+        value = Variant(cast(const(void)[])bytes);
+        return Result.success;
+    }
+
+    const(ubyte)[] payload = cast(const(ubyte)[])bytes[blob_header_length .. $];
+    ubyte kind = (cast(const(ubyte)[])bytes)[4];
+    ubyte format = (cast(const(ubyte)[])bytes)[5];
+    switch (cast(BlobType)kind)
+    {
+        case BlobType.null_:
+            if (payload.length != 0 || format)
+                return nvs_result(NvsError.corrupt);
+            value = Variant();
+            return Result.success;
+        case BlobType.boolean:
+            if (payload.length != 0 || format > 1)
+                return nvs_result(NvsError.corrupt);
+            value = Variant(format != 0);
+            return Result.success;
+        case BlobType.float_:
+            return get_float(format, payload, value);
+        case BlobType.string_:
+            if (format)
+                return nvs_result(NvsError.corrupt);
+            value = Variant(cast(const(char)[])payload);
+            return Result.success;
+        case BlobType.quantity:
+            return get_quantity(format, payload, value);
+        case BlobType.user:
+            return get_user(format, payload, value);
+        default:
+            return nvs_result(NvsError.incompatible_version);
+    }
+}
+
+Result set_integer(T)(uint handle, ref const char[16] key, T number)
+{
+    static if (is(T == long))
+    {
+        if (number < 0)
+        {
+            if (number >= byte.min)
+                return set_native(handle, key.ptr, cast(byte)number);
+            if (number >= short.min)
+                return set_native(handle, key.ptr, cast(short)number);
+            if (number >= int.min)
+                return set_native(handle, key.ptr, cast(int)number);
+            return set_native(handle, key.ptr, number);
+        }
+    }
+
+    ulong unsigned_number = cast(ulong)number;
+    if (unsigned_number <= ubyte.max)
+        return set_native(handle, key.ptr, cast(ubyte)unsigned_number);
+    if (unsigned_number <= ushort.max)
+        return set_native(handle, key.ptr, cast(ushort)unsigned_number);
+    if (unsigned_number <= uint.max)
+        return set_native(handle, key.ptr, cast(uint)unsigned_number);
+    return set_native(handle, key.ptr, unsigned_number);
+}
+
+Result set_float(T)(uint handle, ref const char[16] key, T number)
+    if (is(T == float) || is(T == double))
+{
+    ubyte[T.sizeof] encoded = nativeToLittleEndian(number);
+    return set_typed_blob(handle, key, BlobType.float_, T.sizeof, encoded[]);
+}
+
+Result set_quantity(uint handle, ref const char[16] key, ref const Variant value)
+{
+    if (value.isDouble)
+        return set_quantity_number(handle, key, value.asQuantity.unit, value.isFloat ? value.asFloat : value.asDouble);
+    return value.isUlong ? set_quantity_number(handle, key, value.asQuantity.unit, value.asUlong)
+                         : set_quantity_number(handle, key, value.asQuantity.unit, value.asLong);
+}
+
+Result set_quantity_number(T)(uint handle, ref const char[16] key, ScaledUnit unit, T number)
+{
+    enum NvsType type = nvs_type!T;
+    ubyte[uint.sizeof + T.sizeof] payload = void;
+    payload[0 .. uint.sizeof] = nativeToLittleEndian(unit.pack)[];
+    payload[uint.sizeof .. $] = nativeToLittleEndian(number)[];
+    return set_typed_blob(handle, key, BlobType.quantity, type, payload[]);
+}
+
+Result set_user(uint handle, ref const char[16] key, ref const Variant value)
+{
+    ref const TypeDetails details = find_type_details(value.userType);
+    if (!details.pod)
+        return nvs_result(NvsError.unsupported);
+    if (details.name.length > ubyte.max)
+        return nvs_result(NvsError.invalid_length);
+
+    void[] payload = defaultAllocator.alloc(details.name.length + details.size);
+    if (!payload.ptr)
+        return nvs_result(NvsError.no_memory);
+    scope(exit) defaultAllocator.free(payload);
+
+    payload[0 .. details.name.length] = cast(const(void)[])details.name;
+    void[] image = payload[details.name.length .. $];
+    image[] = value.user_ptr[0 .. details.size];
+    return set_typed_blob(handle, key, BlobType.user, details.name.length, payload);
+}
+
+Result get_float(ubyte format, const(ubyte)[] payload, ref Variant value)
+{
+    if (format == float.sizeof && payload.length == float.sizeof)
+    {
+        ubyte[float.sizeof] encoded = void;
+        encoded[] = payload[];
+        value = Variant(littleEndianToNative!float(encoded));
+        return Result.success;
+    }
+    if (format == double.sizeof && payload.length == double.sizeof)
+    {
+        ubyte[double.sizeof] encoded = void;
+        encoded[] = payload[];
+        value = Variant(littleEndianToNative!double(encoded));
+        return Result.success;
+    }
+    return nvs_result(NvsError.corrupt);
+}
+
+Result get_quantity(ubyte format, const(ubyte)[] payload, ref Variant value)
+{
+    if (payload.length < uint.sizeof)
+        return nvs_result(NvsError.corrupt);
+
+    ubyte[uint.sizeof] encoded_unit = void;
+    encoded_unit[] = payload[0 .. uint.sizeof];
+    ScaledUnit unit;
+    unit.pack = littleEndianToNative!uint(encoded_unit);
+
+    Result result;
+    switch (cast(NvsType)format)
+    {
+        case NvsType.i8:  result = get_quantity_number!byte(payload[4 .. $], value); break;
+        case NvsType.u8:  result = get_quantity_number!ubyte(payload[4 .. $], value); break;
+        case NvsType.i16: result = get_quantity_number!short(payload[4 .. $], value); break;
+        case NvsType.u16: result = get_quantity_number!ushort(payload[4 .. $], value); break;
+        case NvsType.i32: result = get_quantity_number!int(payload[4 .. $], value); break;
+        case NvsType.u32: result = get_quantity_number!uint(payload[4 .. $], value); break;
+        case NvsType.i64: result = get_quantity_number!long(payload[4 .. $], value); break;
+        case NvsType.u64: result = get_quantity_number!ulong(payload[4 .. $], value); break;
+        case NvsType.f32: result = get_quantity_number!float(payload[4 .. $], value); break;
+        case NvsType.f64: result = get_quantity_number!double(payload[4 .. $], value); break;
+        default: return nvs_result(NvsError.corrupt);
+    }
+    if (result)
+        value.set_unit(unit);
+    return result;
+}
+
+Result get_quantity_number(T)(const(ubyte)[] payload, ref Variant value)
+{
+    if (payload.length != T.sizeof)
+        return nvs_result(NvsError.corrupt);
+    ubyte[T.sizeof] encoded = void;
+    encoded[] = payload[];
+    value = Variant(littleEndianToNative!T(encoded));
+    return Result.success;
+}
+
+Result get_user(ubyte name_length, const(ubyte)[] payload, ref Variant value)
+{
+    if (payload.length < name_length)
+        return nvs_result(NvsError.corrupt);
+    const(char)[] type_name = cast(const(char)[])payload[0 .. name_length];
+    immutable(TypeDetails)* details = find_type_by_name(type_name);
+    if (!details || !details.pod || !details.variant ||
+        payload.length != name_length + details.size)
+        return nvs_result(NvsError.incompatible_version);
+
+    void[] record = defaultAllocator.alloc(details.size, details.alignment);
+    if (!record.ptr)
+        return nvs_result(NvsError.no_memory);
+    scope(exit) defaultAllocator.free(record);
+
+    const(void)[] image = payload[name_length .. $];
+    record[] = image[];
+    return details.variant(record.ptr, value, true) ? Result.success : nvs_result(NvsError.incompatible_version);
+}
+
+Result set_typed_blob(uint handle, ref const char[16] key, BlobType type, size_t format, const(void)[] payload)
+{
+    if (format > ubyte.max)
+        return nvs_result(NvsError.invalid_length);
+    void[] bytes = defaultAllocator.alloc(blob_header_length + payload.length);
+    if (!bytes.ptr)
+        return nvs_result(NvsError.no_memory);
+    scope(exit) defaultAllocator.free(bytes);
+
+    write_header(bytes, type, cast(ubyte)format);
+    bytes[blob_header_length .. $] = payload[];
+    return map_result(esp_nvs_set_blob(handle, key.ptr, bytes.ptr, bytes.length));
+}
+
+void write_header(void[] bytes, BlobType type, ubyte format)
+{
+    ubyte[] header = cast(ubyte[])bytes[0 .. blob_header_length];
+    header[0] = 'O';
+    header[1] = 'W';
+    header[2] = 'V';
+    header[3] = 1;
+    header[4] = type;
+    header[5] = format;
+    header[6] = blob_guard;
+    header[7] = header[4] ^ header[5] ^ header[6];
+}
+
+bool valid_header(const(void)[] bytes)
+{
+    if (bytes.length < blob_header_length)
+        return false;
+    const(ubyte)[] header = cast(const(ubyte)[])bytes[0 .. blob_header_length];
+    return header[0] == 'O' && header[1] == 'W' && header[2] == 'V' && header[3] == 1 &&
+           header[6] == blob_guard &&
+           header[7] == (header[4] ^ header[5] ^ header[6]);
+}
+
+template nvs_type(T)
+{
+    static if (is(T == byte))
+        enum NvsType nvs_type = NvsType.i8;
+    else static if (is(T == ubyte))
+        enum NvsType nvs_type = NvsType.u8;
+    else static if (is(T == short))
+        enum NvsType nvs_type = NvsType.i16;
+    else static if (is(T == ushort))
+        enum NvsType nvs_type = NvsType.u16;
+    else static if (is(T == int))
+        enum NvsType nvs_type = NvsType.i32;
+    else static if (is(T == uint))
+        enum NvsType nvs_type = NvsType.u32;
+    else static if (is(T == long))
+        enum NvsType nvs_type = NvsType.i64;
+    else static if (is(T == ulong))
+        enum NvsType nvs_type = NvsType.u64;
+    else static if (is(T == float))
+        enum NvsType nvs_type = NvsType.f32;
+    else static if (is(T == double))
+        enum NvsType nvs_type = NvsType.f64;
+    else static assert(false, "unsupported NVS number type");
+}
+
+Result get_native(T)(uint handle, const(char)* key, out T value)
+{
+    static if (is(T == byte))
+        return map_result(esp_nvs_get_i8(handle, key, &value));
+    else static if (is(T == ubyte))
+        return map_result(esp_nvs_get_u8(handle, key, &value));
+    else static if (is(T == short))
+        return map_result(esp_nvs_get_i16(handle, key, &value));
+    else static if (is(T == ushort))
+        return map_result(esp_nvs_get_u16(handle, key, &value));
+    else static if (is(T == int))
+        return map_result(esp_nvs_get_i32(handle, key, &value));
+    else static if (is(T == uint))
+        return map_result(esp_nvs_get_u32(handle, key, &value));
+    else static if (is(T == long))
+        return map_result(esp_nvs_get_i64(handle, key, &value));
+    else static if (is(T == ulong))
+        return map_result(esp_nvs_get_u64(handle, key, &value));
+    else static assert(false, "unsupported NVS number type");
+}
+
+Result set_native(T)(uint handle, const(char)* key, T value)
+{
+    static if (is(T == byte))
+        return map_result(esp_nvs_set_i8(handle, key, value));
+    else static if (is(T == ubyte))
+        return map_result(esp_nvs_set_u8(handle, key, value));
+    else static if (is(T == short))
+        return map_result(esp_nvs_set_i16(handle, key, value));
+    else static if (is(T == ushort))
+        return map_result(esp_nvs_set_u16(handle, key, value));
+    else static if (is(T == int))
+        return map_result(esp_nvs_set_i32(handle, key, value));
+    else static if (is(T == uint))
+        return map_result(esp_nvs_set_u32(handle, key, value));
+    else static if (is(T == long))
+        return map_result(esp_nvs_set_i64(handle, key, value));
+    else static if (is(T == ulong))
+        return map_result(esp_nvs_set_u64(handle, key, value));
+    else static assert(false, "unsupported NVS number type");
+}
+
+enum int ESP_OK = 0;
+enum int ESP_ERR_NO_MEM = 0x101;
+enum int ESP_ERR_INVALID_ARG = 0x102;
+enum int ESP_ERR_NOT_ALLOWED = 0x10d;
+enum int ESP_ERR_NVS_BASE = 0x1100;
+enum int ESP_ERR_NVS_NOT_INITIALIZED = ESP_ERR_NVS_BASE + 0x01;
+enum int ESP_ERR_NVS_NOT_FOUND = ESP_ERR_NVS_BASE + 0x02;
+enum int ESP_ERR_NVS_TYPE_MISMATCH = ESP_ERR_NVS_BASE + 0x03;
+enum int ESP_ERR_NVS_READ_ONLY = ESP_ERR_NVS_BASE + 0x04;
+enum int ESP_ERR_NVS_NOT_ENOUGH_SPACE = ESP_ERR_NVS_BASE + 0x05;
+enum int ESP_ERR_NVS_INVALID_NAME = ESP_ERR_NVS_BASE + 0x06;
+enum int ESP_ERR_NVS_INVALID_HANDLE = ESP_ERR_NVS_BASE + 0x07;
+enum int ESP_ERR_NVS_REMOVE_FAILED = ESP_ERR_NVS_BASE + 0x08;
+enum int ESP_ERR_NVS_KEY_TOO_LONG = ESP_ERR_NVS_BASE + 0x09;
+enum int ESP_ERR_NVS_INVALID_STATE = ESP_ERR_NVS_BASE + 0x0b;
+enum int ESP_ERR_NVS_INVALID_LENGTH = ESP_ERR_NVS_BASE + 0x0c;
+enum int ESP_ERR_NVS_NO_FREE_PAGES = ESP_ERR_NVS_BASE + 0x0d;
+enum int ESP_ERR_NVS_VALUE_TOO_LONG = ESP_ERR_NVS_BASE + 0x0e;
+enum int ESP_ERR_NVS_PART_NOT_FOUND = ESP_ERR_NVS_BASE + 0x0f;
+enum int ESP_ERR_NVS_NEW_VERSION_FOUND = ESP_ERR_NVS_BASE + 0x10;
+enum int ESP_ERR_NVS_CORRUPT_KEY_PART = ESP_ERR_NVS_BASE + 0x17;
+
+void terminate(const(char)[] source, ref char[16] destination)
+{
+    destination[0 .. source.length] = source[];
+    destination[source.length] = 0;
+}
+
+Result nvs_result(NvsError error)
+{
+    return Result(cast(uint)error);
+}
+
+Result map_result(int result)
+{
+    NvsError error;
+    switch (result)
+    {
+        case ESP_OK:                         error = NvsError.none; break;
+        case ESP_ERR_NO_MEM:                 error = NvsError.no_memory; break;
+        case ESP_ERR_INVALID_ARG:            error = NvsError.invalid_parameter; break;
+        case ESP_ERR_NOT_ALLOWED:
+        case ESP_ERR_NVS_READ_ONLY:          error = NvsError.read_only; break;
+        case ESP_ERR_NVS_NOT_INITIALIZED:    error = NvsError.not_initialized; break;
+        case ESP_ERR_NVS_NOT_FOUND:          error = NvsError.not_found; break;
+        case ESP_ERR_NVS_TYPE_MISMATCH:      error = NvsError.type_mismatch; break;
+        case ESP_ERR_NVS_NOT_ENOUGH_SPACE:
+        case ESP_ERR_NVS_NO_FREE_PAGES:      error = NvsError.not_enough_space; break;
+        case ESP_ERR_NVS_INVALID_NAME:
+        case ESP_ERR_NVS_KEY_TOO_LONG:       error = NvsError.invalid_name; break;
+        case ESP_ERR_NVS_INVALID_HANDLE:     error = NvsError.invalid_handle; break;
+        case ESP_ERR_NVS_REMOVE_FAILED:      error = NvsError.write_failed; break;
+        case ESP_ERR_NVS_INVALID_LENGTH:     error = NvsError.invalid_length; break;
+        case ESP_ERR_NVS_VALUE_TOO_LONG:     error = NvsError.value_too_long; break;
+        case ESP_ERR_NVS_PART_NOT_FOUND:     error = NvsError.partition_not_found; break;
+        case ESP_ERR_NVS_NEW_VERSION_FOUND:  error = NvsError.incompatible_version; break;
+        case ESP_ERR_NVS_INVALID_STATE:
+        case ESP_ERR_NVS_CORRUPT_KEY_PART:   error = NvsError.corrupt; break;
+        default:                             error = NvsError.failed; break;
+    }
+    return nvs_result(error);
+}
+
+extern(C) nothrow @nogc
+{
+    pragma(mangle, "nvs_open") int esp_nvs_open(const(char)* namespace_name, int mode, uint* handle);
+    pragma(mangle, "nvs_close") void esp_nvs_close(uint handle);
+    pragma(mangle, "nvs_commit") int esp_nvs_commit(uint handle);
+    pragma(mangle, "nvs_find_key") int esp_nvs_find_key(uint handle, const(char)* key, int* type);
+    pragma(mangle, "nvs_get_i8") int esp_nvs_get_i8(uint handle, const(char)* key, byte* value);
+    pragma(mangle, "nvs_get_u8") int esp_nvs_get_u8(uint handle, const(char)* key, ubyte* value);
+    pragma(mangle, "nvs_get_i16") int esp_nvs_get_i16(uint handle, const(char)* key, short* value);
+    pragma(mangle, "nvs_get_u16") int esp_nvs_get_u16(uint handle, const(char)* key, ushort* value);
+    pragma(mangle, "nvs_get_i32") int esp_nvs_get_i32(uint handle, const(char)* key, int* value);
+    pragma(mangle, "nvs_get_u32") int esp_nvs_get_u32(uint handle, const(char)* key, uint* value);
+    pragma(mangle, "nvs_get_i64") int esp_nvs_get_i64(uint handle, const(char)* key, long* value);
+    pragma(mangle, "nvs_get_u64") int esp_nvs_get_u64(uint handle, const(char)* key, ulong* value);
+    pragma(mangle, "nvs_get_str") int esp_nvs_get_str(uint handle, const(char)* key, char* value, size_t* length);
+    pragma(mangle, "nvs_get_blob") int esp_nvs_get_blob(uint handle, const(char)* key, void* value, size_t* length);
+    pragma(mangle, "nvs_set_i8") int esp_nvs_set_i8(uint handle, const(char)* key, byte value);
+    pragma(mangle, "nvs_set_u8") int esp_nvs_set_u8(uint handle, const(char)* key, ubyte value);
+    pragma(mangle, "nvs_set_i16") int esp_nvs_set_i16(uint handle, const(char)* key, short value);
+    pragma(mangle, "nvs_set_u16") int esp_nvs_set_u16(uint handle, const(char)* key, ushort value);
+    pragma(mangle, "nvs_set_i32") int esp_nvs_set_i32(uint handle, const(char)* key, int value);
+    pragma(mangle, "nvs_set_u32") int esp_nvs_set_u32(uint handle, const(char)* key, uint value);
+    pragma(mangle, "nvs_set_i64") int esp_nvs_set_i64(uint handle, const(char)* key, long value);
+    pragma(mangle, "nvs_set_u64") int esp_nvs_set_u64(uint handle, const(char)* key, ulong value);
+    pragma(mangle, "nvs_set_blob") int esp_nvs_set_blob(uint handle, const(char)* key, const(void)* value, size_t length);
+    pragma(mangle, "nvs_erase_key") int esp_nvs_erase_key(uint handle, const(char)* key);
+}

--- a/src/urt/driver/esp32/nvs.d
+++ b/src/urt/driver/esp32/nvs.d
@@ -1,7 +1,6 @@
 module urt.driver.esp32.nvs;
 
 import urt.driver.nvs : Nvs, NvsError, NvsOpenMode;
-import urt.endian : littleEndianToNative, nativeToLittleEndian;
 import urt.mem.allocator : defaultAllocator;
 import urt.result : Result, SizeResult;
 import urt.si.unit : ScaledUnit;
@@ -42,18 +41,15 @@ Result nvs_hw_get(ref Nvs nvs, const(char)[] key, out Variant value)
     if (!result)
         return result;
 
-    switch (cast(NvsType)raw_type)
+    NvsType type = cast(NvsType)raw_type;
+    if (is_integer_type(type))
+        return get_integer(nvs.driver_handle, name, type, value);
+
+    switch (type)
     {
-        case NvsType.i8:  return get_integer!byte(nvs.driver_handle, name, value);
-        case NvsType.u8:  return get_integer!ubyte(nvs.driver_handle, name, value);
-        case NvsType.i16: return get_integer!short(nvs.driver_handle, name, value);
-        case NvsType.u16: return get_integer!ushort(nvs.driver_handle, name, value);
-        case NvsType.i32: return get_integer!int(nvs.driver_handle, name, value);
-        case NvsType.u32: return get_integer!uint(nvs.driver_handle, name, value);
-        case NvsType.i64: return get_integer!long(nvs.driver_handle, name, value);
-        case NvsType.u64: return get_integer!ulong(nvs.driver_handle, name, value);
-        case NvsType.string_: return get_string(nvs.driver_handle, name, value);
-        case NvsType.blob: return get_blob(nvs.driver_handle, name, value);
+        case NvsType.string_:
+        case NvsType.blob:
+            return get_buffer(nvs.driver_handle, name, type, value);
         default: return nvs_result(NvsError.type_mismatch);
     }
 }
@@ -78,10 +74,8 @@ Result nvs_hw_set(ref Nvs nvs, const(char)[] key, ref const Variant value)
     if (value.isQuantity)
         return set_quantity(nvs.driver_handle, name, value);
     if (value.isDouble)
-        return value.isFloat ? set_float(nvs.driver_handle, name, value.asFloat)
-                             : set_float(nvs.driver_handle, name, value.asDouble);
-    return value.isUlong ? set_integer(nvs.driver_handle, name, value.asUlong)
-                         : set_integer(nvs.driver_handle, name, value.asLong);
+        return set_float(nvs.driver_handle, name, value);
+    return set_integer(nvs.driver_handle, name, value);
 }
 
 Result nvs_hw_get_size(ref Nvs nvs, const(char)[] key, out size_t length)
@@ -140,47 +134,44 @@ enum BlobType : ubyte
 enum ubyte blob_guard = 0xa5;
 enum size_t blob_header_length = 8;
 
-Result get_integer(T)(uint handle, ref const char[16] key, out Variant value)
+struct EncodedNumber
 {
-    T number;
-    Result result = get_native(handle, key.ptr, number);
-    if (result)
-        value = Variant(number);
-    return result;
+    ulong bits;
+    NvsType type;
 }
 
-Result get_string(uint handle, ref const char[16] key, out Variant value)
+Result get_integer(uint handle, ref const char[16] key, NvsType type, out Variant value)
 {
-    size_t length;
-    Result result = map_result(esp_nvs_get_str(handle, key.ptr, null, &length));
-    if (!result)
-        return result;
-    if (length == 0)
-        return nvs_result(NvsError.corrupt);
+    ulong bits;
+    int result;
+    switch (type)
+    {
+        case NvsType.i8:  result = esp_nvs_get_i8(handle, key.ptr, cast(byte*)&bits); break;
+        case NvsType.u8:  result = esp_nvs_get_u8(handle, key.ptr, cast(ubyte*)&bits); break;
+        case NvsType.i16: result = esp_nvs_get_i16(handle, key.ptr, cast(short*)&bits); break;
+        case NvsType.u16: result = esp_nvs_get_u16(handle, key.ptr, cast(ushort*)&bits); break;
+        case NvsType.i32: result = esp_nvs_get_i32(handle, key.ptr, cast(int*)&bits); break;
+        case NvsType.u32: result = esp_nvs_get_u32(handle, key.ptr, cast(uint*)&bits); break;
+        case NvsType.i64: result = esp_nvs_get_i64(handle, key.ptr, cast(long*)&bits); break;
+        case NvsType.u64: result = esp_nvs_get_u64(handle, key.ptr, &bits); break;
+        default: return nvs_result(NvsError.type_mismatch);
+    }
+    if (result != ESP_OK)
+        return map_result(result);
 
-    void[] bytes = defaultAllocator.alloc(length);
-    if (!bytes.ptr)
-        return nvs_result(NvsError.no_memory);
-    scope(exit) defaultAllocator.free(bytes);
-
-    result = map_result(esp_nvs_get_str(handle, key.ptr, cast(char*)bytes.ptr, &length));
-    if (!result)
-        return result;
-    if (length == 0 || (cast(char*)bytes.ptr)[length - 1] != 0)
-        return nvs_result(NvsError.corrupt);
-    value = Variant(cast(const(char)[])bytes[0 .. length - 1]);
-    return Result.success;
+    return decode_number(type, bits, value);
 }
 
-Result get_blob(uint handle, ref const char[16] key, out Variant value)
+Result get_buffer(uint handle, ref const char[16] key, NvsType type, out Variant value)
 {
     size_t length;
-    Result result = map_result(esp_nvs_get_blob(handle, key.ptr, null, &length));
+    Result result = map_result(get_buffer_native(handle, key.ptr, type, null, &length));
     if (!result)
         return result;
     if (length == 0)
     {
-        value = Variant();
+        if (type == NvsType.string_)
+            return nvs_result(NvsError.corrupt);
         return Result.success;
     }
 
@@ -189,14 +180,33 @@ Result get_blob(uint handle, ref const char[16] key, out Variant value)
         return nvs_result(NvsError.no_memory);
     scope(exit) defaultAllocator.free(bytes);
 
-    result = map_result(esp_nvs_get_blob(handle, key.ptr, bytes.ptr, &length));
+    result = map_result(get_buffer_native(handle, key.ptr, type, bytes.ptr, &length));
     if (!result)
         return result;
-    if (length != bytes.length)
+    if (length == 0 || length > bytes.length)
         return nvs_result(NvsError.corrupt);
+    const(void)[] record = bytes[0 .. length];
+    if (type == NvsType.string_)
+    {
+        if ((cast(const(char)[])record)[$-1] != 0)
+            return nvs_result(NvsError.corrupt);
+        value = Variant(cast(const(char)[])record[0 .. $-1]);
+        return Result.success;
+    }
+    return get_blob(record, value);
+}
+
+int get_buffer_native(uint handle, const(char)* key, NvsType type, void* value, size_t* length)
+{
+    return type == NvsType.string_ ? esp_nvs_get_str(handle, key, cast(char*)value, length)
+                                   : esp_nvs_get_blob(handle, key, value, length);
+}
+
+Result get_blob(const(void)[] bytes, out Variant value)
+{
     if (!valid_header(bytes))
     {
-        value = Variant(cast(const(void)[])bytes);
+        value = Variant(bytes);
         return Result.success;
     }
 
@@ -231,54 +241,43 @@ Result get_blob(uint handle, ref const char[16] key, out Variant value)
     }
 }
 
-Result set_integer(T)(uint handle, ref const char[16] key, T number)
+Result set_integer(uint handle, ref const char[16] key, ref const Variant value)
 {
-    static if (is(T == long))
+    EncodedNumber number = encode_number(value);
+    int result;
+    switch (number.type)
     {
-        if (number < 0)
-        {
-            if (number >= byte.min)
-                return set_native(handle, key.ptr, cast(byte)number);
-            if (number >= short.min)
-                return set_native(handle, key.ptr, cast(short)number);
-            if (number >= int.min)
-                return set_native(handle, key.ptr, cast(int)number);
-            return set_native(handle, key.ptr, number);
-        }
+        case NvsType.i8:  result = esp_nvs_set_i8(handle, key.ptr, cast(byte)number.bits); break;
+        case NvsType.u8:  result = esp_nvs_set_u8(handle, key.ptr, cast(ubyte)number.bits); break;
+        case NvsType.i16: result = esp_nvs_set_i16(handle, key.ptr, cast(short)number.bits); break;
+        case NvsType.u16: result = esp_nvs_set_u16(handle, key.ptr, cast(ushort)number.bits); break;
+        case NvsType.i32: result = esp_nvs_set_i32(handle, key.ptr, cast(int)number.bits); break;
+        case NvsType.u32: result = esp_nvs_set_u32(handle, key.ptr, cast(uint)number.bits); break;
+        case NvsType.i64: result = esp_nvs_set_i64(handle, key.ptr, cast(long)number.bits); break;
+        case NvsType.u64: result = esp_nvs_set_u64(handle, key.ptr, number.bits); break;
+        default: return nvs_result(NvsError.type_mismatch);
     }
-
-    ulong unsigned_number = cast(ulong)number;
-    if (unsigned_number <= ubyte.max)
-        return set_native(handle, key.ptr, cast(ubyte)unsigned_number);
-    if (unsigned_number <= ushort.max)
-        return set_native(handle, key.ptr, cast(ushort)unsigned_number);
-    if (unsigned_number <= uint.max)
-        return set_native(handle, key.ptr, cast(uint)unsigned_number);
-    return set_native(handle, key.ptr, unsigned_number);
+    return map_result(result);
 }
 
-Result set_float(T)(uint handle, ref const char[16] key, T number)
-    if (is(T == float) || is(T == double))
+Result set_float(uint handle, ref const char[16] key, ref const Variant value)
 {
-    ubyte[T.sizeof] encoded = nativeToLittleEndian(number);
-    return set_typed_blob(handle, key, BlobType.float_, T.sizeof, encoded[]);
+    EncodedNumber number = encode_number(value);
+    ubyte[ulong.sizeof] encoded = void;
+    size_t size = number_size(number.type);
+    write_little_endian(number.bits, encoded[0 .. size]);
+    return set_typed_blob(handle, key, BlobType.float_, size, encoded[0 .. size]);
 }
 
 Result set_quantity(uint handle, ref const char[16] key, ref const Variant value)
 {
-    if (value.isDouble)
-        return set_quantity_number(handle, key, value.asQuantity.unit, value.isFloat ? value.asFloat : value.asDouble);
-    return value.isUlong ? set_quantity_number(handle, key, value.asQuantity.unit, value.asUlong)
-                         : set_quantity_number(handle, key, value.asQuantity.unit, value.asLong);
-}
-
-Result set_quantity_number(T)(uint handle, ref const char[16] key, ScaledUnit unit, T number)
-{
-    enum NvsType type = nvs_type!T;
-    ubyte[uint.sizeof + T.sizeof] payload = void;
-    payload[0 .. uint.sizeof] = nativeToLittleEndian(unit.pack)[];
-    payload[uint.sizeof .. $] = nativeToLittleEndian(number)[];
-    return set_typed_blob(handle, key, BlobType.quantity, type, payload[]);
+    EncodedNumber number = encode_number(value);
+    size_t size = number_size(number.type);
+    ubyte[uint.sizeof + ulong.sizeof] payload = void;
+    write_little_endian(value.asQuantity.unit.pack, payload[0 .. uint.sizeof]);
+    write_little_endian(number.bits, payload[uint.sizeof .. uint.sizeof + size]);
+    return set_typed_blob(handle, key, BlobType.quantity, number.type,
+                          payload[0 .. uint.sizeof + size]);
 }
 
 Result set_user(uint handle, ref const char[16] key, ref const Variant value)
@@ -302,21 +301,10 @@ Result set_user(uint handle, ref const char[16] key, ref const Variant value)
 
 Result get_float(ubyte format, const(ubyte)[] payload, out Variant value)
 {
-    if (format == float.sizeof && payload.length == float.sizeof)
-    {
-        ubyte[float.sizeof] encoded = void;
-        encoded[] = payload[];
-        value = Variant(littleEndianToNative!float(encoded));
-        return Result.success;
-    }
-    if (format == double.sizeof && payload.length == double.sizeof)
-    {
-        ubyte[double.sizeof] encoded = void;
-        encoded[] = payload[];
-        value = Variant(littleEndianToNative!double(encoded));
-        return Result.success;
-    }
-    return nvs_result(NvsError.corrupt);
+    NvsType type = format == float.sizeof ? NvsType.f32 : NvsType.f64;
+    if (format != float.sizeof && format != double.sizeof)
+        return nvs_result(NvsError.corrupt);
+    return get_number(type, payload, value);
 }
 
 Result get_quantity(ubyte format, const(ubyte)[] payload, out Variant value)
@@ -324,38 +312,42 @@ Result get_quantity(ubyte format, const(ubyte)[] payload, out Variant value)
     if (payload.length < uint.sizeof)
         return nvs_result(NvsError.corrupt);
 
-    ubyte[uint.sizeof] encoded_unit = void;
-    encoded_unit[] = payload[0 .. uint.sizeof];
     ScaledUnit unit;
-    unit.pack = littleEndianToNative!uint(encoded_unit);
+    unit.pack = cast(uint)read_little_endian(payload[0 .. uint.sizeof]);
 
-    Result result;
-    switch (cast(NvsType)format)
-    {
-        case NvsType.i8:  result = get_quantity_number!byte(payload[4 .. $], value); break;
-        case NvsType.u8:  result = get_quantity_number!ubyte(payload[4 .. $], value); break;
-        case NvsType.i16: result = get_quantity_number!short(payload[4 .. $], value); break;
-        case NvsType.u16: result = get_quantity_number!ushort(payload[4 .. $], value); break;
-        case NvsType.i32: result = get_quantity_number!int(payload[4 .. $], value); break;
-        case NvsType.u32: result = get_quantity_number!uint(payload[4 .. $], value); break;
-        case NvsType.i64: result = get_quantity_number!long(payload[4 .. $], value); break;
-        case NvsType.u64: result = get_quantity_number!ulong(payload[4 .. $], value); break;
-        case NvsType.f32: result = get_quantity_number!float(payload[4 .. $], value); break;
-        case NvsType.f64: result = get_quantity_number!double(payload[4 .. $], value); break;
-        default: return nvs_result(NvsError.corrupt);
-    }
+    Result result = get_number(cast(NvsType)format, payload[uint.sizeof .. $], value);
     if (result)
         value.set_unit(unit);
     return result;
 }
 
-Result get_quantity_number(T)(const(ubyte)[] payload, out Variant value)
+Result get_number(NvsType type, const(ubyte)[] payload, out Variant value)
 {
-    if (payload.length != T.sizeof)
+    size_t size = number_size(type);
+    if (!valid_number_type(type) || payload.length != size)
         return nvs_result(NvsError.corrupt);
-    ubyte[T.sizeof] encoded = void;
-    encoded[] = payload[];
-    value = Variant(littleEndianToNative!T(encoded));
+
+    return decode_number(type, read_little_endian(payload), value);
+}
+
+Result decode_number(NvsType type, ulong bits, out Variant value)
+{
+    size_t size = number_size(type);
+    ubyte kind = cast(ubyte)type & 0xf0;
+    if (kind == 0x00)
+        value = Variant(bits);
+    else if (kind == 0x10)
+    {
+        uint shift = cast(uint)((ulong.sizeof - size) * 8);
+        value = Variant(cast(long)(bits << shift) >> shift);
+    }
+    else if (type == NvsType.f32)
+    {
+        uint float_bits = cast(uint)bits;
+        value = Variant(*cast(float*)&float_bits);
+    }
+    else
+        value = Variant(*cast(double*)&bits);
     return Result.success;
 }
 
@@ -416,71 +408,81 @@ bool valid_header(const(void)[] bytes)
            header[7] == (header[4] ^ header[5] ^ header[6]);
 }
 
-template nvs_type(T)
+EncodedNumber encode_number(ref const Variant value)
 {
-    static if (is(T == byte))
-        enum NvsType nvs_type = NvsType.i8;
-    else static if (is(T == ubyte))
-        enum NvsType nvs_type = NvsType.u8;
-    else static if (is(T == short))
-        enum NvsType nvs_type = NvsType.i16;
-    else static if (is(T == ushort))
-        enum NvsType nvs_type = NvsType.u16;
-    else static if (is(T == int))
-        enum NvsType nvs_type = NvsType.i32;
-    else static if (is(T == uint))
-        enum NvsType nvs_type = NvsType.u32;
-    else static if (is(T == long))
-        enum NvsType nvs_type = NvsType.i64;
-    else static if (is(T == ulong))
-        enum NvsType nvs_type = NvsType.u64;
-    else static if (is(T == float))
-        enum NvsType nvs_type = NvsType.f32;
-    else static if (is(T == double))
-        enum NvsType nvs_type = NvsType.f64;
-    else static assert(false, "unsupported NVS number type");
+    EncodedNumber result;
+    if (value.isDouble)
+    {
+        if (value.isFloat)
+        {
+            float number = value.asFloat;
+            result.bits = *cast(uint*)&number;
+            result.type = NvsType.f32;
+        }
+        else
+        {
+            double number = value.asDouble;
+            result.bits = *cast(ulong*)&number;
+            result.type = NvsType.f64;
+        }
+        return result;
+    }
+
+    if (value.isUlong)
+        result.bits = value.asUlong;
+    else
+    {
+        long number = value.asLong;
+        result.bits = cast(ulong)number;
+        if (number < 0)
+        {
+            result.type = number >= byte.min ? NvsType.i8 :
+                          number >= short.min ? NvsType.i16 :
+                          number >= int.min ? NvsType.i32 : NvsType.i64;
+            return result;
+        }
+    }
+
+    result.type = result.bits <= ubyte.max ? NvsType.u8 :
+                  result.bits <= ushort.max ? NvsType.u16 :
+                  result.bits <= uint.max ? NvsType.u32 : NvsType.u64;
+    return result;
 }
 
-Result get_native(T)(uint handle, const(char)* key, out T value)
+size_t number_size(NvsType type)
 {
-    static if (is(T == byte))
-        return map_result(esp_nvs_get_i8(handle, key, &value));
-    else static if (is(T == ubyte))
-        return map_result(esp_nvs_get_u8(handle, key, &value));
-    else static if (is(T == short))
-        return map_result(esp_nvs_get_i16(handle, key, &value));
-    else static if (is(T == ushort))
-        return map_result(esp_nvs_get_u16(handle, key, &value));
-    else static if (is(T == int))
-        return map_result(esp_nvs_get_i32(handle, key, &value));
-    else static if (is(T == uint))
-        return map_result(esp_nvs_get_u32(handle, key, &value));
-    else static if (is(T == long))
-        return map_result(esp_nvs_get_i64(handle, key, &value));
-    else static if (is(T == ulong))
-        return map_result(esp_nvs_get_u64(handle, key, &value));
-    else static assert(false, "unsupported NVS number type");
+    return cast(ubyte)type & 0x0f;
 }
 
-Result set_native(T)(uint handle, const(char)* key, T value)
+bool is_integer_type(NvsType type)
 {
-    static if (is(T == byte))
-        return map_result(esp_nvs_set_i8(handle, key, value));
-    else static if (is(T == ubyte))
-        return map_result(esp_nvs_set_u8(handle, key, value));
-    else static if (is(T == short))
-        return map_result(esp_nvs_set_i16(handle, key, value));
-    else static if (is(T == ushort))
-        return map_result(esp_nvs_set_u16(handle, key, value));
-    else static if (is(T == int))
-        return map_result(esp_nvs_set_i32(handle, key, value));
-    else static if (is(T == uint))
-        return map_result(esp_nvs_set_u32(handle, key, value));
-    else static if (is(T == long))
-        return map_result(esp_nvs_set_i64(handle, key, value));
-    else static if (is(T == ulong))
-        return map_result(esp_nvs_set_u64(handle, key, value));
-    else static assert(false, "unsupported NVS number type");
+    ubyte code = cast(ubyte)type;
+    ubyte size = code & 0x0f;
+    ubyte kind = code & 0xf0;
+    return (kind == 0x00 || kind == 0x10) &&
+           (size == 1 || size == 2 || size == 4 || size == 8);
+}
+
+bool valid_number_type(NvsType type)
+{
+    return is_integer_type(type) || type == NvsType.f32 || type == NvsType.f64;
+}
+
+ulong read_little_endian(const(ubyte)[] value)
+{
+    ulong result;
+    foreach_reverse (ubyte byte_; value)
+        result = (result << 8) | byte_;
+    return result;
+}
+
+void write_little_endian(ulong bits, ubyte[] value)
+{
+    foreach (ref ubyte byte_; value)
+    {
+        byte_ = cast(ubyte)bits;
+        bits >>= 8;
+    }
 }
 
 enum int ESP_OK = 0;

--- a/src/urt/driver/esp32/nvs.d
+++ b/src/urt/driver/esp32/nvs.d
@@ -64,7 +64,7 @@ Result nvs_hw_set(ref Nvs nvs, const(char)[] key, ref const Variant value)
     if (value.isBool)
         return set_typed_blob(nvs.driver_handle, name, BlobType.boolean, value.asBool, null);
     if (value.isString)
-        return set_typed_blob(nvs.driver_handle, name, BlobType.string_, 0, value.asString);
+        return set_string(nvs.driver_handle, name, value.asString);
     if (value.isBuffer)
         return map_result(esp_nvs_set_blob(nvs.driver_handle, name.ptr, value.asBuffer.ptr, value.asBuffer.length));
     if (!value.isNumber)
@@ -123,12 +123,11 @@ enum NvsType : ubyte
 
 enum BlobType : ubyte
 {
-    boolean,
-    float_,
-    string_,
-    quantity,
-    user,
-    null_,
+    boolean = 0,
+    float_ = 1,
+    quantity = 3,
+    user = 4,
+    null_ = 5,
 }
 
 enum ubyte blob_guard = 0xa5;
@@ -227,11 +226,6 @@ Result get_blob(const(void)[] bytes, out Variant value)
             return Result.success;
         case BlobType.float_:
             return get_float(format, payload, value);
-        case BlobType.string_:
-            if (format)
-                return nvs_result(NvsError.corrupt);
-            value = Variant(cast(const(char)[])payload);
-            return Result.success;
         case BlobType.quantity:
             return get_quantity(format, payload, value);
         case BlobType.user:
@@ -239,6 +233,23 @@ Result get_blob(const(void)[] bytes, out Variant value)
         default:
             return nvs_result(NvsError.incompatible_version);
     }
+}
+
+Result set_string(uint handle, ref const char[16] key, const(char)[] value)
+{
+    char[] terminated = cast(char[])defaultAllocator.alloc(value.length + 1);
+    if (!terminated.ptr)
+        return nvs_result(NvsError.no_memory);
+    scope(exit) defaultAllocator.free(terminated);
+
+    foreach (size_t i, char character; value)
+    {
+        if (!character)
+            return nvs_result(NvsError.invalid_parameter);
+        terminated[i] = character;
+    }
+    terminated[$-1] = 0;
+    return map_result(esp_nvs_set_str(handle, key.ptr, terminated.ptr));
 }
 
 Result set_integer(uint handle, ref const char[16] key, ref const Variant value)
@@ -429,23 +440,19 @@ EncodedNumber encode_number(ref const Variant value)
     }
 
     if (value.isUlong)
-        result.bits = value.asUlong;
-    else
     {
-        long number = value.asLong;
-        result.bits = cast(ulong)number;
-        if (number < 0)
-        {
-            result.type = number >= byte.min ? NvsType.i8 :
-                          number >= short.min ? NvsType.i16 :
-                          number >= int.min ? NvsType.i32 : NvsType.i64;
-            return result;
-        }
+        result.bits = value.asUlong;
+        result.type = result.bits <= ubyte.max ? NvsType.u8 :
+                      result.bits <= ushort.max ? NvsType.u16 :
+                      value.isUint ? NvsType.u32 : NvsType.u64;
+        return result;
     }
 
-    result.type = result.bits <= ubyte.max ? NvsType.u8 :
-                  result.bits <= ushort.max ? NvsType.u16 :
-                  result.bits <= uint.max ? NvsType.u32 : NvsType.u64;
+    long number = value.asLong;
+    result.bits = cast(ulong)number;
+    result.type = number >= byte.min ? NvsType.i8 :
+                  number >= short.min ? NvsType.i16 :
+                  value.isInt ? NvsType.i32 : NvsType.i64;
     return result;
 }
 
@@ -572,6 +579,7 @@ extern(C) nothrow @nogc
     pragma(mangle, "nvs_set_u32") int esp_nvs_set_u32(uint handle, const(char)* key, uint value);
     pragma(mangle, "nvs_set_i64") int esp_nvs_set_i64(uint handle, const(char)* key, long value);
     pragma(mangle, "nvs_set_u64") int esp_nvs_set_u64(uint handle, const(char)* key, ulong value);
+    pragma(mangle, "nvs_set_str") int esp_nvs_set_str(uint handle, const(char)* key, const(char)* value);
     pragma(mangle, "nvs_set_blob") int esp_nvs_set_blob(uint handle, const(char)* key, const(void)* value, size_t length);
     pragma(mangle, "nvs_erase_key") int esp_nvs_erase_key(uint handle, const(char)* key);
 }

--- a/src/urt/driver/esp32/nvs.d
+++ b/src/urt/driver/esp32/nvs.d
@@ -32,7 +32,7 @@ Result nvs_hw_commit(ref Nvs nvs)
     return map_result(esp_nvs_commit(nvs.driver_handle));
 }
 
-Result nvs_hw_get(ref Nvs nvs, const(char)[] key, ref Variant value)
+Result nvs_hw_get(ref Nvs nvs, const(char)[] key, out Variant value)
 {
     char[16] name = void;
     terminate(key, name);
@@ -140,7 +140,7 @@ enum BlobType : ubyte
 enum ubyte blob_guard = 0xa5;
 enum size_t blob_header_length = 8;
 
-Result get_integer(T)(uint handle, ref const char[16] key, ref Variant value)
+Result get_integer(T)(uint handle, ref const char[16] key, out Variant value)
 {
     T number;
     Result result = get_native(handle, key.ptr, number);
@@ -149,7 +149,7 @@ Result get_integer(T)(uint handle, ref const char[16] key, ref Variant value)
     return result;
 }
 
-Result get_string(uint handle, ref const char[16] key, ref Variant value)
+Result get_string(uint handle, ref const char[16] key, out Variant value)
 {
     size_t length;
     Result result = map_result(esp_nvs_get_str(handle, key.ptr, null, &length));
@@ -172,7 +172,7 @@ Result get_string(uint handle, ref const char[16] key, ref Variant value)
     return Result.success;
 }
 
-Result get_blob(uint handle, ref const char[16] key, ref Variant value)
+Result get_blob(uint handle, ref const char[16] key, out Variant value)
 {
     size_t length;
     Result result = map_result(esp_nvs_get_blob(handle, key.ptr, null, &length));
@@ -300,7 +300,7 @@ Result set_user(uint handle, ref const char[16] key, ref const Variant value)
     return set_typed_blob(handle, key, BlobType.user, details.name.length, payload);
 }
 
-Result get_float(ubyte format, const(ubyte)[] payload, ref Variant value)
+Result get_float(ubyte format, const(ubyte)[] payload, out Variant value)
 {
     if (format == float.sizeof && payload.length == float.sizeof)
     {
@@ -319,7 +319,7 @@ Result get_float(ubyte format, const(ubyte)[] payload, ref Variant value)
     return nvs_result(NvsError.corrupt);
 }
 
-Result get_quantity(ubyte format, const(ubyte)[] payload, ref Variant value)
+Result get_quantity(ubyte format, const(ubyte)[] payload, out Variant value)
 {
     if (payload.length < uint.sizeof)
         return nvs_result(NvsError.corrupt);
@@ -349,7 +349,7 @@ Result get_quantity(ubyte format, const(ubyte)[] payload, ref Variant value)
     return result;
 }
 
-Result get_quantity_number(T)(const(ubyte)[] payload, ref Variant value)
+Result get_quantity_number(T)(const(ubyte)[] payload, out Variant value)
 {
     if (payload.length != T.sizeof)
         return nvs_result(NvsError.corrupt);
@@ -359,7 +359,7 @@ Result get_quantity_number(T)(const(ubyte)[] payload, ref Variant value)
     return Result.success;
 }
 
-Result get_user(ubyte name_length, const(ubyte)[] payload, ref Variant value)
+Result get_user(ubyte name_length, const(ubyte)[] payload, out Variant value)
 {
     if (payload.length < name_length)
         return nvs_result(NvsError.corrupt);

--- a/src/urt/driver/esp32/nvs.d
+++ b/src/urt/driver/esp32/nvs.d
@@ -1,7 +1,7 @@
 module urt.driver.esp32.nvs;
 
 import urt.driver.nvs : Nvs, NvsError, NvsOpenMode;
-import urt.mem.allocator : defaultAllocator;
+import urt.mem.alloc : alloc, free, MemFlags;
 import urt.result : Result, SizeResult;
 import urt.si.unit : ScaledUnit;
 import urt.typereg : find_type_by_name, find_type_details, TypeDetails;
@@ -174,10 +174,10 @@ Result get_buffer(uint handle, ref const char[16] key, NvsType type, out Variant
         return Result.success;
     }
 
-    void[] bytes = defaultAllocator.alloc(length);
+    void[] bytes = alloc(length, MemFlags.fastest);
     if (!bytes.ptr)
         return nvs_result(NvsError.no_memory);
-    scope(exit) defaultAllocator.free(bytes);
+    scope(exit) free(bytes);
 
     result = map_result(get_buffer_native(handle, key.ptr, type, bytes.ptr, &length));
     if (!result)
@@ -237,10 +237,10 @@ Result get_blob(const(void)[] bytes, out Variant value)
 
 Result set_string(uint handle, ref const char[16] key, const(char)[] value)
 {
-    char[] terminated = cast(char[])defaultAllocator.alloc(value.length + 1);
+    char[] terminated = cast(char[])alloc(value.length + 1, MemFlags.fastest);
     if (!terminated.ptr)
         return nvs_result(NvsError.no_memory);
-    scope(exit) defaultAllocator.free(terminated);
+    scope(exit) free(terminated);
 
     foreach (size_t i, char character; value)
     {
@@ -299,10 +299,10 @@ Result set_user(uint handle, ref const char[16] key, ref const Variant value)
     if (details.name.length > ubyte.max)
         return nvs_result(NvsError.invalid_length);
 
-    void[] payload = defaultAllocator.alloc(details.name.length + details.size);
+    void[] payload = alloc(details.name.length + details.size, MemFlags.fastest);
     if (!payload.ptr)
         return nvs_result(NvsError.no_memory);
-    scope(exit) defaultAllocator.free(payload);
+    scope(exit) free(payload);
 
     payload[0 .. details.name.length] = cast(const(void)[])details.name;
     void[] image = payload[details.name.length .. $];
@@ -372,10 +372,10 @@ Result get_user(ubyte name_length, const(ubyte)[] payload, out Variant value)
         payload.length != name_length + details.size)
         return nvs_result(NvsError.incompatible_version);
 
-    void[] record = defaultAllocator.alloc(details.size, details.alignment);
+    void[] record = alloc(details.size, details.alignment, MemFlags.fastest);
     if (!record.ptr)
         return nvs_result(NvsError.no_memory);
-    scope(exit) defaultAllocator.free(record);
+    scope(exit) free(record);
 
     const(void)[] image = payload[name_length .. $];
     record[] = image[];
@@ -386,10 +386,10 @@ Result set_typed_blob(uint handle, ref const char[16] key, BlobType type, size_t
 {
     if (format > ubyte.max)
         return nvs_result(NvsError.invalid_length);
-    void[] bytes = defaultAllocator.alloc(blob_header_length + payload.length);
+    void[] bytes = alloc(blob_header_length + payload.length, MemFlags.fastest);
     if (!bytes.ptr)
         return nvs_result(NvsError.no_memory);
-    scope(exit) defaultAllocator.free(bytes);
+    scope(exit) free(bytes);
 
     write_header(bytes, type, cast(ubyte)format);
     bytes[blob_header_length .. $] = payload[];
@@ -440,19 +440,23 @@ EncodedNumber encode_number(ref const Variant value)
     }
 
     if (value.isUlong)
-    {
         result.bits = value.asUlong;
-        result.type = result.bits <= ubyte.max ? NvsType.u8 :
-                      result.bits <= ushort.max ? NvsType.u16 :
-                      value.isUint ? NvsType.u32 : NvsType.u64;
-        return result;
+    else
+    {
+        long number = value.asLong;
+        result.bits = cast(ulong)number;
+        if (number < 0)
+        {
+            result.type = number >= byte.min ? NvsType.i8 :
+                          number >= short.min ? NvsType.i16 :
+                          number >= int.min ? NvsType.i32 : NvsType.i64;
+            return result;
+        }
     }
 
-    long number = value.asLong;
-    result.bits = cast(ulong)number;
-    result.type = number >= byte.min ? NvsType.i8 :
-                  number >= short.min ? NvsType.i16 :
-                  value.isInt ? NvsType.i32 : NvsType.i64;
+    result.type = result.bits <= ubyte.max ? NvsType.u8 :
+                  result.bits <= ushort.max ? NvsType.u16 :
+                  result.bits <= uint.max ? NvsType.u32 : NvsType.u64;
     return result;
 }
 

--- a/src/urt/driver/nvs.d
+++ b/src/urt/driver/nvs.d
@@ -97,7 +97,7 @@ Result nvs_commit(ref Nvs nvs)
         return nvs.is_open ? nvs_hw_commit(nvs) : nvs_result(NvsError.invalid_handle);
 }
 
-Result nvs_get(ref Nvs nvs, const(char)[] key, ref Variant value)
+Result nvs_get(ref Nvs nvs, const(char)[] key, out Variant value)
 {
     static if (!has_nvs)
         return nvs_result(NvsError.unsupported);

--- a/src/urt/driver/nvs.d
+++ b/src/urt/driver/nvs.d
@@ -70,7 +70,6 @@ Result nvs_open(ref Nvs nvs, const(char)[] namespace_, NvsOpenMode mode = NvsOpe
         return nvs_result(NvsError.unsupported);
     else
     {
-        assert(namespace_.length <= nvs_max_namespace_length, "NVS namespace is too long");
         if (!valid_name(namespace_, nvs_max_namespace_length))
             return nvs_result(NvsError.invalid_name);
         if (nvs.is_open)
@@ -165,7 +164,6 @@ Result nvs_result(NvsError error)
 
 Result validate_key(ref const Nvs nvs, const(char)[] key)
 {
-    assert(key.length <= nvs_max_key_length, "NVS key is too long");
     if (!valid_name(key, nvs_max_key_length))
         return nvs_result(NvsError.invalid_name);
     return nvs.is_open ? Result.success : nvs_result(NvsError.invalid_handle);

--- a/src/urt/driver/nvs.d
+++ b/src/urt/driver/nvs.d
@@ -1,0 +1,203 @@
+module urt.driver.nvs;
+
+import urt.result : Result, SizeResult;
+import urt.variant : Variant;
+
+nothrow @nogc:
+
+
+enum NvsOpenMode : ubyte
+{
+    read_only,
+    read_write,
+}
+
+enum NvsError : uint
+{
+    none,
+    failed,
+    unsupported,
+    not_initialized,
+    not_found,
+    type_mismatch,
+    read_only,
+    not_enough_space,
+    invalid_name,
+    invalid_handle,
+    write_failed,
+    invalid_length,
+    value_too_long,
+    partition_not_found,
+    incompatible_version,
+    no_memory,
+    invalid_parameter,
+    already_open,
+    corrupt,
+}
+
+struct Nvs
+{
+    uint driver_handle;
+}
+
+version (Espressif)
+{
+    enum bool has_nvs = true;
+    enum size_t nvs_max_namespace_length = 15;
+    enum size_t nvs_max_key_length = 15;
+    private import urt.driver.esp32.nvs;
+}
+else
+{
+    enum bool has_nvs = false;
+    enum size_t nvs_max_namespace_length = 0;
+    enum size_t nvs_max_key_length = 0;
+}
+
+bool is_open(ref const Nvs nvs)
+{
+    return nvs.driver_handle != 0;
+}
+
+NvsError nvs_error(Result result)
+{
+    return cast(NvsError)result.system_code;
+}
+
+Result nvs_open(ref Nvs nvs, const(char)[] namespace_, NvsOpenMode mode = NvsOpenMode.read_write)
+{
+    static if (!has_nvs)
+        return nvs_result(NvsError.unsupported);
+    else
+    {
+        assert(namespace_.length <= nvs_max_namespace_length, "NVS namespace is too long");
+        if (!valid_name(namespace_, nvs_max_namespace_length))
+            return nvs_result(NvsError.invalid_name);
+        if (nvs.is_open)
+            return nvs_result(NvsError.already_open);
+        if (mode > NvsOpenMode.read_write)
+            return nvs_result(NvsError.invalid_parameter);
+        return nvs_hw_open(nvs, namespace_, mode);
+    }
+}
+
+void nvs_close(ref Nvs nvs)
+{
+    static if (has_nvs)
+        if (nvs.is_open)
+            nvs_hw_close(nvs);
+    nvs.driver_handle = 0;
+}
+
+Result nvs_commit(ref Nvs nvs)
+{
+    static if (!has_nvs)
+        return nvs_result(NvsError.unsupported);
+    else
+        return nvs.is_open ? nvs_hw_commit(nvs) : nvs_result(NvsError.invalid_handle);
+}
+
+Result nvs_get(ref Nvs nvs, const(char)[] key, ref Variant value)
+{
+    static if (!has_nvs)
+        return nvs_result(NvsError.unsupported);
+    else
+    {
+        if (!valid_key(key))
+            return nvs_result(NvsError.invalid_name);
+        if (!nvs.is_open)
+            return nvs_result(NvsError.invalid_handle);
+        return nvs_hw_get(nvs, key, value);
+    }
+}
+
+Result nvs_set(ref Nvs nvs, const(char)[] key, ref const Variant value)
+{
+    static if (!has_nvs)
+        return nvs_result(NvsError.unsupported);
+    else
+    {
+        if (!valid_key(key))
+            return nvs_result(NvsError.invalid_name);
+        if (!nvs.is_open)
+            return nvs_result(NvsError.invalid_handle);
+        return nvs_hw_set(nvs, key, value);
+    }
+}
+
+Result nvs_get_size(ref Nvs nvs, const(char)[] key, out size_t length)
+{
+    length = 0;
+    static if (!has_nvs)
+        return nvs_result(NvsError.unsupported);
+    else
+    {
+        if (!valid_key(key))
+            return nvs_result(NvsError.invalid_name);
+        if (!nvs.is_open)
+            return nvs_result(NvsError.invalid_handle);
+        return nvs_hw_get_size(nvs, key, length);
+    }
+}
+
+SizeResult nvs_read(ref Nvs nvs, const(char)[] key, void[] value)
+{
+    static if (!has_nvs)
+        return SizeResult(nvs_result(NvsError.unsupported));
+    else
+    {
+        if (!valid_key(key))
+            return SizeResult(nvs_result(NvsError.invalid_name));
+        if (!nvs.is_open)
+            return SizeResult(nvs_result(NvsError.invalid_handle));
+        return nvs_hw_read(nvs, key, value);
+    }
+}
+
+Result nvs_write(ref Nvs nvs, const(char)[] key, const(void)[] value)
+{
+    static if (!has_nvs)
+        return nvs_result(NvsError.unsupported);
+    else
+    {
+        if (!valid_key(key))
+            return nvs_result(NvsError.invalid_name);
+        if (!nvs.is_open)
+            return nvs_result(NvsError.invalid_handle);
+        return nvs_hw_write(nvs, key, value);
+    }
+}
+
+
+private:
+
+Result nvs_result(NvsError error)
+{
+    return Result(cast(uint)error);
+}
+
+bool valid_name(const(char)[] name, size_t max_length)
+{
+    if (name.length == 0 || name.length > max_length)
+        return false;
+    foreach (char c; name)
+        if (c == 0)
+            return false;
+    return true;
+}
+
+bool valid_key(const(char)[] key)
+{
+    assert(key.length <= nvs_max_key_length, "NVS key is too long");
+    return valid_name(key, nvs_max_key_length);
+}
+
+
+unittest
+{
+    assert(nvs_error(Result.success) == NvsError.none);
+    assert(valid_name("openwatt", 15));
+    assert(!valid_name("", 15));
+    assert(!valid_name("0123456789abcdef", 15));
+    assert(!valid_name("bad\0name", 15));
+}

--- a/src/urt/driver/nvs.d
+++ b/src/urt/driver/nvs.d
@@ -103,11 +103,8 @@ Result nvs_get(ref Nvs nvs, const(char)[] key, out Variant value)
         return nvs_result(NvsError.unsupported);
     else
     {
-        if (!valid_key(key))
-            return nvs_result(NvsError.invalid_name);
-        if (!nvs.is_open)
-            return nvs_result(NvsError.invalid_handle);
-        return nvs_hw_get(nvs, key, value);
+        Result result = validate_key(nvs, key);
+        return result ? nvs_hw_get(nvs, key, value) : result;
     }
 }
 
@@ -117,11 +114,8 @@ Result nvs_set(ref Nvs nvs, const(char)[] key, ref const Variant value)
         return nvs_result(NvsError.unsupported);
     else
     {
-        if (!valid_key(key))
-            return nvs_result(NvsError.invalid_name);
-        if (!nvs.is_open)
-            return nvs_result(NvsError.invalid_handle);
-        return nvs_hw_set(nvs, key, value);
+        Result result = validate_key(nvs, key);
+        return result ? nvs_hw_set(nvs, key, value) : result;
     }
 }
 
@@ -132,11 +126,8 @@ Result nvs_get_size(ref Nvs nvs, const(char)[] key, out size_t length)
         return nvs_result(NvsError.unsupported);
     else
     {
-        if (!valid_key(key))
-            return nvs_result(NvsError.invalid_name);
-        if (!nvs.is_open)
-            return nvs_result(NvsError.invalid_handle);
-        return nvs_hw_get_size(nvs, key, length);
+        Result result = validate_key(nvs, key);
+        return result ? nvs_hw_get_size(nvs, key, length) : result;
     }
 }
 
@@ -146,10 +137,9 @@ SizeResult nvs_read(ref Nvs nvs, const(char)[] key, void[] value)
         return SizeResult(nvs_result(NvsError.unsupported));
     else
     {
-        if (!valid_key(key))
-            return SizeResult(nvs_result(NvsError.invalid_name));
-        if (!nvs.is_open)
-            return SizeResult(nvs_result(NvsError.invalid_handle));
+        Result result = validate_key(nvs, key);
+        if (!result)
+            return SizeResult(result);
         return nvs_hw_read(nvs, key, value);
     }
 }
@@ -160,11 +150,8 @@ Result nvs_write(ref Nvs nvs, const(char)[] key, const(void)[] value)
         return nvs_result(NvsError.unsupported);
     else
     {
-        if (!valid_key(key))
-            return nvs_result(NvsError.invalid_name);
-        if (!nvs.is_open)
-            return nvs_result(NvsError.invalid_handle);
-        return nvs_hw_write(nvs, key, value);
+        Result result = validate_key(nvs, key);
+        return result ? nvs_hw_write(nvs, key, value) : result;
     }
 }
 
@@ -176,6 +163,14 @@ Result nvs_result(NvsError error)
     return Result(cast(uint)error);
 }
 
+Result validate_key(ref const Nvs nvs, const(char)[] key)
+{
+    assert(key.length <= nvs_max_key_length, "NVS key is too long");
+    if (!valid_name(key, nvs_max_key_length))
+        return nvs_result(NvsError.invalid_name);
+    return nvs.is_open ? Result.success : nvs_result(NvsError.invalid_handle);
+}
+
 bool valid_name(const(char)[] name, size_t max_length)
 {
     if (name.length == 0 || name.length > max_length)
@@ -185,13 +180,6 @@ bool valid_name(const(char)[] name, size_t max_length)
             return false;
     return true;
 }
-
-bool valid_key(const(char)[] key)
-{
-    assert(key.length <= nvs_max_key_length, "NVS key is too long");
-    return valid_name(key, nvs_max_key_length);
-}
-
 
 unittest
 {


### PR DESCRIPTION
## Summary

Adds a compact NVS driver surface to uRT:

- caller-selected namespaces with explicit ESP length limits
- a single `Variant` get/set API
- integers stored using the smallest native NVS integer type
- strings stored as native NVS strings
- framed blobs for booleans, floating-point values, quantities, user POD values, and null
- raw blob size/read/write access for interoperation with records owned by other firmware

## Why

OpenWatt needs to retain its own state without reading or overwriting records owned by other firmware. Native NVS types preserve interoperability, while the raw blob API permits safe coexistence with application-owned entries.

The backend uses runtime dispatch instead of per-type template instantiations to minimise embedded flash use.

## Validation

- SmartEVSE v3.0 Xtensa release object compiled with `FEATURES=switch-http IDF_LOG_LEVEL=none`
- combined common and ESP NVS symbols measure 5,252 bytes, down from 8,240 bytes in the initial implementation
- `git diff --check`

## Follow-up

The typed user-value payload currently copies POD layout. Before treating those records as cross-architecture durable data, its serialization needs canonical little-endian handling.