### PR TITLE
file: pluggable filesystem backends, with SPIFFS on Espressif

### DIFF
--- a/platforms.mk
+++ b/platforms.mk
@@ -535,6 +535,20 @@ else ifeq ($(USE_LWIP),1)
     DFLAGS := $(DFLAGS) $(VERSION_FLAG)lwIP
 endif
 
+# Filesystem backends: urt.file has no backend on targets without a host
+# filesystem. Selection is additive -- each enabled backend is consulted in
+# turn, so a file may be sourced from whichever one holds it.
+ifeq ($(USE_SPIFFS),)
+  ifneq ($(filter esp%,$(PLATFORM)),)
+    USE_SPIFFS := 1
+  else
+    USE_SPIFFS := 0
+  endif
+endif
+ifeq ($(USE_SPIFFS),1)
+    DFLAGS := $(DFLAGS) $(VERSION_FLAG)UseSpiffs
+endif
+
 ifeq ($(CONFIG),unittest)
     DFLAGS := $(DFLAGS) -unittest
 endif

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -2091,3 +2091,213 @@ void ow_lwip_freeaddrinfo(struct addrinfo *ai)
     lwip_freeaddrinfo(ai);
 }
 #endif
+
+
+// =====================================================================
+// SPIFFS -- urt.file backend
+//
+// TRAJECTORY, not the destination.
+//
+// This rides newlib's open/read/write, which reach SPIFFS through IDF's VFS.
+// That is why platforms/esp32s3/sdkconfig.defaults has to enable
+// CONFIG_VFS_SUPPORT_IO and _DIR: with them off, open() is a stub returning
+// ENOSYS even though the filesystem mounted fine. Those were deliberately off
+// to save space, and turning them on costs every ESP target the whole syscall
+// layer for the sake of a stopgap filesystem.
+//
+// Where this should go: mount SPIFFS directly with SPIFFS_mount() and read /
+// write / erase callbacks over esp_partition_*, then call SPIFFS_open() and
+// friends. No VFS, no newlib, no "/spiffs" prefixing, and the sdkconfig change
+// reverts. The blocker is that IDF keeps spiffs.h in PRIV_INCLUDE_DIRS and
+// esp_vfs_spiffs_register() keeps its spiffs* handle private, so it means
+// either widening the include path or vendoring the SPIFFS sources -- the
+// latter being what a non-Espressif target would need anyway.
+//
+// littlefs wants exactly that shape too (bring your own block device), so the
+// work is not thrown away when this is replaced.
+// =====================================================================
+
+#ifdef OW_USE_SPIFFS
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "esp_spiffs.h"
+
+#define OW_SPIFFS_ROOT "/spiffs"
+
+// Registration state is ours, not esp_spiffs_mounted()'s: that reports whether
+// the partition is mounted internally, which a format also does, and mounting
+// the partition does not put a VFS on OW_SPIFFS_ROOT. -1 latches a failed mount
+// so an unformatted partition is not retried on every access.
+static bool ow_spiffs_registered = false;
+static int ow_spiffs_mount_state = 0;
+
+static bool ow_spiffs_ready(void)
+{
+    if (ow_spiffs_registered)
+        return true;
+    if (ow_spiffs_mount_state < 0)
+        return false;
+
+    esp_vfs_spiffs_conf_t conf = {
+        .base_path = OW_SPIFFS_ROOT,
+        .partition_label = NULL,
+        .max_files = 4,
+        .format_if_mount_failed = false,
+    };
+    if (esp_vfs_spiffs_register(&conf) != ESP_OK)
+    {
+        ow_spiffs_mount_state = -1;
+        return false;
+    }
+    ow_spiffs_registered = true;
+    return true;
+}
+
+// Anchor caller paths under the mount point.
+static bool ow_spiffs_path(const char *path, size_t path_len, char *buffer, size_t buffer_size)
+{
+    const size_t root = sizeof(OW_SPIFFS_ROOT) - 1;
+    size_t skip = (path_len && path[0] == '/') ? 1 : 0;
+    if (root + 1 + (path_len - skip) + 1 > buffer_size)
+        return false;
+    memcpy(buffer, OW_SPIFFS_ROOT, root);
+    buffer[root] = '/';
+    memcpy(buffer + root + 1, path + skip, path_len - skip);
+    buffer[root + 1 + path_len - skip] = 0;
+    return true;
+}
+
+int urt_spiffs_exists(const char *path, size_t path_len)
+{
+    char buffer[128];
+    if (!ow_spiffs_ready() || !ow_spiffs_path(path, path_len, buffer, sizeof(buffer)))
+        return 0;
+    struct stat st;
+    return stat(buffer, &st) == 0 && S_ISREG(st.st_mode);
+}
+
+int urt_spiffs_open(const char *path, size_t path_len, bool write, bool truncate)
+{
+    char buffer[128];
+    if (!ow_spiffs_ready() || !ow_spiffs_path(path, path_len, buffer, sizeof(buffer)))
+        return -1;
+    int flags = write ? (O_RDWR | O_CREAT) : O_RDONLY;
+    if (write && truncate)
+        flags |= O_TRUNC;
+    return open(buffer, flags, 0644);
+}
+
+ptrdiff_t urt_spiffs_read(int fd, void *buffer, size_t length)
+{
+    return read(fd, buffer, length);
+}
+
+ptrdiff_t urt_spiffs_write(int fd, const void *data, size_t length)
+{
+    return write(fd, data, length);
+}
+
+void urt_spiffs_close(int fd)
+{
+    close(fd);
+}
+
+uint64_t urt_spiffs_size(int fd)
+{
+    struct stat st;
+    return fstat(fd, &st) == 0 ? (uint64_t)st.st_size : 0;
+}
+
+int64_t urt_spiffs_seek(int fd, int64_t offset, int whence)
+{
+    return lseek(fd, (off_t)offset, whence);
+}
+
+int urt_spiffs_truncate(int fd, uint64_t length)
+{
+    return ftruncate(fd, (off_t)length);
+}
+
+int urt_spiffs_sync(int fd)
+{
+    return fsync(fd);
+}
+
+int urt_spiffs_unlink(const char *path, size_t path_len)
+{
+    char buffer[128];
+    if (!ow_spiffs_ready() || !ow_spiffs_path(path, path_len, buffer, sizeof(buffer)))
+        return -1;
+    return unlink(buffer);
+}
+
+int urt_spiffs_rename(const char *from, size_t from_len, const char *to, size_t to_len)
+{
+    char from_buffer[128], to_buffer[128];
+    if (!ow_spiffs_ready() ||
+        !ow_spiffs_path(from, from_len, from_buffer, sizeof(from_buffer)) ||
+        !ow_spiffs_path(to, to_len, to_buffer, sizeof(to_buffer)))
+        return -1;
+    return rename(from_buffer, to_buffer);
+}
+
+int urt_spiffs_stat(const char *path, size_t path_len, uint64_t *size)
+{
+    char buffer[128];
+    if (!ow_spiffs_ready() || !ow_spiffs_path(path, path_len, buffer, sizeof(buffer)))
+        return -1;
+    struct stat st;
+    if (stat(buffer, &st) != 0)
+        return -1;
+    *size = (uint64_t)st.st_size;
+    return 0;
+}
+
+// Formatting a multi-megabyte partition blocks for long enough to starve the
+// watchdog, so it runs on its own task and the caller polls for completion.
+enum { OW_SPIFFS_FORMAT_IDLE = 0, OW_SPIFFS_FORMAT_RUNNING, OW_SPIFFS_FORMAT_COMPLETE, OW_SPIFFS_FORMAT_FAILED };
+
+static volatile int ow_spiffs_format_state = OW_SPIFFS_FORMAT_IDLE;
+
+static void ow_spiffs_format_task(void *argument)
+{
+    (void)argument;
+    esp_err_t err = esp_spiffs_format(NULL);
+    if (err == ESP_OK)
+    {
+        // Formatting leaves the partition mounted but unregistered; drop that so
+        // the next access can register a VFS on it.
+        if (!ow_spiffs_registered && esp_spiffs_mounted(NULL))
+            esp_vfs_spiffs_unregister(NULL);
+        ow_spiffs_mount_state = 0;
+    }
+    ow_spiffs_format_state = (err == ESP_OK) ? OW_SPIFFS_FORMAT_COMPLETE : OW_SPIFFS_FORMAT_FAILED;
+    vTaskDelete(NULL);
+}
+
+int urt_spiffs_format_begin(void)
+{
+    if (ow_spiffs_format_state == OW_SPIFFS_FORMAT_RUNNING)
+        return 0;
+    ow_spiffs_format_state = OW_SPIFFS_FORMAT_RUNNING;
+    if (xTaskCreate(ow_spiffs_format_task, "ow-spiffs-fmt", 4096, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
+    {
+        ow_spiffs_format_state = OW_SPIFFS_FORMAT_FAILED;
+        return -1;
+    }
+    return 0;
+}
+
+int urt_spiffs_available(void)
+{
+    return ow_spiffs_ready() ? 1 : 0;
+}
+
+int urt_spiffs_format_status(void)
+{
+    return ow_spiffs_format_state;
+}
+
+#endif // OW_USE_SPIFFS

--- a/src/urt/file.d
+++ b/src/urt/file.d
@@ -8,6 +8,26 @@ import urt.time;
 
 public import urt.result;
 
+// Backend selection is additive: each enabled backend is consulted in turn.
+version (UseSpiffs) version = HasFileBackend;
+
+version (HasFileBackend)
+{
+    import urt.meta : AliasSeq;
+
+    version (UseSpiffs)
+    {
+        import urt.fs.spiffs;
+        private alias SpiffsBackends = AliasSeq!(SpiffsBackend);
+    }
+    else
+        private alias SpiffsBackends = AliasSeq!();
+
+    private alias FileBackends = AliasSeq!(SpiffsBackends);
+
+    private enum : int { seek_set = 0, seek_cur = 1, seek_end = 2 }
+}
+
 alias SystemTime = void;
 
 version(Windows)
@@ -109,7 +129,11 @@ struct File
     else version (Posix)
         int fd = -1;
     else version (FreeStanding)
+    {
         int fd = -1;
+        version (HasFileBackend)
+            ubyte backend = ubyte.max;
+    }
     else
         static assert(0, "File: not implemented for this platform");
 }
@@ -126,6 +150,13 @@ bool file_exists(const(char)[] path)
         stat_t st;
         return stat(path.tstringz, &st) == 0 && S_ISREG(st.st_mode);
     }
