### PR TITLE
Spend spare IRAM as slow overflow memory

### DIFF
--- a/src/urt/driver/esp32/alloc.d
+++ b/src/urt/driver/esp32/alloc.d
@@ -78,19 +78,25 @@ void _free_retain(void[] mem) pure
 
 private:
 
-enum CAP_DMA      = 1 << 3;
-enum CAP_SPIRAM   = 1 << 10;
-enum CAP_INTERNAL = 1 << 11;
-enum CAP_DEFAULT  = 1 << 12;
-enum CAP_RTCRAM   = 1 << 15;
+enum CAP_DMA       = 1 << 3;
+enum CAP_SPIRAM    = 1 << 10;
+enum CAP_INTERNAL  = 1 << 11;
+enum CAP_DEFAULT   = 1 << 12;
+enum CAP_IRAM_8BIT = 1 << 13;
+enum CAP_RTCRAM    = 1 << 15;
 
-// MemFlags [2:0] → ESP-IDF heap_caps
+version (Iram8BitSlowMemory)
+    enum slow_caps = CAP_IRAM_8BIT;
+else
+    enum slow_caps = CAP_DEFAULT | CAP_SPIRAM;
+
+// MemFlags [2:0] -> ESP-IDF heap_caps
 //   [1:0] speed: 0=default, 1=fast, 2=slow, 3=fastest
 //   [2]   dma
 immutable uint[8] _esp_caps = [
     CAP_DEFAULT,                          // 0: default
     CAP_DEFAULT | CAP_INTERNAL,           // 1: fast
-    CAP_DEFAULT | CAP_SPIRAM,             // 2: slow
+    slow_caps,                            // 2: slow
     CAP_DEFAULT | CAP_INTERNAL,           // 3: fastest (no TCM on ESP32)
     CAP_DEFAULT | CAP_DMA,                // 4: dma
     CAP_DEFAULT | CAP_DMA | CAP_INTERNAL, // 5: dma+fast

--- a/src/urt/mem/alloc.d
+++ b/src/urt/mem/alloc.d
@@ -11,7 +11,7 @@ enum MemFlags : ubyte
 
     // Speed bits are placement *preferences*
     fast     = 1,   // prefer internal SRAM
-    slow     = 2,   // prefer external PSRAM
+    slow     = 2,   // prefer slow overflow memory
     fastest  = 3,   // prefer TCM (single-cycle), else internal SRAM
 
     dma      = 0x4, // DMA-accessible (hard requirement)

--- a/src/urt/system.d
+++ b/src/urt/system.d
@@ -6,8 +6,22 @@ import urt.time;
 
 version (Espressif)
 {
-    enum uint MALLOC_CAP_SPIRAM   = 1 << 10;
-    enum uint MALLOC_CAP_INTERNAL = 1 << 11;
+    enum uint MALLOC_CAP_8BIT      = 1 << 2;
+    enum uint MALLOC_CAP_SPIRAM    = 1 << 10;
+    enum uint MALLOC_CAP_INTERNAL  = 1 << 11;
+    enum uint MALLOC_CAP_IRAM_8BIT = 1 << 13;
+
+    version (Iram8BitSlowMemory)
+    {
+        enum uint slow_memory_caps = MALLOC_CAP_IRAM_8BIT;
+        enum string slow_memory_name = "IRAM";
+    }
+    else
+    {
+        enum uint slow_memory_caps = MALLOC_CAP_SPIRAM;
+        enum string slow_memory_name = "PSRAM";
+    }
+
     extern(C) nothrow @nogc
     {
         size_t heap_caps_get_total_size(uint caps);
@@ -149,21 +163,22 @@ SystemInfo get_sysinfo()
     else version (Espressif)
     {
         r.pools[0].name = "SRAM";
-        r.pools[0].total = heap_caps_get_total_size(MALLOC_CAP_INTERNAL);
+        enum sram_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+        r.pools[0].total = heap_caps_get_total_size(sram_caps);
         if (r.pools[0].total > 0)
         {
-            r.pools[0].used = r.pools[0].total - heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
-            r.pools[0].peak_used = r.pools[0].total - heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL);
-            r.pools[0].largest_free = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+            r.pools[0].used = r.pools[0].total - heap_caps_get_free_size(sram_caps);
+            r.pools[0].peak_used = r.pools[0].total - heap_caps_get_minimum_free_size(sram_caps);
+            r.pools[0].largest_free = heap_caps_get_largest_free_block(sram_caps);
         }
 
-        r.pools[1].name = "PSRAM";
-        r.pools[1].total = heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
+        r.pools[1].name = slow_memory_name;
+        r.pools[1].total = heap_caps_get_total_size(slow_memory_caps);
         if (r.pools[1].total > 0)
         {
-            r.pools[1].used = r.pools[1].total - heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
-            r.pools[1].peak_used = r.pools[1].total - heap_caps_get_minimum_free_size(MALLOC_CAP_SPIRAM);
-            r.pools[1].largest_free = heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM);
+            r.pools[1].used = r.pools[1].total - heap_caps_get_free_size(slow_memory_caps);
+            r.pools[1].peak_used = r.pools[1].total - heap_caps_get_minimum_free_size(slow_memory_caps);
+            r.pools[1].largest_free = heap_caps_get_largest_free_block(slow_memory_caps);
         }
 
         r.uptime = get_app_time();


### PR DESCRIPTION
Targets with no PSRAM still have IRAM the application never fills. Under `Iram8BitSlowMemory` the slow allocation tier maps to `MALLOC_CAP_IRAM_8BIT` instead of PSRAM, and sysinfo reports the pool under its real name rather than labelling it PSRAM.

The SRAM pool query also gains `MALLOC_CAP_8BIT`, so the reported figure reflects memory a general allocation can actually use rather than counting regions only word access can reach.