### PR TITLE
Add an SPI master driver

### DIFF
--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -536,12 +536,10 @@ static uint16_t IRAM_ATTR adc1_read_isr(unsigned channel)
     SENS.sar_touch_ctrl1.xpd_hall_force = 1;
     SENS.sar_touch_ctrl1.hall_phase_force = 1;
     SENS.sar_meas_start1.sar1_en_pad = 1U << channel;
-    while (SENS.sar_slave_addr1.meas_status != 0) {
-    }
+    while (SENS.sar_slave_addr1.meas_status != 0) {}
     SENS.sar_meas_start1.meas1_start_sar = 0;
     SENS.sar_meas_start1.meas1_start_sar = 1;
-    while (SENS.sar_meas_start1.meas1_done_sar == 0) {
-    }
+    while (SENS.sar_meas_start1.meas1_done_sar == 0) {}
     return SENS.sar_meas_start1.meas1_data_sar;
 }
 
@@ -884,8 +882,7 @@ static void ow_i2c_worker(void *argument)
         esp_err_t result = ESP_FAIL;
         if (ow_i2c_configure_device(context, request.address, request.address_mode, request.frequency)) {
             if (request.write_length && request.read_length)
-                result = i2c_master_transmit_receive(context->device, request.write_data, request.write_length,
-                                                     request.read_data, request.read_length, request.timeout_ms);
+                result = i2c_master_transmit_receive(context->device, request.write_data, request.write_length, request.read_data, request.read_length, request.timeout_ms);
             else if (request.write_length)
                 result = i2c_master_transmit(context->device, request.write_data, request.write_length, request.timeout_ms);
             else
@@ -974,12 +971,10 @@ void ow_i2c_close(void *context_ptr)
     context->queue = NULL;
 }
 