+    else version (HasFileBackend)
+    {
+        static foreach (B; FileBackends)
+            if (B.exists(path))
+                return true;
+        return false;
+    }
     else
         return false;
 }
@@ -141,6 +172,15 @@ Result delete_file(const(char)[] path)
     {
         if (unlink(path.tstringz) == -1)
             return errno_result();
+    }
+    else version (HasFileBackend)
+    {
+        static foreach (B; FileBackends)
+        {
+            if (B.exists(path))
+                return B.remove(path) ? Result.success : InternalResult.failed;
+        }
+        return InternalResult.failed;
     }
     else
         return InternalResult.unsupported; // no filesystem on this platform
@@ -159,6 +199,15 @@ Result rename_file(const(char)[] oldPath, const(char)[] newPath)
     {
         if (int result = rename(oldPath.tstringz, newPath.tstringz) != 0)
            return posix_result(result);
+    }
+    else version (HasFileBackend)
+    {
+        static foreach (B; FileBackends)
+        {
+            if (B.exists(oldPath))
+                return B.rename(oldPath, newPath) ? Result.success : InternalResult.failed;
+        }
+        return InternalResult.failed;
     }
     else
         return InternalResult.unsupported; // no filesystem on this platform
@@ -268,6 +317,22 @@ Result get_file_attributes(const(char)[] path, out FileAttributes outAttributes)
         // TODO
         assert(false);
     }
