### PR TITLE
esp32: give the i2c and spi completion callbacks distinct C symbols

### DIFF
--- a/src/urt/driver/esp32/i2c.d
+++ b/src/urt/driver/esp32/i2c.d
@@ -30,7 +30,7 @@ Result i2c_hw_submit(ref I2cBus bus, ref I2cOperation operation, ref const I2cTr
 {
     int result = ow_i2c_submit(bus.driver_data, transfer.address, transfer.address_mode, bus.frequency,
         transfer.write_data.ptr, transfer.write_data.length, cast(void*)transfer.read_data.ptr, transfer.read_data.length,
-        timeout_ms(transfer.timeout), &operation_complete, &operation);
+        timeout_ms(transfer.timeout), &i2c_operation_complete, &operation);
     return result == 0 ? Result.success : InternalResult.failed;
 }
 
@@ -53,7 +53,7 @@ int timeout_ms(Duration timeout)
     return cast(int)value;
 }
 
-extern(C) bool operation_complete(void* context, int result)
+extern(C) bool i2c_operation_complete(void* context, int result)
 {
     I2cError error;
     switch (result)

--- a/src/urt/driver/esp32/spi.d
+++ b/src/urt/driver/esp32/spi.d
@@ -28,7 +28,7 @@ void spi_hw_close(ref SpiBus bus)
 
 Result spi_hw_submit(ref SpiBus bus, ref SpiOperation operation, ref const SpiTransfer transfer)
 {
-    int result = ow_spi_submit(bus.driver_data, transfer.write_data.ptr, transfer.write_data.length, cast(void*)transfer.read_data.ptr, transfer.read_data.length, &operation_complete, &operation);
+    int result = ow_spi_submit(bus.driver_data, transfer.write_data.ptr, transfer.write_data.length, cast(void*)transfer.read_data.ptr, transfer.read_data.length, &spi_operation_complete, &operation);
     return result == 0 ? Result.success : InternalResult.failed;
 }
 
@@ -54,7 +54,7 @@ extern(C) alias SpiCompletion = bool function(void*, int);
 int gpio_arg(ubyte gpio)
     => gpio == ubyte.max ? -1 : gpio;
 
-@critical extern(C) bool operation_complete(void* context, int result)
+@critical extern(C) bool spi_operation_complete(void* context, int result)
 {
     return spi_complete(*cast(SpiOperation*)context, result == 0 ? SpiError.none : SpiError.bus, SpiCallbackContext.interrupt);
 }


### PR DESCRIPTION
## Problem

Both ESP32 backends declared their completion trampoline with the same name:

```d
// urt/driver/esp32/i2c.d:56
extern(C) bool operation_complete(void* context, int result)

// urt/driver/esp32/spi.d:57
@critical extern(C) bool operation_complete(void* context, int result)
```

`extern(C)` suppresses D's module mangling, so both emit the same unmangled global symbol. `private` does not help here: it is module visibility, not linkage.

The linker silently keeps one. In an OpenWatt esp32-s3 image there was exactly one:

```
$ nm openwatt.elf | grep -w operation_complete
4037e0a4 T operation_complete      <- IRAM: the @critical SPI one won
```

So every I2C completion dispatched into the **SPI** handler, which reinterpreted the `I2cOperation*` as a `SpiOperation*` and tripped the sanity check in `spi_complete`:

```
*** ASSERT: Assertion failed at third_party/urt/src/urt/driver/spi.d:260
abort() was called at PC 0x42006fb6 on core 0
```

Decoded backtrace, showing the I2C worker crossing into SPI:

```
ow_i2c_worker (ow_shim.c:891)
  -> operation_complete
    -> urt.driver.spi.spi_complete(...)
      -> urt_assert
```

Any board with an I2C peripheral configured aborts on its first transfer and boot-loops.

## Fix

The names are only taken by address within their own module, so nothing external depends on them. Rename to `i2c_operation_complete` and `spi_operation_complete`.

## Testing

ESP32-S3 (Waveshare RS485-CAN board) with a PCF85063 RTC on I2C:

- before: 17 boots in 30 seconds, aborting at `spi.d:260` on the first I2C transfer
- after: 0 reboots, 0 asserts, I2C transfers complete and the RTC driver reaches `Running`

`nm` now shows two distinct symbols rather than one shared one.