-int ow_i2c_submit(void *context_ptr, uint16_t address, uint8_t address_mode, uint32_t frequency, const void *write_data, size_t write_length,
-                  void *read_data, size_t read_length, int timeout_ms, ow_i2c_callback_t callback, void *callback_context)
+int ow_i2c_submit(void *context_ptr, uint16_t address, uint8_t address_mode, uint32_t frequency, const void *write_data, size_t write_length, void *read_data, size_t read_length, int timeout_ms, ow_i2c_callback_t callback, void *callback_context)
 {
     ow_i2c_context_t *context = context_ptr;
-    if (!context || !atomic_load_explicit(&context->initialized, memory_order_acquire) || !callback ||
-        (write_length == 0 && read_length == 0))
+    if (!context || !atomic_load_explicit(&context->initialized, memory_order_acquire) || !callback || (write_length == 0 && read_length == 0))
         return -1;
 
     ow_i2c_request_t request = {
@@ -995,6 +990,182 @@ int ow_i2c_submit(void *context_ptr, uint16_t address, uint8_t address_mode, uin
         .callback_context = callback_context,
     };
     return xQueueSend(context->queue, &request, 0) == pdTRUE ? 0 : -1;
+}
+
+
+// -- SPI master wrappers --
+
+#include "driver/spi_master.h"
+#include "esp_rom_gpio.h"
+#include "soc/gpio_sig_map.h"
+#include "soc/spi_periph.h"
+
+// SPI1 is the flash controller; only the general-purpose hosts are exposed.
+#define OW_SPI_COUNT (SOC_SPI_PERIPH_NUM - 1)
+
+typedef bool (*ow_spi_callback_t)(void *context, int result);
+
+typedef struct {
+    spi_device_handle_t device;
+    spi_host_device_t host;
+    int mosi_gpio;
+    spi_transaction_t transaction;
+    ow_spi_callback_t callback;
+    void *callback_context;
+    void *read_data;
+    size_t read_length;
+    atomic_bool initialized;
+} ow_spi_context_t;
+
+static ow_spi_context_t spi_contexts[OW_SPI_COUNT];
+
+// Runs in the SPI completion interrupt: SPI_DEVICE_NO_RETURN_RESULT means the descriptor is never posted back to a task.
+static void IRAM_ATTR ow_spi_post(spi_transaction_t *transaction)
+{
+    ow_spi_context_t *context = transaction->user;
+    if (!context)
+        return;                 // priming transfer at open: no caller to notify
+
+    // Only the descriptor-resident small-transfer path needs a copy out; DMA wrote straight into the caller's buffer.
+    uint8_t *destination = context->read_data;
+    for (size_t i = 0; i < context->read_length; ++i)
+        destination[i] = transaction->rx_data[i];
+
+    if (context->callback(context->callback_context, 0))
+        portYIELD_FROM_ISR();
+}
+
+uint32_t ow_spi_count(void)
+{
+    return OW_SPI_COUNT;
+}
+
+void *ow_spi_open(unsigned port, int sck_gpio, int mosi_gpio, int miso_gpio, int cs_gpio, uint32_t frequency, uint8_t mode)
+{
+    if (port >= OW_SPI_COUNT)
+        return NULL;
+
+    ow_spi_context_t *context = &spi_contexts[port];
+    if (atomic_exchange_explicit(&context->initialized, true, memory_order_acq_rel))
+        return NULL;
+
+    context->host = SPI2_HOST + port;
+    context->mosi_gpio = mosi_gpio;
+    spi_bus_config_t bus_config = {
+        .sclk_io_num = sck_gpio,
+        .mosi_io_num = mosi_gpio,
+        .miso_io_num = miso_gpio,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+        .max_transfer_sz = 4096,
+    };
+    bool bus_initialized = false;
+    if (spi_bus_initialize(context->host, &bus_config, SPI_DMA_CH_AUTO) != ESP_OK)
+        goto fail;
+    bus_initialized = true;
+
+    spi_device_interface_config_t device_config = {
+        .clock_speed_hz = (int)frequency,
+        .mode = mode,
+        .spics_io_num = cs_gpio,
+        .queue_size = 1,
+        .flags = SPI_DEVICE_NO_RETURN_RESULT,
+        .post_cb = ow_spi_post,
+    };
+    if (spi_bus_add_device(context->host, &device_config, &context->device) != ESP_OK)
+        goto fail;
+
+    // SCLK only settles at the mode's idle level once a transaction has run. A device with no
+    // chip-select has no frame delimiter, so it counts the first edge after open as data and
+    // every subsequent byte lands shifted. Prime the line before any caller can transmit.
+    spi_transaction_t priming = {
+        .length = 8,
+        .flags = SPI_TRANS_USE_TXDATA,
+    };
+    spi_device_polling_transmit(context->device, &priming);
+    return context;
+
+fail:
+    if (bus_initialized)
+        spi_bus_free(context->host);
+    atomic_store_explicit(&context->initialized, false, memory_order_release);
+    return NULL;
+}
+
+void ow_spi_close(void *context_ptr)
+{
+    ow_spi_context_t *context = context_ptr;
+    if (!context || !atomic_exchange_explicit(&context->initialized, false, memory_order_acq_rel))
+        return;
+
+    spi_bus_remove_device(context->device);
+    context->device = NULL;
+    spi_bus_free(context->host);
+}
+
+int ow_spi_submit(void *context_ptr, const void *write_data, size_t write_length, void *read_data, size_t read_length, ow_spi_callback_t callback, void *callback_context)
+{
+    ow_spi_context_t *context = context_ptr;
+    if (!context || !atomic_load_explicit(&context->initialized, memory_order_acquire) || !callback || (write_length == 0 && read_length == 0))
+        return -1;
+    // spi_device_queue_trans takes a FreeRTOS queue with task-context semantics, so a completion callback cannot resubmit directly.
+    if (xPortInIsrContext())
+        return -1;
+
+    size_t length = write_length > read_length ? write_length : read_length;
+    spi_transaction_t *transaction = &context->transaction;
+    memset(transaction, 0, sizeof(*transaction));
+    transaction->length = length * 8;
+    transaction->user = context;
+
+    context->callback = callback;
+    context->callback_context = callback_context;
+    context->read_data = read_data;
+    context->read_length = 0;
+
+    if (length <= 4)
+    {
+        // Small transfers ride inside the descriptor, so command bytes may live in flash rather than DMA-capable RAM.
+        if (write_length)
+        {
+            transaction->flags |= SPI_TRANS_USE_TXDATA;
+            memcpy(transaction->tx_data, write_data, write_length);
+        }
+        if (read_length)
+        {
+            transaction->flags |= SPI_TRANS_USE_RXDATA;
+            context->read_length = read_length;
+        }
+    }
+    else
+    {
+        transaction->tx_buffer = write_length ? write_data : NULL;
+        transaction->rx_buffer = read_length ? read_data : NULL;
+        if (read_length)
+            transaction->rxlength = read_length * 8;
+    }
+
+    return spi_device_queue_trans(context->device, transaction, 0) == ESP_OK ? 0 : -1;
+}
+
+int ow_spi_suspend(void *context_ptr)
+{
+    ow_spi_context_t *context = context_ptr;
+    if (!context || !atomic_load_explicit(&context->initialized, memory_order_acquire) || context->mosi_gpio < 0)
+        return -1;
+    // Hand MOSI's output stage back to the GPIO output register; the caller may now re-init and sample the pin.
+    esp_rom_gpio_connect_out_signal(context->mosi_gpio, SIG_GPIO_OUT_IDX, false, false);
+    return 0;
+}
+
+int ow_spi_resume(void *context_ptr)
+{
+    ow_spi_context_t *context = context_ptr;
+    if (!context || !atomic_load_explicit(&context->initialized, memory_order_acquire) || context->mosi_gpio < 0)
+        return -1;
+    gpio_set_direction((gpio_num_t)context->mosi_gpio, GPIO_MODE_OUTPUT);
+    esp_rom_gpio_connect_out_signal(context->mosi_gpio, spi_periph_signal[context->host].spid_out, false, false);
+    return 0;
 }
 
 
@@ -1068,8 +1239,7 @@ static void ow_uart_event_task(void *argument)
         }
 
         atomic_fetch_or_explicit(&uart_errors[port], error, memory_order_relaxed);