+    else version (HasFileBackend)
+    {
+        static foreach (B; FileBackends)
+        {
+            if (B.exists(path))
+            {
+                ulong size;
+                if (!B.stat(path, size))
+                    return InternalResult.failed;
+                outAttributes.attributes = FileAttributeFlag.None;
+                outAttributes.size = size;
+                return Result.success;
+            }
+        }
+        return InternalResult.failed;
+    }
     else
         return InternalResult.unsupported; // no filesystem on this platform
 
@@ -311,6 +376,14 @@ Result get_attributes(ref const File file, out FileAttributes outAttributes)
     {
         // TODO
         assert(false);
+    }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return InternalResult.invalid_parameter;
+        outAttributes.attributes = FileAttributeFlag.None;
+        outAttributes.size = file.get_size();
+        return Result.success;
     }
     else
         return InternalResult.unsupported; // no filesystem on this platform
@@ -509,6 +582,45 @@ Result open(ref File file, const(char)[] path, FileOpenMode mode, FileOpenFlags 
         if (mode == FileOpenMode.WriteAppend || mode == FileOpenMode.ReadWriteAppend)
             lseek(file.fd, 0, SEEK_END);
     }
+    else version (HasFileBackend)
+    {
+        const bool write = mode != FileOpenMode.ReadExisting;
+        const bool truncate = mode == FileOpenMode.WriteTruncate || mode == FileOpenMode.ReadWriteTruncate;
+        const bool create = mode != FileOpenMode.ReadExisting && mode != FileOpenMode.ReadWriteExisting;
+
+        // Prefer the backend already holding it, so writes land on the copy
+        // that reads will find.
+        static foreach (i, B; FileBackends)
+        {
+            if (file.fd < 0 && B.exists(path))
+            {
+                int fd = B.open(path, write, truncate);
+                if (fd >= 0)
+                {
+                    file.fd = fd;
+                    file.backend = i;
+                }
+            }
+        }
+        if (file.fd < 0 && create)
+        {
+            int fd = FileBackends[0].open(path, true, truncate);
+            if (fd >= 0)
+            {
+                file.fd = fd;
+                file.backend = 0;
+            }
+        }
+        if (file.fd < 0)
+        {
+            static foreach (B; FileBackends)
+            {
+                if (B.available())
+                    return InternalResult.failed;
+            }
+            return InternalResult.unsupported;
+        }
+    }
     else
         return InternalResult.unsupported; // no filesystem on this platform
 
