### PR TITLE
map: construct the kvp in AVLTreeNode's copy ctor instead of assigning it

### DIFF
--- a/src/urt/map.d
+++ b/src/urt/map.d
@@ -567,7 +567,7 @@ nothrow @nogc:
     {
         left = rh.left;
         right = rh.right;
-        kvp = rh.kvp;
+        emplace(&kvp, rh.kvp);
         _base.height = rh._base.height;
     }
 


### PR DESCRIPTION
## Problem

`KVP` disables its postblit and provides a copy constructor instead, so it is copy-*constructible* but not copy-*assignable*:

```d
struct KVP(K, V)
{
    this(this) @disable;
    this(ref KVP!(K, V) kvp) { ... }
}
```

`AVLTreeNode`'s copy constructor then did:

```d
this(ref AVLTreeNode rh)
{
    left = rh.left;      // property setter, touches `this`
    right = rh.right;    // property setter, touches `this`
    kvp = rh.kvp;        // <-- assignment, not initialisation
    _base.height = rh._base.height;
}
```

Inside a constructor D treats the first assignment to a field as initialisation, which would invoke the copy constructor. But `left` and `right` are property setters that call into `this` first, so by the time we reach `kvp` it is a genuine assignment. The compiler looks for an `opAssign`, finds the disabled postblit, and rejects it:

```
Error: struct urt.kvp.KVP!(K, V).KVP is not copyable because it has a disabled postblit
```

## Why it has gone unnoticed

The failure is latent. `AVLTreeNode.this(ref AVLTreeNode)` is only instantiated when something actually copies a node, so the vast majority of `Map` instantiations never reach it.

OpenWatt's `Map!(Port*, float)` in `src/apps/energy/attribution.d` does, and fails to compile against current urt master.

## Fix

`emplace` the field so the copy constructor runs. That is what was intended, and it matches the two `opAssign` overloads immediately below, which already `emplace(&this, rh)`.

## Testing

With this change OpenWatt's esp32-s3 D build compiles cleanly against urt master, where it previously failed on the `Map!(Port*, float)` instantiation. No behavioural change for any `Map` that was already compiling: the field was uninitialised at that point either way, and `emplace` performs the same copy the constructor was meant to.