### PR TITLE
Keep zero-initialised globals out of .data

### DIFF
--- a/src/urt/driver/esp32/event.d
+++ b/src/urt/driver/esp32/event.d
@@ -284,7 +284,7 @@ struct LinkSlot
     shared bool active;
 }
 
-__gshared LinkSlot[num_links] _slots;
+__gshared LinkSlot[num_links] _slots = void;
 __gshared ubyte[num_counters] _counter_slots = ubyte.max;
 
 @critical extern(C) bool ow_link_fire(uint slot)

--- a/src/urt/log.d
+++ b/src/urt/log.d
@@ -254,7 +254,7 @@ struct SinkSlot
     bool active;
 }
 
-__gshared SinkSlot[max_sinks] g_sinks;
+__gshared SinkSlot[max_sinks] g_sinks = void;
 __gshared Severity g_max_severity = Severity.info;
 
 __gshared const(char)[] g_log_hostname;


### PR DESCRIPTION
A global with a non-zero-initialised default is emitted as an image in `.data` and pays flash for its whole size, even where every field is written before it is ever read.

`g_sinks` and the ESP32 link `_slots` table are both populated during init, so `= void` moves them to `.bss`.