@@ -541,6 +653,18 @@ void close(ref File file)
         urt.internal.sys.posix.close(file.fd);
         file.fd = -1;
     }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return;
+        static foreach (i, B; FileBackends)
+        {
+            if (file.backend == i)
+                B.close(file.fd);
+        }
+        file.fd = -1;
+        file.backend = ubyte.max;
+    }
 }
 
 ulong get_size(ref const File file)
@@ -558,6 +682,17 @@ ulong get_size(ref const File file)
         if (fstat(file.fd, &fs))
             return 0;
         return fs.st_size;
+    }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return 0;
+        static foreach (i, B; FileBackends)
+        {
+            if (file.backend == i)
+                return B.size(file.fd);
+        }
+        return 0;
     }
     else
         return 0;
@@ -608,6 +743,16 @@ Result set_size(ref File file, ulong size)
         if (ftruncate(file.fd, size))
             return errno_result();
     }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return InternalResult.invalid_parameter;
+        static foreach (i, B; FileBackends)
+        {
+            if (file.backend == i && !B.set_size(file.fd, size))
+                return InternalResult.failed;
+        }
+    }
     else
         return InternalResult.unsupported; // no filesystem on this platform
     return Result.success;
@@ -625,6 +770,21 @@ ulong get_pos(ref const File file)
     }
     else version (Posix)
         return lseek(file.fd, 0, SEEK_CUR);
+    else version (HasFileBackend)
+    {
+        if (file.fd >= 0)
+        {
+            static foreach (i, B; FileBackends)
+            {
+                if (file.backend == i)
+                {
+                    long pos = B.seek(file.fd, 0, seek_cur);
+                    return pos < 0 ? 0 : cast(ulong)pos;
+                }
+            }
+        }
+        return 0;
+    }
     else
         return 0;
 }
@@ -643,6 +803,16 @@ Result set_pos(ref File file, ulong offset)
         off_t rc = lseek(file.fd, offset, SEEK_SET);
         if (rc < 0)
             return errno_result();
+    }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return InternalResult.invalid_parameter;
+        static foreach (i, B; FileBackends)
+        {
+            if (file.backend == i && B.seek(file.fd, cast(long)offset, seek_set) < 0)
+                return InternalResult.failed;
+        }
     }
     else
         return InternalResult.unsupported; // no filesystem on this platform
@@ -669,6 +839,21 @@ Result read(ref File file, void[] buffer, out size_t bytesRead)
         if (n < 0)
             return errno_result();
         bytesRead = n;
+    }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return InternalResult.invalid_parameter;
+        static foreach (i, B; FileBackends)
+        {
+            if (file.backend == i)
+            {
+                ptrdiff_t n = B.read(file.fd, buffer);
+                if (n < 0)
+                    return InternalResult.failed;
+                bytesRead = n;
+            }
+        }
     }
     else
         return InternalResult.unsupported; // no filesystem on this platform
@@ -702,6 +887,26 @@ Result read_at(ref File file, void[] buffer, ulong offset, out size_t bytesRead)
             return errno_result();
         bytesRead = n;
     }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return InternalResult.invalid_parameter;