-        ow_uart_rx_ready_cb_t callback = atomic_load_explicit(
-            &uart_rx_ready[port], memory_order_acquire);
+        ow_uart_rx_ready_cb_t callback = atomic_load_explicit(&uart_rx_ready[port], memory_order_acquire);
         if (callback)
             callback(port, 0);
     }
@@ -1084,41 +1254,34 @@ int ow_uart_open(unsigned port, uint32_t baud_rate, uint8_t data_bits,
                  bool rs485_enabled, int8_t de_gpio, bool de_active_high,
                  ow_uart_rx_ready_cb_t rx_ready)
 {
-    if (port >= NUM_UARTS ||
-        atomic_load_explicit(&uart_initialized[port], memory_order_acquire) ||
-        data_bits < 5 || data_bits > 8)
+    if (port >= NUM_UARTS || atomic_load_explicit(&uart_initialized[port], memory_order_acquire) || data_bits < 5 || data_bits > 8)
         return 0;
 
     uart_config_t config = {0};
     config.baud_rate = (int)baud_rate;
     config.data_bits = (uart_word_length_t)(UART_DATA_5_BITS + data_bits - 5);
-    config.parity = parity < sizeof(parity_map) / sizeof(parity_map[0])
-        ? parity_map[parity] : UART_PARITY_DISABLE;
-    config.stop_bits = stop_bits < sizeof(stop_bits_map) / sizeof(stop_bits_map[0])
-        ? stop_bits_map[stop_bits] : UART_STOP_BITS_1;
+    config.parity = parity < sizeof(parity_map) / sizeof(parity_map[0]) ? parity_map[parity] : UART_PARITY_DISABLE;
+    config.stop_bits = stop_bits < sizeof(stop_bits_map) / sizeof(stop_bits_map[0]) ? stop_bits_map[stop_bits] : UART_STOP_BITS_1;
     config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     config.source_clk = UART_SCLK_DEFAULT;
 
     uart_port_t uart = (uart_port_t)port;
     if (uart_param_config(uart, &config) != ESP_OK ||
         uart_set_pin(uart, tx_gpio, rx_gpio, de_gpio, UART_PIN_NO_CHANGE) != ESP_OK ||
-        uart_driver_install(uart, UART_RX_BUFFER_SIZE, UART_TX_BUFFER_SIZE,
-                            UART_EVENT_QUEUE_SIZE, &uart_event_queue[port], 0) != ESP_OK)
+        uart_driver_install(uart, UART_RX_BUFFER_SIZE, UART_TX_BUFFER_SIZE, UART_EVENT_QUEUE_SIZE, &uart_event_queue[port], 0) != ESP_OK)
     {
         uart_event_queue[port] = NULL;
         return 0;
     }
 
-    uint32_t inverse = rs485_enabled && !de_active_high
-        ? UART_SIGNAL_RTS_INV : 0;
+    uint32_t inverse = rs485_enabled && !de_active_high ? UART_SIGNAL_RTS_INV : 0;
     if (uart_set_line_inverse(uart, inverse) != ESP_OK)
     {
         uart_driver_delete(uart);
         uart_event_queue[port] = NULL;
         return 0;
     }
