### PR TITLE
Hide mbedtls state allocation behind shim

### DIFF
--- a/src/urt/crypto/pki.d
+++ b/src/urt/crypto/pki.d
@@ -17,7 +17,7 @@ struct KeyPair
 nothrow @nogc:
     version (MbedTLS)
     {
-        mbedtls_pk_context pk;
+        mbedtls_pk_context* pk;
     }
     else version (Windows)
     {
@@ -35,7 +35,7 @@ nothrow @nogc:
     bool valid() const pure
     {
         version (MbedTLS)
-            return pk.pk_info !is null;
+            return pk !is null;
         else version (Windows)
             return hcng !is null;
         else
@@ -48,7 +48,7 @@ struct CertRef
 nothrow @nogc:
     version (MbedTLS)
     {
-        mbedtls_x509_crt* crt;     // heap-allocated via urt_x509_crt_new
+        mbedtls_x509_crt* crt;
     }
     else version (Windows)
     {
@@ -73,12 +73,14 @@ Result generate_keypair(out KeyPair kp)
 {
     version (MbedTLS)
     {
-        mbedtls_pk_init(&kp.pk);
-        int ret = urt_pk_gen_ec_p256_key(&kp.pk);
+        kp.pk = urt_pk_new();
+        if (!kp.pk)
+            return InternalResult.no_memory;
+        int ret = urt_pk_gen_ec_p256_key(kp.pk);
         if (ret != 0)
         {
-            mbedtls_pk_free(&kp.pk);
-            kp.pk = mbedtls_pk_context.init;
+            urt_pk_delete(kp.pk);
+            kp.pk = null;
             return Result(cast(uint)ret);
         }
 
@@ -118,8 +120,8 @@ void free_keypair(ref KeyPair kp)
 {
     version (MbedTLS)
     {
-        mbedtls_pk_free(&kp.pk);
-        kp.pk = mbedtls_pk_context.init;
+        urt_pk_delete(kp.pk);
+        kp.pk = null;
     }
     else version (Windows)
     {
@@ -595,8 +597,7 @@ Result sign_hash(ref KeyPair kp, const(ubyte)[] hash, out Array!ubyte signature)
         // we need raw R||S format (64 bytes for P-256) to match the Windows contract.
         ubyte[256] sig_buf = void;
         size_t sig_len = 0;
-        int ret = urt_pk_sign(&kp.pk,
-            hash.ptr, hash.length, sig_buf.ptr, sig_buf.length, &sig_len);
+        int ret = urt_pk_sign(kp.pk, hash.ptr, hash.length, sig_buf.ptr, sig_buf.length, &sig_len);
         if (ret != 0)
             return Result(cast(uint)ret);
 
@@ -645,7 +646,7 @@ Result export_public_key_raw(ref KeyPair kp, out Array!ubyte x, out Array!ubyte 
         // export uncompressed point: 0x04 || X || Y
         ubyte[65] pt_buf = void; // 1 + 32 + 32 for P-256
         size_t olen = 0;
-        int ret = urt_pk_export_pubkey_xy(&kp.pk, pt_buf.ptr, pt_buf.length, &olen);
+        int ret = urt_pk_export_pubkey_xy(kp.pk, pt_buf.ptr, pt_buf.length, &olen);
         if (ret != 0)
             return Result(cast(uint)ret);
 
@@ -759,11 +760,11 @@ Result export_private_key(ref KeyPair kp, out Array!ubyte key_out)
         ubyte[65] xy_buf = void;
         size_t d_len = 0, xy_len = 0;
 
-        int ret = urt_pk_export_privkey_d(&kp.pk, d.ptr, d.length, &d_len);
+        int ret = urt_pk_export_privkey_d(kp.pk, d.ptr, d.length, &d_len);
         if (ret != 0)
             return Result(cast(uint)ret);
 
-        ret = urt_pk_export_pubkey_xy(&kp.pk, xy_buf.ptr, xy_buf.length, &xy_len);
+        ret = urt_pk_export_pubkey_xy(kp.pk, xy_buf.ptr, xy_buf.length, &xy_len);
         if (ret != 0)
             return Result(cast(uint)ret);
 
@@ -821,12 +822,14 @@ Result import_private_key(const(ubyte)[] key_data, out KeyPair kp)
         xy[1 .. 33] = x[];
         xy[33 .. 65] = y[];
 
-        mbedtls_pk_init(&kp.pk);
-        int ret = urt_pk_import_ec_p256_key(&kp.pk, d.ptr, d.length, xy.ptr, xy.length);
+        kp.pk = urt_pk_new();
+        if (!kp.pk)
+            return InternalResult.no_memory;
+        int ret = urt_pk_import_ec_p256_key(kp.pk, d.ptr, d.length, xy.ptr, xy.length);
         if (ret != 0)
         {
-            mbedtls_pk_free(&kp.pk);
-            kp.pk = mbedtls_pk_context.init;
+            urt_pk_delete(kp.pk);
+            kp.pk = null;
             return Result(cast(uint)ret);
         }
 

--- a/src/urt/internal/mbedtls.c
+++ b/src/urt/internal/mbedtls.c
@@ -40,6 +40,7 @@
 size_t urt_sizeof_x509_crt(void)    { return sizeof(mbedtls_x509_crt); }
 size_t urt_sizeof_ssl_context(void) { return sizeof(mbedtls_ssl_context); }
 size_t urt_sizeof_ssl_config(void)  { return sizeof(mbedtls_ssl_config); }
+size_t urt_sizeof_pk_context(void)  { return sizeof(mbedtls_pk_context); }
 
 
 // =====================================================================
@@ -100,8 +101,7 @@ static int _urt_rng_seeded = 0;
  * its own poll function -- on Bouffalo that's the SEC_ENG TRNG driver in
  * urt.driver.bl_common.trng (declared extern(C) urt_platform_entropy_poll). */
 #if defined(MBEDTLS_NO_PLATFORM_ENTROPY)
-extern int urt_platform_entropy_poll(void *data, unsigned char *output,
-                                     size_t len, size_t *olen);
+extern int urt_platform_entropy_poll(void *data, unsigned char *output, size_t len, size_t *olen);
 #endif
 
 int urt_rng_init(void)
@@ -110,8 +110,7 @@ int urt_rng_init(void)
         return 0;
     mbedtls_entropy_init(&_urt_entropy);
 #if defined(MBEDTLS_NO_PLATFORM_ENTROPY)
-    int es = mbedtls_entropy_add_source(&_urt_entropy, urt_platform_entropy_poll,
-                                        NULL, 32, MBEDTLS_ENTROPY_SOURCE_STRONG);
+    int es = mbedtls_entropy_add_source(&_urt_entropy, urt_platform_entropy_poll, NULL, 32, MBEDTLS_ENTROPY_SOURCE_STRONG);
     if (es != 0)
     {
         mbedtls_entropy_free(&_urt_entropy);
@@ -119,8 +118,7 @@ int urt_rng_init(void)
     }
 #endif
     mbedtls_ctr_drbg_init(&_urt_ctr_drbg);
-    int ret = mbedtls_ctr_drbg_seed(&_urt_ctr_drbg, mbedtls_entropy_func,
-                                     &_urt_entropy, NULL, 0);
+    int ret = mbedtls_ctr_drbg_seed(&_urt_ctr_drbg, mbedtls_entropy_func, &_urt_entropy, NULL, 0);
     if (ret != 0)
     {
         mbedtls_ctr_drbg_free(&_urt_ctr_drbg);
@@ -169,9 +167,7 @@ static void _urt_p256_attr(psa_key_attributes_t *attr)
     *attr = psa_key_attributes_init();
     psa_set_key_type(attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
     psa_set_key_bits(attr, 256);
-    psa_set_key_usage_flags(attr, PSA_KEY_USAGE_SIGN_HASH
-                                | PSA_KEY_USAGE_VERIFY_HASH
-                                | PSA_KEY_USAGE_EXPORT);
+    psa_set_key_usage_flags(attr, PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH | PSA_KEY_USAGE_EXPORT);
     psa_set_key_algorithm(attr, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
 }
 
@@ -195,17 +191,12 @@ int urt_pk_gen_ec_p256_key(mbedtls_pk_context *pk)
     return ret;
 }
 
-int urt_pk_sign(mbedtls_pk_context *ctx,
-                const unsigned char *hash, size_t hash_len,
-                unsigned char *sig, size_t sig_size, size_t *sig_len)
+int urt_pk_sign(mbedtls_pk_context *ctx, const unsigned char *hash, size_t hash_len, unsigned char *sig, size_t sig_size, size_t *sig_len)
 {
-    return mbedtls_pk_sign(ctx, MBEDTLS_MD_SHA256,
-                            hash, hash_len, sig, sig_size, sig_len);
+    return mbedtls_pk_sign(ctx, MBEDTLS_MD_SHA256, hash, hash_len, sig, sig_size, sig_len);
 }
 
-int urt_pk_import_ec_p256_key(mbedtls_pk_context *pk,
-                               const unsigned char *d, size_t d_len,
-                               const unsigned char *xy, size_t xy_len)
+int urt_pk_import_ec_p256_key(mbedtls_pk_context *pk, const unsigned char *d, size_t d_len, const unsigned char *xy, size_t xy_len)
 {
     // P-256 private key is the 32-byte big-endian d. xy is recomputable.
     (void)xy; (void)xy_len;
@@ -229,16 +220,16 @@ int urt_pk_import_ec_p256_key(mbedtls_pk_context *pk,
     return ret;
 }
 
-int urt_pk_export_privkey_d(mbedtls_pk_context *pk,
-                             unsigned char *buf, size_t buflen,
-                             size_t *olen)
+int urt_pk_export_privkey_d(mbedtls_pk_context *pk, unsigned char *buf, size_t buflen, size_t *olen)
 {
     if (buflen < 32)
         return MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL;
 
     // Pull the key material out of pk into a fresh PSA handle, export, drop.
-    psa_key_attributes_t attr = psa_key_attributes_init();
-    psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT);
+    // pk_import_into_psa rejects attributes whose key type doesn't match pk.
+    psa_key_attributes_t attr;
+    _urt_p256_attr(&attr);
+
     mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
     int ret = mbedtls_pk_import_into_psa(pk, &attr, &key_id);
     if (ret != 0)
@@ -263,30 +254,23 @@ int urt_pk_gen_ec_p256_key(mbedtls_pk_context *pk)
     if (ret != 0)
         return ret;
     // mbedtls_pk_ec() is deprecated in 3.1+ but present in all 2.x and 3.x.
-    return mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, mbedtls_pk_ec(*pk),
-                                urt_rng_callback, NULL);
+    return mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, mbedtls_pk_ec(*pk), urt_rng_callback, NULL);
 }
 
 // Always signs with SHA-256. The md_type_t enum values changed between
 // mbedtls 2.x and 3.x, so we resolve the correct value here in C.
-int urt_pk_sign(mbedtls_pk_context *ctx,
-                const unsigned char *hash, size_t hash_len,
-                unsigned char *sig, size_t sig_size, size_t *sig_len)
+int urt_pk_sign(mbedtls_pk_context *ctx, const unsigned char *hash, size_t hash_len, unsigned char *sig, size_t sig_size, size_t *sig_len)
 {
 #if MBEDTLS_VERSION_MAJOR >= 3
-    return mbedtls_pk_sign(ctx, MBEDTLS_MD_SHA256, hash, hash_len,
-                            sig, sig_size, sig_len, urt_rng_callback, NULL);
+    return mbedtls_pk_sign(ctx, MBEDTLS_MD_SHA256, hash, hash_len, sig, sig_size, sig_len, urt_rng_callback, NULL);
 #else
     (void)sig_size;
-    return mbedtls_pk_sign(ctx, MBEDTLS_MD_SHA256, hash, hash_len,
-                            sig, sig_len, urt_rng_callback, NULL);
+    return mbedtls_pk_sign(ctx, MBEDTLS_MD_SHA256, hash, hash_len, sig, sig_len, urt_rng_callback, NULL);
 #endif
 }
 
 // Import raw EC P-256 key components (d, X, Y) into a pk context.
-int urt_pk_import_ec_p256_key(mbedtls_pk_context *pk,
-                               const unsigned char *d, size_t d_len,
-                               const unsigned char *xy, size_t xy_len)
+int urt_pk_import_ec_p256_key(mbedtls_pk_context *pk, const unsigned char *d, size_t d_len, const unsigned char *xy, size_t xy_len)
 {
     int ret = mbedtls_pk_setup(pk, mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
     if (ret != 0)
@@ -312,9 +296,7 @@ int urt_pk_import_ec_p256_key(mbedtls_pk_context *pk,
 }
 
 // Export the raw private key scalar d (32 bytes for P-256).
-int urt_pk_export_privkey_d(mbedtls_pk_context *pk,
-                             unsigned char *buf, size_t buflen,
-                             size_t *olen)
+int urt_pk_export_privkey_d(mbedtls_pk_context *pk, unsigned char *buf, size_t buflen, size_t *olen)
 {
     mbedtls_ecp_keypair *ec = mbedtls_pk_ec(*pk);
 #if MBEDTLS_VERSION_MAJOR >= 3
@@ -334,9 +316,7 @@ int urt_pk_export_privkey_d(mbedtls_pk_context *pk,
 
 // Export the public key as an uncompressed EC point (0x04 || X || Y).
 // mbedtls_pk_write_pubkey_der stays public in 4.x, so this needs no branch.
-int urt_pk_export_pubkey_xy(mbedtls_pk_context *pk,
-                             unsigned char *buf, size_t buflen,
-                             size_t *olen)
+int urt_pk_export_pubkey_xy(mbedtls_pk_context *pk, unsigned char *buf, size_t buflen, size_t *olen)
 {
     unsigned char der[256];
     int len = mbedtls_pk_write_pubkey_der(pk, der, sizeof(der));
@@ -366,8 +346,7 @@ int urt_gcm_encrypt(const unsigned char *key, size_t key_len,
     mbedtls_gcm_init(&ctx);
     int ret = mbedtls_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key, (unsigned)(key_len * 8));
     if (ret == 0)
-        ret = mbedtls_gcm_crypt_and_tag(&ctx, MBEDTLS_GCM_ENCRYPT, pt_len, iv, iv_len,
-                                        aad, aad_len, plaintext, ciphertext, tag_len, tag);
+        ret = mbedtls_gcm_crypt_and_tag(&ctx, MBEDTLS_GCM_ENCRYPT, pt_len, iv, iv_len, aad, aad_len, plaintext, ciphertext, tag_len, tag);
     mbedtls_gcm_free(&ctx);
     return ret;
 }
@@ -383,8 +362,7 @@ int urt_gcm_decrypt(const unsigned char *key, size_t key_len,
     mbedtls_gcm_init(&ctx);
     int ret = mbedtls_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key, (unsigned)(key_len * 8));
     if (ret == 0)
-        ret = mbedtls_gcm_auth_decrypt(&ctx, ct_len, iv, iv_len, aad, aad_len,
-                                       tag, tag_len, ciphertext, plaintext);
+        ret = mbedtls_gcm_auth_decrypt(&ctx, ct_len, iv, iv_len, aad, aad_len, tag, tag_len, ciphertext, plaintext);
     mbedtls_gcm_free(&ctx);
     return ret;
 }
@@ -395,9 +373,7 @@ int urt_gcm_decrypt(const unsigned char *key, size_t key_len,
 // WPA2 4-way handshake GTK decryption).
 // =====================================================================
 
-int urt_aes_ecb_decrypt(const unsigned char *key, size_t key_len,
-                        const unsigned char *cipher_block,
-                        unsigned char *plain_block)
+int urt_aes_ecb_decrypt(const unsigned char *key, size_t key_len, const unsigned char *cipher_block, unsigned char *plain_block)
 {
     mbedtls_aes_context ctx;
     mbedtls_aes_init(&ctx);
@@ -408,9 +384,7 @@ int urt_aes_ecb_decrypt(const unsigned char *key, size_t key_len,
     return ret;
 }
 
-int urt_aes_ecb_encrypt(const unsigned char *key, size_t key_len,
-                        const unsigned char *plain_block,
-                        unsigned char *cipher_block)
+int urt_aes_ecb_encrypt(const unsigned char *key, size_t key_len, const unsigned char *plain_block, unsigned char *cipher_block)
 {
     mbedtls_aes_context ctx;
     mbedtls_aes_init(&ctx);
@@ -430,8 +404,7 @@ int urt_aes_ecb_encrypt(const unsigned char *key, size_t key_len,
 // peer_xy:      64-byte uncompressed peer point (X || Y, no 0x04 prefix).
 // shared_x_out: 32 bytes -- big-endian X coordinate of (priv_d * peer_point).
 int urt_ecdh_p256_compute_shared(const unsigned char *priv_d, size_t priv_len,
-                                  const unsigned char *peer_xy, size_t peer_xy_len,
-                                  unsigned char *shared_x_out)
+                                 const unsigned char *peer_xy, size_t peer_xy_len, unsigned char *shared_x_out)
 {
     if (priv_len != 32 || peer_xy_len != 64)
         return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;

--- a/src/urt/internal/mbedtls.d
+++ b/src/urt/internal/mbedtls.d
@@ -30,13 +30,7 @@ int urt_rng_callback(void* p_rng, ubyte* output, size_t len);  // f_rng-shaped, 
 
 // --- PK (public key abstraction) ---
 
-struct mbedtls_pk_info_t; // opaque
-
-struct mbedtls_pk_context
-{
-    const(mbedtls_pk_info_t)* pk_info;
-    void* pk_ctx;
-}
+struct mbedtls_pk_context;
 
 void mbedtls_pk_init(mbedtls_pk_context* ctx);
 void mbedtls_pk_free(mbedtls_pk_context* ctx);
@@ -51,45 +45,26 @@ void mbedtls_pk_free(mbedtls_pk_context* ctx);
 int urt_pk_gen_ec_p256_key(mbedtls_pk_context* pk);
 int urt_pk_sign(mbedtls_pk_context* ctx, const(ubyte)* hash, size_t hash_len,
                 ubyte* sig, size_t sig_size, size_t* sig_len);
-int urt_pk_import_ec_p256_key(mbedtls_pk_context* pk,
-                              const(ubyte)* d, size_t d_len,
-                              const(ubyte)* xy, size_t xy_len);
+int urt_pk_import_ec_p256_key(mbedtls_pk_context* pk, const(ubyte)* d, size_t d_len, const(ubyte)* xy, size_t xy_len);
 int urt_pk_export_privkey_d(mbedtls_pk_context* pk, ubyte* buf, size_t buflen, size_t* olen);
 int urt_pk_export_pubkey_xy(mbedtls_pk_context* pk, ubyte* buf, size_t buflen, size_t* olen);
 
 
 // --- ECDH P-256 (from urt/internal/mbedtls.c) ---
 
-int urt_ecdh_p256_compute_shared(const(ubyte)* priv_d, size_t priv_len,
-                                  const(ubyte)* peer_xy, size_t peer_xy_len,
-                                  ubyte* shared_x_out);
+int urt_ecdh_p256_compute_shared(const(ubyte)* priv_d, size_t priv_len, const(ubyte)* peer_xy, size_t peer_xy_len, ubyte* shared_x_out);
 
 
 // --- AES-GCM one-shot (from urt/internal/mbedtls.c) ---
 
-int urt_gcm_encrypt(const(ubyte)* key, size_t key_len,
-                    const(ubyte)* iv, size_t iv_len,
-                    const(ubyte)* aad, size_t aad_len,
-                    const(ubyte)* plaintext, size_t pt_len,
-                    ubyte* ciphertext,
-                    ubyte* tag, size_t tag_len);
-
-int urt_gcm_decrypt(const(ubyte)* key, size_t key_len,
-                    const(ubyte)* iv, size_t iv_len,
-                    const(ubyte)* aad, size_t aad_len,
-                    const(ubyte)* ciphertext, size_t ct_len,
-                    const(ubyte)* tag, size_t tag_len,
-                    ubyte* plaintext);
+int urt_gcm_encrypt(const(ubyte)* key, size_t key_len, const(ubyte)* iv, size_t iv_len, const(ubyte)* aad, size_t aad_len, const(ubyte)* plaintext, size_t pt_len, ubyte* ciphertext, ubyte* tag, size_t tag_len);
+int urt_gcm_decrypt(const(ubyte)* key, size_t key_len, const(ubyte)* iv, size_t iv_len, const(ubyte)* aad, size_t aad_len, const(ubyte)* ciphertext, size_t ct_len, const(ubyte)* tag, size_t tag_len, ubyte* plaintext);
 
 
 // --- AES single-block ECB (RFC 3394 key-wrap building blocks) ---
 
-int urt_aes_ecb_decrypt(const(ubyte)* key, size_t key_len,
-                        const(ubyte)* cipher_block,
-                        ubyte* plain_block);
-int urt_aes_ecb_encrypt(const(ubyte)* key, size_t key_len,
-                        const(ubyte)* plain_block,
-                        ubyte* cipher_block);
+int urt_aes_ecb_encrypt(const(ubyte)* key, size_t key_len, const(ubyte)* plain_block, ubyte* cipher_block);
+int urt_aes_ecb_decrypt(const(ubyte)* key, size_t key_len, const(ubyte)* cipher_block, ubyte* plain_block);
 
 
 // --- X.509 certificate ---
@@ -153,8 +128,26 @@ enum MBEDTLS_SSL_VERIFY_REQUIRED = 2;
 size_t urt_sizeof_x509_crt();
 size_t urt_sizeof_ssl_context();
 size_t urt_sizeof_ssl_config();
+size_t urt_sizeof_pk_context();
 
 import urt.mem.alloc;
+
+mbedtls_pk_context* urt_pk_new()
+{
+    auto ctx = cast(mbedtls_pk_context*)alloc(urt_sizeof_pk_context()).ptr;
+    if (ctx)
+        mbedtls_pk_init(ctx);
+    return ctx;
+}
+
+void urt_pk_delete(mbedtls_pk_context* pk)
+{
+    if (pk)
+    {
+        mbedtls_pk_free(pk);
+        free((cast(void*)pk)[0..urt_sizeof_pk_context()]);
+    }
+}
 
 mbedtls_x509_crt* urt_x509_crt_new()
 {


### PR DESCRIPTION
...because C library changes between versions.