+        static foreach (i, B; FileBackends)
+        {
+            if (file.backend == i)
+            {
+                // no pread; emulate it and put the position back
+                long restore = B.seek(file.fd, 0, seek_cur);
+                if (restore < 0 || B.seek(file.fd, cast(long)offset, seek_set) < 0)
+                    return InternalResult.failed;
+                ptrdiff_t n = B.read(file.fd, buffer);
+                B.seek(file.fd, restore, seek_set);
+                if (n < 0)
+                    return InternalResult.failed;
+                bytesRead = n;
+            }
+        }
+    }
     else
         return InternalResult.unsupported; // no filesystem on this platform
     return Result.success;
@@ -722,6 +927,21 @@ Result write(ref File file, const(void)[] data, out size_t bytesWritten)
         if (n < 0)
             return errno_result();
         bytesWritten = n;
+    }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return InternalResult.invalid_parameter;
+        static foreach (i, B; FileBackends)
+        {
+            if (file.backend == i)
+            {
+                ptrdiff_t n = B.write(file.fd, data);
+                if (n < 0)
+                    return InternalResult.failed;
+                bytesWritten = n;
+            }
+        }
     }
     else
         return InternalResult.unsupported; // no filesystem on this platform
@@ -751,6 +971,26 @@ Result write_at(ref File file, const(void)[] data, ulong offset, out size_t byte
             return errno_result();
         bytesWritten = n;
     }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return InternalResult.invalid_parameter;
+        static foreach (i, B; FileBackends)
+        {
+            if (file.backend == i)
+            {
+                // no pwrite; emulate it and put the position back
+                long restore = B.seek(file.fd, 0, seek_cur);
+                if (restore < 0 || B.seek(file.fd, cast(long)offset, seek_set) < 0)
+                    return InternalResult.failed;
+                ptrdiff_t n = B.write(file.fd, data);
+                B.seek(file.fd, restore, seek_set);
+                if (n < 0)
+                    return InternalResult.failed;
+                bytesWritten = n;
+            }
+        }
+    }
     else
         return InternalResult.unsupported; // no filesystem on this platform
     return Result.success;
@@ -767,6 +1007,16 @@ Result flush(ref File file)
     {
         if (fsync(file.fd))
             return errno_result();
+    }
+    else version (HasFileBackend)
+    {
+        if (file.fd < 0)
+            return InternalResult.invalid_parameter;
+        static foreach (i, B; FileBackends)
+        {
+            if (file.backend == i && !B.sync(file.fd))
+                return InternalResult.failed;
+        }
     }
     else
         return InternalResult.unsupported; // no filesystem on this platform

--- a/src/urt/fs/spiffs.d
+++ b/src/urt/fs/spiffs.d
@@ -1,0 +1,91 @@
+module urt.fs.spiffs;
+
+version (UseSpiffs):
+
+nothrow @nogc:
+
+
+enum SpiffsFormatState : ubyte
+{
+    idle,
+    running,
+    complete,
+    failed,
+}
+
+bool format_begin()
+    => urt_spiffs_format_begin() == 0;
+
+SpiffsFormatState format_state()
+    => cast(SpiffsFormatState)urt_spiffs_format_status();
+
+
+// Flat namespace: the whole path is the object name, so paths round trip but
+// there is nothing to enumerate, and SPIFFS_OBJ_NAME_LEN caps them at 31 chars.
+struct SpiffsBackend
+{
+static nothrow @nogc:
+
+    enum name = "spiffs";
+
+    // False when the partition is absent or unformatted, which lets urt.file
+    // separate "no filesystem" from "the operation failed".
+    bool available()
+        => urt_spiffs_available() != 0;
+
+    bool exists(const(char)[] path)
+        => urt_spiffs_exists(path.ptr, path.length) != 0;
+
+    bool stat(const(char)[] path, out ulong size)
+        => urt_spiffs_stat(path.ptr, path.length, &size) == 0;
+
+    bool remove(const(char)[] path)
+        => urt_spiffs_unlink(path.ptr, path.length) == 0;
+
+    bool rename(const(char)[] from, const(char)[] to)
+        => urt_spiffs_rename(from.ptr, from.length, to.ptr, to.length) == 0;
+
+    int open(const(char)[] path, bool write, bool truncate)
+        => urt_spiffs_open(path.ptr, path.length, write, truncate);
+
+    ptrdiff_t read(int fd, void[] buffer)
+        => urt_spiffs_read(fd, buffer.ptr, buffer.length);
+
+    ptrdiff_t write(int fd, const(void)[] data)
+        => urt_spiffs_write(fd, data.ptr, data.length);
+
+    void close(int fd)
+        => urt_spiffs_close(fd);
+
+    ulong size(int fd)
+        => urt_spiffs_size(fd);
+
+    long seek(int fd, long offset, int whence)
+        => urt_spiffs_seek(fd, offset, whence);
+
+    bool set_size(int fd, ulong length)
+        => urt_spiffs_truncate(fd, length) == 0;
+
+    bool sync(int fd)
+        => urt_spiffs_sync(fd) == 0;
+}
+
+
+private extern(C)
+{
+    int urt_spiffs_format_begin();
+    int urt_spiffs_format_status();
+    int urt_spiffs_available();
+    int urt_spiffs_exists(const(char)* path, size_t path_len);
+    int urt_spiffs_stat(const(char)* path, size_t path_len, ulong* size);
+    int urt_spiffs_unlink(const(char)* path, size_t path_len);
+    int urt_spiffs_rename(const(char)* from, size_t from_len, const(char)* to, size_t to_len);
+    int urt_spiffs_open(const(char)* path, size_t path_len, bool write, bool truncate);
+    ptrdiff_t urt_spiffs_read(int fd, void* buffer, size_t length);
+    ptrdiff_t urt_spiffs_write(int fd, const(void)* data, size_t length);
+    void urt_spiffs_close(int fd);
+    ulong urt_spiffs_size(int fd);
+    long urt_spiffs_seek(int fd, long offset, int whence);
+    int urt_spiffs_truncate(int fd, ulong length);
+    int urt_spiffs_sync(int fd);
+}