-    if (rs485_enabled &&
-        uart_set_mode(uart, UART_MODE_RS485_HALF_DUPLEX) != ESP_OK)
+    if (rs485_enabled && uart_set_mode(uart, UART_MODE_RS485_HALF_DUPLEX) != ESP_OK)
     {
         uart_driver_delete(uart);
         uart_event_queue[port] = NULL;
@@ -1126,8 +1289,7 @@ int ow_uart_open(unsigned port, uint32_t baud_rate, uint8_t data_bits,
     }
 
     if (!uart_event_task_done[port])
-        uart_event_task_done[port] = xSemaphoreCreateBinaryStatic(
-            &uart_event_task_done_storage[port]);
+        uart_event_task_done[port] = xSemaphoreCreateBinaryStatic(&uart_event_task_done_storage[port]);
     if (!uart_event_task_done[port])
     {
         uart_driver_delete(uart);
@@ -1139,14 +1301,10 @@ int ow_uart_open(unsigned port, uint32_t baud_rate, uint8_t data_bits,
     atomic_store_explicit(&uart_errors[port], 0, memory_order_relaxed);
     atomic_store_explicit(&uart_rx_ready[port], rx_ready, memory_order_release);
     atomic_store_explicit(&uart_initialized[port], true, memory_order_release);
-    if (xTaskCreate(ow_uart_event_task, "ow-uart", UART_EVENT_TASK_STACK,
-                    (void *)(uintptr_t)port, tskIDLE_PRIORITY + 2,
-                    &uart_event_task[port]) != pdPASS)
+    if (xTaskCreate(ow_uart_event_task, "ow-uart", UART_EVENT_TASK_STACK, (void *)(uintptr_t)port, tskIDLE_PRIORITY + 2, &uart_event_task[port]) != pdPASS)
     {
-        atomic_store_explicit(&uart_initialized[port], false,
-                              memory_order_release);
-        atomic_store_explicit(&uart_rx_ready[port], NULL,
-                              memory_order_release);
+        atomic_store_explicit(&uart_initialized[port], false, memory_order_release);
+        atomic_store_explicit(&uart_rx_ready[port], NULL, memory_order_release);
         uart_driver_delete(uart);
         uart_event_queue[port] = NULL;
         return 0;
@@ -1156,9 +1314,7 @@ int ow_uart_open(unsigned port, uint32_t baud_rate, uint8_t data_bits,
 
 void ow_uart_close(unsigned port)
 {
-    if (port >= NUM_UARTS ||
-        !atomic_exchange_explicit(&uart_initialized[port], false,
-                                  memory_order_acq_rel))
+    if (port >= NUM_UARTS || !atomic_exchange_explicit(&uart_initialized[port], false, memory_order_acq_rel))
         return;
     atomic_store_explicit(&uart_rx_ready[port], NULL, memory_order_release);
     if (uart_event_task[port])
@@ -1175,18 +1331,14 @@ void ow_uart_close(unsigned port)
 
 int32_t ow_uart_read(unsigned port, uint8_t *buf, int32_t len)
 {
-    if (port >= NUM_UARTS ||
-        !atomic_load_explicit(&uart_initialized[port], memory_order_acquire) ||
-        !buf || len <= 0)
+    if (port >= NUM_UARTS || !atomic_load_explicit(&uart_initialized[port], memory_order_acquire) || !buf || len <= 0)
         return 0;
     return uart_read_bytes((uart_port_t)port, buf, (uint32_t)len, 0);
 }
 
 int32_t ow_uart_write(unsigned port, const uint8_t *buf, int32_t len)
 {
-    if (port >= NUM_UARTS ||
-        !atomic_load_explicit(&uart_initialized[port], memory_order_acquire) ||
-        !buf || len <= 0)
+    if (port >= NUM_UARTS || !atomic_load_explicit(&uart_initialized[port], memory_order_acquire) || !buf || len <= 0)
         return 0;
     size_t available = 0;
     if (uart_get_tx_buffer_free_size((uart_port_t)port, &available) != ESP_OK)
@@ -1203,37 +1355,31 @@ void ow_uart_poll(unsigned port)
 
 int32_t ow_uart_rx_pending(unsigned port)
 {
-    if (port >= NUM_UARTS ||
-        !atomic_load_explicit(&uart_initialized[port], memory_order_acquire))
+    if (port >= NUM_UARTS || !atomic_load_explicit(&uart_initialized[port], memory_order_acquire))
         return 0;
     size_t available = 0;
-    return uart_get_buffered_data_len((uart_port_t)port, &available) == ESP_OK
-        ? (int32_t)available : 0;
+    return uart_get_buffered_data_len((uart_port_t)port, &available) == ESP_OK ? (int32_t)available : 0;
 }
 
 int ow_uart_tx_idle(unsigned port)
 {
-    if (port >= NUM_UARTS ||
-        !atomic_load_explicit(&uart_initialized[port], memory_order_acquire))
+    if (port >= NUM_UARTS || !atomic_load_explicit(&uart_initialized[port], memory_order_acquire))
         return 1;
     return uart_wait_tx_done((uart_port_t)port, 0) == ESP_OK;
 }
 
 int32_t ow_uart_flush(unsigned port)
 {
-    if (port >= NUM_UARTS ||
-        !atomic_load_explicit(&uart_initialized[port], memory_order_acquire))
+    if (port >= NUM_UARTS || !atomic_load_explicit(&uart_initialized[port], memory_order_acquire))
         return 0;
     return uart_wait_tx_done((uart_port_t)port, portMAX_DELAY) == ESP_OK ? 0 : -1;
 }
 
 int ow_uart_check_errors(unsigned port)
 {
-    if (port >= NUM_UARTS ||
-        !atomic_load_explicit(&uart_initialized[port], memory_order_acquire))
+    if (port >= NUM_UARTS || !atomic_load_explicit(&uart_initialized[port], memory_order_acquire))
         return 0;
-    return (int)atomic_exchange_explicit(&uart_errors[port], 0,
-                                          memory_order_relaxed);
+    return (int)atomic_exchange_explicit(&uart_errors[port], 0, memory_order_relaxed);
 }
 
 // -- WiFi wrappers --
@@ -1490,9 +1636,7 @@ void ow_wifi_set_ap_callback(ow_wifi_event_cb_t cb)
 // fires for every 802.11 frame the radio decodes, including frames with
 // FCS errors when the FCSFAIL filter bit is set.
 
-typedef void (*ow_wifi_promisc_cb_t)(int type, int rssi, int channel,
-                                     int rate, int fcs_fail, int len,
-                                     const uint8_t *payload);
+typedef void (*ow_wifi_promisc_cb_t)(int type, int rssi, int channel, int rate, int fcs_fail, int len, const uint8_t *payload);
 
 static ow_wifi_promisc_cb_t ow_wifi_promisc_callback;
 
@@ -1503,9 +1647,7 @@ static void ow_wifi_promisc_trampoline(void *buf, wifi_promiscuous_pkt_type_t ty
         return;
     const wifi_promiscuous_pkt_t *pkt = (const wifi_promiscuous_pkt_t *)buf;
     const wifi_pkt_rx_ctrl_t *rx = &pkt->rx_ctrl;
-    ow_wifi_promisc_callback((int)type, (int)rx->rssi, (int)rx->channel,
-                             (int)rx->rate, (int)rx->rx_state, (int)rx->sig_len,
-                             pkt->payload);
+    ow_wifi_promisc_callback((int)type, (int)rx->rssi, (int)rx->channel, (int)rx->rate, (int)rx->rx_state, (int)rx->sig_len, pkt->payload);
 }
 
 void ow_wifi_set_promiscuous_callback(ow_wifi_promisc_cb_t cb)
@@ -1526,8 +1668,7 @@ int ow_wifi_set_promiscuous(int enable, uint32_t filter_mask)
 
 int ow_wifi_set_channel(int primary, int secondary)
 {
-    return esp_wifi_set_channel((uint8_t)primary,
-                                (wifi_second_chan_t)secondary) == ESP_OK ? 1 : 0;
+    return esp_wifi_set_channel((uint8_t)primary, (wifi_second_chan_t)secondary) == ESP_OK ? 1 : 0;
 }
 
 // Inject a raw 802.11 frame. ifx selects WIFI_IF_STA (0) or WIFI_IF_AP (1).
@@ -1536,8 +1677,7 @@ int ow_wifi_set_channel(int primary, int secondary)
 // injection paths.
 int ow_wifi_raw_tx(int ifx, const uint8_t *frame, int len, int en_sys_seq)
 {
-    return esp_wifi_80211_tx((wifi_interface_t)ifx, frame, len,
-                             en_sys_seq ? true : false) == ESP_OK ? 1 : 0;
+    return esp_wifi_80211_tx((wifi_interface_t)ifx, frame, len, en_sys_seq ? true : false) == ESP_OK ? 1 : 0;
 }
 #else // !CONFIG_ESP_WIFI_ENABLED
 
@@ -1726,8 +1866,7 @@ static bool ow_can_error(twai_node_handle_t handle, const twai_error_event_data_
     return false;
 }
 
-twai_node_handle_t ow_can_open(unsigned port, uint32_t bitrate, int tx_gpio, int rx_gpio, uint8_t sjw, uint8_t tseg1, uint8_t tseg2,
-                               uint16_t brp, ow_can_rx_cb_t rx_cb)
+twai_node_handle_t ow_can_open(unsigned port, uint32_t bitrate, int tx_gpio, int rx_gpio, uint8_t sjw, uint8_t tseg1, uint8_t tseg2, uint16_t brp, ow_can_rx_cb_t rx_cb)
 {
     if (port >= SOC_TWAI_CONTROLLER_NUM || bitrate == 0 || tx_gpio < 0 || rx_gpio < 0)
         return NULL;
@@ -1918,8 +2057,7 @@ typedef struct {
     uint8_t data[8];
 } ow_can_frame_t;
 
-twai_node_handle_t ow_can_open(unsigned port, uint32_t bitrate, int tx_gpio, int rx_gpio, uint8_t sjw, uint8_t tseg1, uint8_t tseg2,
-                               uint16_t brp, ow_can_rx_cb_t rx_cb)
+twai_node_handle_t ow_can_open(unsigned port, uint32_t bitrate, int tx_gpio, int rx_gpio, uint8_t sjw, uint8_t tseg1, uint8_t tseg2, uint16_t brp, ow_can_rx_cb_t rx_cb)
 {
     return NULL;
 }

--- a/src/urt/driver/esp32/spi.d
+++ b/src/urt/driver/esp32/spi.d
@@ -1,0 +1,70 @@
+module urt.driver.esp32.spi;
+
+import urt.attribute : critical;
+import urt.driver.spi : SpiBus, SpiBusConfig, SpiCallbackContext, SpiError, SpiOperation, SpiTransfer, spi_complete;
+import urt.result : Result, InternalResult;
+
+nothrow @nogc:
+
+
+// SPI1 drives the flash; only the general-purpose controllers are exposed. spi_count() returns the actual number for the active chip variant.
+enum uint num_spi = 2;
+
+uint spi_count() => ow_spi_count();
+
+bool spi_hw_open(ref SpiBus bus, uint port, ref const SpiBusConfig config)
+{
+    if (port >= spi_count())
+        return false;
+    bus.driver_data = ow_spi_open(port, config.sck_gpio, gpio_arg(config.mosi_gpio), gpio_arg(config.miso_gpio), gpio_arg(config.cs_gpio), config.frequency, config.mode);
+    return bus.driver_data !is null;
+}
+
+void spi_hw_close(ref SpiBus bus)
+{
+    if (bus.driver_data !is null)
+        ow_spi_close(bus.driver_data);
+}
+
+Result spi_hw_submit(ref SpiBus bus, ref SpiOperation operation, ref const SpiTransfer transfer)
+{
+    int result = ow_spi_submit(bus.driver_data, transfer.write_data.ptr, transfer.write_data.length, cast(void*)transfer.read_data.ptr, transfer.read_data.length, &operation_complete, &operation);
+    return result == 0 ? Result.success : InternalResult.failed;
+}
+
+Result spi_hw_cancel(ref SpiBus, ref SpiOperation)
+{
+    return InternalResult.unsupported;
+}
+
+Result spi_hw_suspend(ref SpiBus bus)
+{
+    return ow_spi_suspend(bus.driver_data) == 0 ? Result.success : InternalResult.failed;
+}
+
+Result spi_hw_resume(ref SpiBus bus)
+{
+    return ow_spi_resume(bus.driver_data) == 0 ? Result.success : InternalResult.failed;
+}
+
+private:
+
+extern(C) alias SpiCompletion = bool function(void*, int);
+
+int gpio_arg(ubyte gpio)
+    => gpio == ubyte.max ? -1 : gpio;
+
+@critical extern(C) bool operation_complete(void* context, int result)
+{
+    return spi_complete(*cast(SpiOperation*)context, result == 0 ? SpiError.none : SpiError.bus, SpiCallbackContext.interrupt);
+}
+
+extern(C)
+{
+    uint ow_spi_count();
+    void* ow_spi_open(uint port, int sck_gpio, int mosi_gpio, int miso_gpio, int cs_gpio, uint frequency, ubyte mode);
+    void ow_spi_close(void* bus);
+    int ow_spi_submit(void* bus, const(void)* write_data, size_t write_length, void* read_data, size_t read_length, SpiCompletion callback, void* callback_context);
+    int ow_spi_suspend(void* bus);
+    int ow_spi_resume(void* bus);
+}

--- a/src/urt/driver/spi.d
+++ b/src/urt/driver/spi.d
@@ -1,0 +1,298 @@
+// SPI master driver. One device per bus: the wiring, clock, mode, and
+// optional chip-select are fixed at open. cs_gpio = ubyte.max means no
+// chip-select line; the device is permanently selected.
+//
+// Transfers are simultaneous full-duplex: write and read start on the
+// same clock edge, and the transaction runs for max(write, read) bytes.
+// SPI is master-clocked so a transfer's duration is bounded by its
+// length; there is no timeout. The transfer itself is DMA, and
+// completion is signalled from the controller's interrupt -- see the
+// callback contract on SpiOperation.
+//
+// Some boards multiplex the data pins with other functions (e.g. push
+// buttons behind a display's MOSI). spi_suspend releases the MOSI pin
+// to software GPIO control so it can be re-initialized and sampled;
+// spi_resume routes it back to the peripheral and restores it as an
+// output. No operation may be pending across either call.
+//
+// num_spi is a compile-time upper bound used to remove unsupported backends. spi_count() returns the actual number of usable controllers.
+//
+// Each backend exports:
+//   uint spi_count();
+//   bool spi_hw_open(ref SpiBus, uint port, ref const SpiBusConfig);
+//   void spi_hw_close(ref SpiBus);
+//   Result spi_hw_submit(ref SpiBus, ref SpiOperation, ref const SpiTransfer);
+//   Result spi_hw_cancel(ref SpiBus, ref SpiOperation);
+//   Result spi_hw_suspend(ref SpiBus);
+//   Result spi_hw_resume(ref SpiBus);
+
+module urt.driver.spi;
+
+import urt.atomic;
+import urt.attribute : critical;
+import urt.result : Result, InternalResult;
+
+version (Espressif)
+    public import urt.driver.esp32.spi;
+else
+{
+    enum uint num_spi = 0;
+    uint spi_count() nothrow @nogc => 0;
+}
+
+nothrow @nogc:
+
+
+enum SpiMode : ubyte
+{
+    mode0,  // CPOL=0 CPHA=0
+    mode1,  // CPOL=0 CPHA=1
+    mode2,  // CPOL=1 CPHA=0
+    mode3,  // CPOL=1 CPHA=1
+}
+
+enum SpiError : ubyte
+{
+    none,
+    bus,
+}
+
+enum SpiCallbackContext : ubyte
+{
+    thread,
+    interrupt,
+}
+
+enum SpiOperationState : uint
+{
+    idle,
+    pending,
+    complete,
+    cancelled,
+    error,
+}
+
+struct SpiBusConfig
+{
+    uint frequency = 1_000_000;
+    SpiMode mode;
+    ubyte sck_gpio = ubyte.max;
+    ubyte mosi_gpio = ubyte.max;
+    ubyte miso_gpio = ubyte.max;
+    ubyte cs_gpio = ubyte.max;
+}
+
+struct SpiTransfer
+{
+    // The operation and both buffers must remain alive and unmoved until completion. The write buffer must not be modified while pending.
+    // When both directions are present the buffers must be the same length (the transfer is simultaneous, not write-then-read).
+    // Backends may require buffers larger than 4 bytes to reside in DMA-capable RAM (not flash/rodata).
+    const(void)[] write_data;
+    void[] read_data;
+}
+
+struct SpiOperation
+{
+nothrow @nogc:
+    // Completion is published and the callback runs immediately in the backend's completion context, which is the completion interrupt on backends that
+    // have one. Such a callback must be @critical and must not block, allocate, or resubmit; spi_submit needs thread context and rejects an interrupt
+    // caller. The receiver marshals anything else out. An interrupt callback returns whether the platform should yield to a thread it woke; thread-context
+    // backends ignore the result. Other threads must first observe is_done, which performs an acquire load, before reading the result or reusing the
+    // operation, its buffers, or its bus. Completion state is published and bus ownership is released before the callback begins.
+    alias Callback = bool function(ref SpiOperation operation, SpiCallbackContext context) nothrow @nogc;
+
+    void* user_data;
+    Callback callback;
+
+    SpiOperationState state() const
+        => cast(SpiOperationState)atomicLoad!(MemoryOrder.acquire)(_state);
+
+    SpiError error() const
+    {
+        assert(state != SpiOperationState.pending);
+        return _error;
+    }
+
+    bool is_pending() const
+        => state == SpiOperationState.pending;
+
+    bool is_done() const
+        => state >= SpiOperationState.complete;
+
+    void reset()
+    {
+        assert(state != SpiOperationState.pending);
+        assert(_bus is null);
+        _error = SpiError.none;
+        atomicStore!(MemoryOrder.release)(_state, SpiOperationState.idle);
+    }
+
+private:
+    shared uint _state;
+    SpiError _error;
+    SpiBus* _bus;
+}
+
+struct SpiBus
+{
+nothrow @nogc:
+    ubyte port = ubyte.max;
+    void* driver_data;
+
+private:
+    SpiOperation* _operation;
+}
+
+bool is_open(ref const SpiBus bus)
+{
+    return bus.port != ubyte.max;
+}
+
+Result spi_open(ref SpiBus bus, ubyte port, ref const SpiBusConfig config)
+{
+    static if (num_spi == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (port >= spi_count() || config.sck_gpio == ubyte.max || (config.mosi_gpio == ubyte.max && config.miso_gpio == ubyte.max) || config.frequency == 0)
+            return InternalResult.invalid_parameter;
+        if (bus.is_open)
+            return InternalResult.already_exists;
+        if (!spi_hw_open(bus, port, config))
+            return InternalResult.failed;
+        bus.port = port;
+        return Result.success;
+    }
+}
+
+void spi_close(ref SpiBus bus)
+{
+    assert(bus._operation is null, "an SPI bus cannot close while an operation is pending");
+    if (bus._operation !is null)
+        return;
+
+    static if (num_spi != 0)
+    {
+        if (bus.is_open)
+            spi_hw_close(bus);
+    }
+    bus.port = ubyte.max;
+    bus.driver_data = null;
+}
+
+Result spi_submit(ref SpiBus bus, ref SpiOperation operation, ref const SpiTransfer transfer)
+{
+    static if (num_spi == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!bus.is_open || operation.state != SpiOperationState.idle || bus._operation !is null ||
+            (transfer.write_data.length == 0 && transfer.read_data.length == 0) ||
+            (transfer.write_data.length != 0 && transfer.read_data.length != 0 &&
+             transfer.write_data.length != transfer.read_data.length))
+            return InternalResult.invalid_parameter;
+
+        operation._error = SpiError.none;
+        operation._bus = &bus;
+        bus._operation = &operation;
+        atomicStore!(MemoryOrder.release)(operation._state, SpiOperationState.pending);
+        Result result = spi_hw_submit(bus, operation, transfer);
+        if (!result)
+        {
+            bus._operation = null;
+            operation._bus = null;
+            operation._error = SpiError.bus;
+            atomicStore!(MemoryOrder.release)(operation._state, SpiOperationState.idle);
+        }
+        return result;
+    }
+}
+
+Result spi_cancel(ref SpiBus bus, ref SpiOperation operation)
+{
+    static if (num_spi == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!bus.is_open || !operation.is_pending || operation._bus !is &bus)
+            return InternalResult.invalid_parameter;
+        return spi_hw_cancel(bus, operation);
+    }
+}
+
+Result spi_suspend(ref SpiBus bus)
+{
+    static if (num_spi == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!bus.is_open || bus._operation !is null)
+            return InternalResult.invalid_parameter;
+        return spi_hw_suspend(bus);
+    }
+}
+
+Result spi_resume(ref SpiBus bus)
+{
+    static if (num_spi == 0)
+        return InternalResult.unsupported;
+    else
+    {
+        if (!bus.is_open || bus._operation !is null)
+            return InternalResult.invalid_parameter;
+        return spi_hw_resume(bus);
+    }
+}
+
+@critical package bool spi_complete(ref SpiOperation operation, SpiError error, SpiCallbackContext context)
+{
+    SpiOperationState state = error == SpiError.none ? SpiOperationState.complete : SpiOperationState.error;
+    return spi_complete(operation, state, error, context);
+}
+
+@critical package bool spi_complete(ref SpiOperation operation, SpiOperationState completion_state, SpiError error, SpiCallbackContext context)
+{
+    if (!operation.is_pending)
+        return false;
+    assert(completion_state == SpiOperationState.complete || completion_state == SpiOperationState.cancelled || completion_state == SpiOperationState.error);
+
+    SpiBus* bus = operation._bus;
+    assert(bus !is null && bus._operation is &operation);
+    if (bus !is null && bus._operation is &operation)
+        bus._operation = null;
+    operation._bus = null;
+    operation._error = error;
+    atomicStore!(MemoryOrder.release)(operation._state, completion_state);
+    return operation.callback ? operation.callback(operation, context) : false;
+}
+
+
+unittest
+{
+    static assert(is(typeof(num_spi) == uint));
+    spi_count();
+
+    // Mode encoding is load-bearing: backends pass the ordinal straight through as CPOL/CPHA.
+    static assert(SpiMode.mode0 == 0);
+    static assert(SpiMode.mode3 == 3);
+
+    SpiBus bus;
+    SpiOperation operation;
+    bus._operation = &operation;
+    operation._bus = &bus;
+    atomicStore!(MemoryOrder.release)(operation._state, SpiOperationState.pending);
+
+    assert(!spi_complete(operation, SpiError.bus, SpiCallbackContext.thread));
+    assert(operation.state == SpiOperationState.error);
+    assert(operation.error == SpiError.bus);
+    assert(operation._bus is null);
+    assert(bus._operation is null);
+    assert(!spi_complete(operation, SpiError.none, SpiCallbackContext.thread));
+
+    operation.reset();
+    bus._operation = &operation;
+    operation._bus = &bus;
+    atomicStore!(MemoryOrder.release)(operation._state, SpiOperationState.pending);
+    assert(!spi_complete(operation, SpiOperationState.cancelled, SpiError.none, SpiCallbackContext.thread));
+    assert(operation.state == SpiOperationState.cancelled);
+}


### PR DESCRIPTION
One device per bus, with wiring, clock and mode fixed at open. Transfers run on DMA and complete from the controller's interrupt.

The ESP-IDF backend queues transactions with `SPI_DEVICE_NO_RETURN_RESULT` and reports completion from `post_cb`, so there is no worker task and no result queue to service. `spi_submit` needs thread context and rejects an interrupt-context caller rather than pretending to work; the completion callback marshals anything further out itself.

`spi_suspend` / `spi_resume` hand the MOSI pad back to software GPIO and put it back, for boards that multiplex buttons behind a display's data line.

**Priming transaction at open.** SCLK only settles at the mode's idle level once a transaction has run. A device with no chip-select has no frame delimiter, so it counts the first edge after open as data and every byte afterwards lands shifted by a bit. Running one transaction at open parks the line before any caller can transmit.

That was not theoretical: on a SmartEVSE the ST7565 panel has no CS, and without priming the display-on and power-control commands never arrived, so the panel stayed perfectly blank rather than showing garbage. Confirmed by bit-banging the same init through plain GPIO, which lit the panel while the DMA path could not.

Also strips gratuitous comments from the surrounding shim.
