### PR TITLE
Preserve NVS during ESP startup

### DIFF
--- a/src/urt/driver/esp32/main.c
+++ b/src/urt/driver/esp32/main.c
@@ -23,11 +23,15 @@ void app_main(void)
 {
     // Initialize NVS -- required by WiFi for calibration data storage.
     esp_err_t ret = nvs_flash_init();
+#ifndef OW_PRESERVE_NVS
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND)
     {
         nvs_flash_erase();
         nvs_flash_init();
     }
+#else
+    (void)ret;
+#endif
 
     // Event loop is required for WIFI_EVENT delivery.
     esp_event_loop_create_default();


### PR DESCRIPTION
## Summary

Allows an ESP board profile to opt out of the IDF startup path that erases NVS when its stored format is incompatible.

## Why

A migration target can retain application-owned NVS records from prior firmware. When `OW_PRESERVE_NVS` is set, startup leaves recovery of an incompatible NVS partition to the board/application policy instead of silently erasing it.

## Validation

- Diff is limited to `src/urt/driver/esp32/main.c`.
- Included in the SmartEVSE ESP-IDF build validation.