### PR DESCRIPTION
## Problem

`urt.file` had no backend on bare-metal targets. `version(Posix)` is not defined for a `-none-` triple, so every operation fell through to:

```d
else
    return InternalResult.unsupported; // no filesystem on this platform
```

On ESP32 that surfaces as `ENOTSUP` (134) from `save_file`, which reads like a caller bug rather than a missing platform feature. Nothing could persist: EC keys, TLS certificates, or configuration.

## Backends are additive, not exclusive

Selection is per-backend (`UseSpiffs`, and later `UseLittleFS`), and each enabled backend is consulted in turn:

```d
version (UseSpiffs) version = HasFileBackend;

version (HasFileBackend)
{
    version (UseSpiffs)
        private alias SpiffsBackends = AliasSeq!(SpiffsBackend);
    else
        private alias SpiffsBackends = AliasSeq!();

    private alias FileBackends = AliasSeq!(SpiffsBackends);
}
```

`AliasSeq` flattens, so a disabled backend costs nothing and adding one is an alias plus a flag. `File` carries the index of the backend owning its fd. `open()` prefers a backend that already holds the path, so a write lands on the copy a read would find, and falls back to the first for creation.

## Whole surface, not just the two calls that prompted it

`open`, `read`, `write`, `close`, `get_size`, `file_exists`, `delete_file`, `rename_file`, `set_size`, `get_pos`/`set_pos`, `read_at`/`write_at`, `flush`, and both attribute queries.

`read_at`/`write_at` are emulated over seek and restore the file position afterwards, so they keep `pread`/`pwrite` semantics. SPIFFS supports all of the above; only `get_path` and `set_file_times` have no equivalent and stay unsupported.

## Format runs on its own task

Formatting a multi-megabyte partition blocks long enough to starve the watchdog. Doing it inline boot-looped the board (17 boots in 30 seconds); it now runs on a temporary task and the caller polls `format_state()`.

Mount failure is latched so an unformatted partition is not retried on every access, and a completed format clears the latch. Registration state is tracked separately from `esp_spiffs_mounted()`, which reports whether the *partition* is mounted internally, not whether a VFS is registered on our path. Conflating the two cost some debugging: registration silently never happened while every symptom said it had.

## This is a stopgap, deliberately

The Espressif backend rides newlib and IDF's VFS, which is why the consumer has to enable `CONFIG_VFS_SUPPORT_IO`/`_DIR`. The destination is `SPIFFS_mount()` over `esp_partition_*` directly: no VFS, no newlib, no path prefixing. The blocker is IDF keeping `spiffs.h` in `PRIV_INCLUDE_DIRS`. The header on the shim records the reasoning so it is not rediscovered later, and littlefs wants the same shape, so the structure carries over.

## Testing

ESP32-S3 (Waveshare RS485-CAN). Format, then create / read / overwrite / delete / recreate a file over HTTP, verified byte-exact, surviving reboot. Full end-to-end results are in the OpenWatt PR that consumes this.