### PR TITLE
Reduce concat and log formatting footprint

### DIFF
--- a/src/urt/array.d
+++ b/src/urt/array.d
@@ -513,13 +513,12 @@ nothrow @nogc:
 
         ref Array!(T, EmbedCount) append(Things...)(auto ref Things things)
         {
-            import urt.string.format : _concat = concat_impl, normalise_args;
-
-            auto args = normalise_args(things);
-
-            size_t ext_len = _concat(null, args).length;
+            import urt.string.format : ConcatArg, concat_impl, make_concat_args;
+            ConcatArg[Things.length] args = void;
+            make_concat_args(things, args.ptr);
+            size_t ext_len = concat_impl(null, 0, args.ptr, args.length).length;
             grow(_length + ext_len);
-            _concat(ptr[_length .. _length + ext_len], args);
+            concat_impl(ptr + _length, ext_len, args.ptr, args.length);
             _length += ext_len;
             return this;
         }

--- a/src/urt/array.d
+++ b/src/urt/array.d
@@ -513,12 +513,13 @@ nothrow @nogc:
 
         ref Array!(T, EmbedCount) append(Things...)(auto ref Things things)
         {
-            import urt.string.format : ConcatArg, concat_impl, make_concat_args;
+            import urt.string.format : ConcatArg, concat_impl, concat_mask, make_concat_args;
             ConcatArg[Things.length] args = void;
             make_concat_args(things, args.ptr);
-            size_t ext_len = concat_impl(null, 0, args.ptr, args.length).length;
+            enum arg_mask = concat_mask!Things;
+            size_t ext_len = concat_impl(null, 0, args.ptr, arg_mask).length;
             grow(_length + ext_len);
-            concat_impl(ptr + _length, ext_len, args.ptr, args.length);
+            concat_impl(ptr + _length, ext_len, args.ptr, arg_mask);
             _length += ext_len;
             return this;
         }

--- a/src/urt/log.d
+++ b/src/urt/log.d
@@ -1,7 +1,7 @@
 module urt.log;
 
 import urt.mem.temp : tconcat_impl, tformat;
-import urt.string.format : ConcatArg, make_concat_args;
+import urt.string.format : ConcatArg, concat_mask, make_concat_args;
 import urt.time;
 
 nothrow @nogc:
@@ -158,7 +158,8 @@ void write_log(T...)(Severity severity, const(char)[] tag, const(char)[] object_
     {
         ConcatArg[T.length] packed = void;
         make_concat_args(args, packed.ptr);
-        write_concat_log(severity, tag.ptr, tag.length, object_name.ptr, object_name.length, packed.ptr, packed.length);
+        write_concat_log(severity, tag.ptr, tag.length, object_name.ptr, object_name.length,
+            packed.ptr, concat_mask!T);
     }
 }
 
@@ -250,9 +251,9 @@ LogSinkHandle register_log_sink(LegacyLogSink sink)
 private:
 
 void write_concat_log(Severity severity, const(char)* tag, size_t tag_length, const(char)* object_name,
-    size_t object_name_length, const(void)* args, size_t count)
+    size_t object_name_length, const(void)* args, size_t arg_mask)
 {
-    const(char)[] message = tconcat_impl(args, count);
+    const(char)[] message = tconcat_impl(args, arg_mask);
     write_log_message(severity, tag, tag_length, object_name, object_name_length, message.ptr, message.length);
 }
 

--- a/src/urt/log.d
+++ b/src/urt/log.d
@@ -1,7 +1,7 @@
 module urt.log;
 
-import urt.mem.temp : tconcat, tconcat_impl, tformat;
-import urt.string.format : normalise_args;
+import urt.mem.temp : tconcat_impl, tformat;
+import urt.string.format : ConcatArg, make_concat_args;
 import urt.time;
 
 nothrow @nogc:
@@ -150,18 +150,24 @@ void write_log(T...)(Severity severity, const(char)[] tag, const(char)[] object_
         return;
     import urt.string, urt.array;
     static if (T.length == 1 && (is(T[0] : const(char)[]) || is(T[0] : const String) || is(T[0] : const MutableString!N, size_t N) || is(T[0] : const Array!char)))
-        auto msg = LogMessage(severity, tag, object_name, args[0][], g_log_hostname, get_sys_time());
+    {
+        const(char)[] message = args[0][];
+        write_log_message(severity, tag.ptr, tag.length, object_name.ptr, object_name.length, message.ptr, message.length);
+    }
     else
-        auto msg = LogMessage(severity, tag, object_name, tconcat_impl(normalise_args(args)), g_log_hostname, get_sys_time());
-    write_log(msg);
+    {
+        ConcatArg[T.length] packed = void;
+        make_concat_args(args, packed.ptr);
+        write_concat_log(severity, tag.ptr, tag.length, object_name.ptr, object_name.length, packed.ptr, packed.length);
+    }
 }
 
 void write_logf(T...)(Severity severity, const(char)[] tag, const(char)[] object_name, const(char)[] fmt, ref T args)
 {
     if (severity > g_max_severity)
         return;
-    auto msg = LogMessage(severity, tag, object_name, tformat(fmt, args), g_log_hostname, get_sys_time());
-    write_log(msg);
+    const(char)[] message = tformat(fmt, args);
+    write_log_message(severity, tag.ptr, tag.length, object_name.ptr, object_name.length, message.ptr, message.length);
 }
 
 void write_log(scope ref const LogMessage msg)
@@ -243,6 +249,21 @@ LogSinkHandle register_log_sink(LegacyLogSink sink)
 
 private:
 
+void write_concat_log(Severity severity, const(char)* tag, size_t tag_length, const(char)* object_name,
+    size_t object_name_length, const(void)* args, size_t count)
+{
+    const(char)[] message = tconcat_impl(args, count);
+    write_log_message(severity, tag, tag_length, object_name, object_name_length, message.ptr, message.length);
+}
+
+void write_log_message(Severity severity, const(char)* tag, size_t tag_length, const(char)* object_name,
+    size_t object_name_length, const(char)* message, size_t message_length)
+{
+    auto msg = LogMessage(severity, tag[0 .. tag_length], object_name[0 .. object_name_length],
+        message[0 .. message_length], g_log_hostname, get_sys_time());
+    write_log(msg);
+}
+
 enum max_sinks = 16;
 
 struct SinkSlot
@@ -268,4 +289,32 @@ void recalc_max_severity()
             max_sev = sink.filter.max_severity;
     }
     g_max_severity = max_sev;
+}
+
+version (unittest)
+{
+    struct TestLogCapture
+    {
+        const(char)[] tag;
+        const(char)[] message;
+    }
+
+    void test_log_sink(void* context, scope ref const LogMessage message)
+    {
+        TestLogCapture* capture = cast(TestLogCapture*)context;
+        capture.tag = message.tag;
+        capture.message = message.message;
+    }
+}
+
+unittest
+{
+    Severity old_max_severity = g_max_severity;
+    TestLogCapture capture;
+    LogSinkHandle sink = register_log_sink(&test_log_sink, &capture);
+    log_info("test", "value=", 10);
+    assert(capture.tag == "test");
+    assert(capture.message == "value=10");
+    unregister_log_sink(sink);
+    g_max_severity = old_max_severity;
 }

--- a/src/urt/mem/temp.d
+++ b/src/urt/mem/temp.d
@@ -167,20 +167,23 @@ const(char)[] tconcat(Args...)(ref Args args)
     else
     {
         pragma(inline, true);
-        import urt.string.format : normalise_args;
-        return tconcat_impl(normalise_args(args));
+        import urt.string.format : ConcatArg, make_concat_args;
+        ConcatArg[Args.length] packed = void;
+        make_concat_args(args, packed.ptr);
+        return tconcat_impl(packed.ptr, packed.length);
     }
 }
 
-import urt.meta.tuple : Tuple;
-const(char)[] tconcat_impl(Args...)(Tuple!Args args)
+pragma(inline, false)
+const(char)[] tconcat_impl(const(void)* raw_args, size_t count)
 {
-    import urt.string.format : concat_impl;
-    const(char)[] r = concat_impl(cast(char[])tempMem[alloc_offset..$], args);
+    import urt.string.format : ConcatArg, concat_impl;
+    const(ConcatArg)* args = cast(const(ConcatArg)*)raw_args;
+    const(char)[] r = concat_impl(cast(char*)tempMem.ptr + alloc_offset, tempMem.length - alloc_offset, args, count);
     if (!r)
     {
         alloc_offset = 0;
-        r = concat_impl(cast(char[])tempMem[0..TempMemSize / 2], args);
+        r = concat_impl(cast(char*)tempMem.ptr, TempMemSize / 2, args, count);
     }
     alloc_offset += r.length;
     return r;

--- a/src/urt/mem/temp.d
+++ b/src/urt/mem/temp.d
@@ -167,23 +167,23 @@ const(char)[] tconcat(Args...)(ref Args args)
     else
     {
         pragma(inline, true);
-        import urt.string.format : ConcatArg, make_concat_args;
+        import urt.string.format : ConcatArg, concat_mask, make_concat_args;
         ConcatArg[Args.length] packed = void;
         make_concat_args(args, packed.ptr);
-        return tconcat_impl(packed.ptr, packed.length);
+        return tconcat_impl(packed.ptr, concat_mask!Args);
     }
 }
 
 pragma(inline, false)
-const(char)[] tconcat_impl(const(void)* raw_args, size_t count)
+const(char)[] tconcat_impl(const(void)* raw_args, size_t arg_mask)
 {
     import urt.string.format : ConcatArg, concat_impl;
     const(ConcatArg)* args = cast(const(ConcatArg)*)raw_args;
-    const(char)[] r = concat_impl(cast(char*)tempMem.ptr + alloc_offset, tempMem.length - alloc_offset, args, count);
+    const(char)[] r = concat_impl(cast(char*)tempMem.ptr + alloc_offset, tempMem.length - alloc_offset, args, arg_mask);
     if (!r)
     {
         alloc_offset = 0;
-        r = concat_impl(cast(char*)tempMem.ptr, TempMemSize / 2, args, count);
+        r = concat_impl(cast(char*)tempMem.ptr, TempMemSize / 2, args, arg_mask);
     }
     alloc_offset += r.length;
     return r;

--- a/src/urt/string/format.d
+++ b/src/urt/string/format.d
@@ -35,9 +35,14 @@ struct Format
 struct ConcatArg
 {
     const(void)* data;
-    size_t length;
-    typeof(StringifyFunc.funcptr) stringify;
+    union
+    {
+        size_t length;
+        typeof(StringifyFunc.funcptr) stringify;
+    }
 }
+
+enum max_concat_args = size_t.sizeof * 8 - 1;
 
 ptrdiff_t toString(T)(ref const T value, char[] buffer, const(char)[] format = null, const(FormatArg)[] formatArgs = null)
 {
@@ -55,37 +60,43 @@ void make_concat_arg(T)(ref const T arg, ref ConcatArg result)
     {
         result.data = &arg;
         result.length = 1;
-        result.stringify = null;
     }
     else static if (is(T : const(char)[]) || is(T == E[N], E, size_t N) && is(Unqual!E == char))
     {
         result.data = arg[].ptr;
         result.length = arg[].length;
-        result.stringify = null;
     }
     else static if (is(Unqual!T == String) || is(Unqual!T == MutableString!N, size_t N) || is(Unqual!T == Array!(char, N), size_t N))
     {
         result.data = arg[].ptr;
         result.length = arg[].length;
-        result.stringify = null;
     }
     else static if (is(Unqual!T == Format))
     {
         result.data = &arg;
-        result.length = 0;
         result.stringify = &Format.stringify;
     }
     else
     {
         StringifyFunc fn = get_to_string_func(arg);
         result.data = fn.ptr;
-        result.length = 0;
         result.stringify = fn.funcptr;
     }
 }
 
+enum concat_mask(Args...) = () {
+    static assert(Args.length <= max_concat_args, "Too many concat arguments");
+    size_t mask = size_t(1) << Args.length;
+    static foreach (i, T; Args)
+        static if (is_concat_text!T)
+            mask |= size_t(1) << i;
+    return mask;
+}();
+
 void make_concat_args(Args...)(ref const Args args, ConcatArg* result)
 {
+    pragma(inline, true);
+
     static foreach (i; 0 .. Args.length)
         make_concat_arg(args[i], result[i]);
 }
@@ -100,28 +111,32 @@ char[] concat(Args...)(char[] buffer, auto ref const Args args)
     {
         ConcatArg[Args.length] packed = void;
         make_concat_args(args, packed.ptr);
-        return concat_impl(buffer.ptr, buffer.length, packed.ptr, packed.length);
+        return concat_impl(buffer.ptr, buffer.length, packed.ptr, concat_mask!Args);
     }
 }
 
 pragma(inline, false)
-char[] concat_impl(char* buffer, size_t capacity, const ConcatArg* args, size_t count)
+char[] concat_impl(char* buffer, size_t capacity, const ConcatArg* args, size_t arg_mask)
 {
     size_t length = 0;
-    for (size_t i = 0; i < count; ++i)
+    size_t mask = arg_mask;
+    const(ConcatArg)* arg = args;
+    while (mask > 1)
     {
-        if (args[i].stringify)
+        if (mask & 1)
+            length += arg.length;
+        else
         {
             StringifyFunc fn;
-            fn.ptr = cast(void*)args[i].data;
-            fn.funcptr = args[i].stringify;
+            fn.ptr = cast(void*)arg.data;
+            fn.funcptr = arg.stringify;
             ptrdiff_t result = fn(null, null, null);
             if (result < 0)
                 return null;
             length += result;
         }
-        else
-            length += args[i].length;
+        ++arg;
+        mask >>= 1;
     }
 
     if (buffer)
@@ -129,23 +144,27 @@ char[] concat_impl(char* buffer, size_t capacity, const ConcatArg* args, size_t 
         if (length > capacity)
             return null;
         size_t offset = 0;
-        for (size_t i = 0; i < count; ++i)
+        mask = arg_mask;
+        arg = args;
+        while (mask > 1)
         {
-            if (args[i].stringify)
+            if (mask & 1)
+            {
+                buffer[offset .. offset + arg.length] = (cast(const(char)*)arg.data)[0 .. arg.length];
+                offset += arg.length;
+            }
+            else
             {
                 StringifyFunc fn;
-                fn.ptr = cast(void*)args[i].data;
-                fn.funcptr = args[i].stringify;
+                fn.ptr = cast(void*)arg.data;
+                fn.funcptr = arg.stringify;
                 ptrdiff_t result = fn(buffer[offset .. capacity], null, null);
                 if (result < 0)
                     return null;
                 offset += result;
             }
-            else
-            {
-                buffer[offset .. offset + args[i].length] = (cast(const(char)*)args[i].data)[0 .. args[i].length];
-                offset += args[i].length;
-            }
+            ++arg;
+            mask >>= 1;
         }
     }
     return buffer[0 .. length];
@@ -195,6 +214,10 @@ private:
 
 
 private:
+
+enum is_concat_text(T) = is(Unqual!T == char) || is(T : const(char)[]) ||
+    is(T == E[N], E, size_t N) && is(Unqual!E == char) || is(Unqual!T == String) ||
+    is(Unqual!T == MutableString!N, size_t N) || is(Unqual!T == Array!(char, N), size_t N);
 
 import urt.array;
 

--- a/src/urt/string/format.d
+++ b/src/urt/string/format.d
@@ -17,11 +17,6 @@ debug
 
 alias StringifyFunc = ptrdiff_t delegate(char[] buffer, const(char)[] format, const(FormatArg)[] formatArgs) nothrow @nogc;
 
-struct Arg
-{
-    StringifyFunc fn;
-}
-
 struct Format
 {
     this(T)(ref const T value, const(char)[] format) pure nothrow @nogc
@@ -30,8 +25,18 @@ struct Format
         fmt = format;
     }
 
+    ptrdiff_t stringify(char[] buffer, const(char)[], const(FormatArg)[]) nothrow @nogc
+        => fn(buffer, fmt, null);
+
     StringifyFunc fn;
     const(char)[] fmt;
+}
+
+struct ConcatArg
+{
+    const(void)* data;
+    size_t length;
+    typeof(StringifyFunc.funcptr) stringify;
 }
 
 ptrdiff_t toString(T)(ref const T value, char[] buffer, const(char)[] format = null, const(FormatArg)[] formatArgs = null)
@@ -44,92 +49,106 @@ ptrdiff_t toString(T)(ref const T value, char[] buffer, const(char)[] format = n
 
 alias formatValue = toString; // TODO: remove me?
 
-auto normalise_args(Args...)(ref const Args args)
+void make_concat_arg(T)(ref const T arg, ref ConcatArg result)
 {
-    import urt.meta.tuple : Tuple;
-    alias NormalisedArgs = NormaliseArgs!Args;
-    Tuple!(NormalisedArgs) result = void;
-
-//    pragma(msg, "[ ", Args, " ] --> [ ", NormalisedArgs, " ]");
-
-    static foreach (i; 0 .. Args.length)
+    static if (is(Unqual!T == char))
     {
-        static if (is(NormalisedArgs[i] == char) || is(NormalisedArgs[i] == Format))
-            result[i] = args[i];
-        else static if (is(NormalisedArgs[i] == Arg))
-            result[i] = Arg(get_to_string_func(args[i]));
-        else static if (is(NormalisedArgs[i] == Array!char) || is(NormalisedArgs[i] == String) || is(NormalisedArgs[i] == MutableString!N, size_t N))
-            static assert(false, "use container[] at the callsite!");
-        else
-            result[i] = args[i][];
+        result.data = &arg;
+        result.length = 1;
+        result.stringify = null;
     }
-    return result;
+    else static if (is(T : const(char)[]) || is(T == E[N], E, size_t N) && is(Unqual!E == char))
+    {
+        result.data = arg[].ptr;
+        result.length = arg[].length;
+        result.stringify = null;
+    }
+    else static if (is(Unqual!T == String) || is(Unqual!T == MutableString!N, size_t N) || is(Unqual!T == Array!(char, N), size_t N))
+    {
+        result.data = arg[].ptr;
+        result.length = arg[].length;
+        result.stringify = null;
+    }
+    else static if (is(Unqual!T == Format))
+    {
+        result.data = &arg;
+        result.length = 0;
+        result.stringify = &Format.stringify;
+    }
+    else
+    {
+        StringifyFunc fn = get_to_string_func(arg);
+        result.data = fn.ptr;
+        result.length = 0;
+        result.stringify = fn.funcptr;
+    }
+}
+
+void make_concat_args(Args...)(ref const Args args, ConcatArg* result)
+{
+    static foreach (i; 0 .. Args.length)
+        make_concat_arg(args[i], result[i]);
 }
 
 char[] concat(Args...)(char[] buffer, auto ref const Args args)
 {
     pragma(inline, true);
 
-    alias NormalisedArgs = NormaliseArgs!Args;
-
     static if (Args.length == 0)
         return buffer.ptr[0 .. 0];
     else
-        return concat_impl(buffer, normalise_args(forward!args));
+    {
+        ConcatArg[Args.length] packed = void;
+        make_concat_args(args, packed.ptr);
+        return concat_impl(buffer.ptr, buffer.length, packed.ptr, packed.length);
+    }
 }
 
-import urt.meta.tuple : Tuple;
-char[] concat_impl(Args...)(char[] buffer, Tuple!Args args)
+pragma(inline, false)
+char[] concat_impl(char* buffer, size_t capacity, const ConcatArg* args, size_t count)
 {
-    size_t[Args.length] lens = void;
     size_t length = 0;
-    static foreach (i; 0 .. Args.length)
+    for (size_t i = 0; i < count; ++i)
     {
-        static if (is(Args[i] == char))
-            length += 1;
-        else static if (is(Args[i] == Arg))
+        if (args[i].stringify)
         {
-            lens[i] = args[i].fn(null, null, null);
-            length += lens[i];
-        }
-        else static if (is(Args[i] == Format))
-        {
-            lens[i] = args[i].fn(null, args[i].fmt, null);
-            length += lens[i];
+            StringifyFunc fn;
+            fn.ptr = cast(void*)args[i].data;
+            fn.funcptr = args[i].stringify;
+            ptrdiff_t result = fn(null, null, null);
+            if (result < 0)
+                return null;
+            length += result;
         }
         else
-        {
-            lens[i] = args[i].length;
-            length += lens[i];
-        }
+            length += args[i].length;
     }
-    if (buffer.ptr)
+
+    if (buffer)
     {
-        if (length > buffer.length)
+        if (length > capacity)
             return null;
-        char* p = buffer.ptr;
-        static foreach (i; 0 .. Args.length)
+        size_t offset = 0;
+        for (size_t i = 0; i < count; ++i)
         {
-            static if (is(Args[i] == char))
-                *p++ = args[i];
-            else static if (is(Args[i] == Arg))
+            if (args[i].stringify)
             {
-                args[i].fn(p[0..lens[i]], null, null);
-                p += lens[i];
-            }
-            else static if (is(Args[i] == Format))
-            {
-                args[i].fn(p[0..lens[i]], args[i].fmt, null);
-                p += lens[i];
+                StringifyFunc fn;
+                fn.ptr = cast(void*)args[i].data;
+                fn.funcptr = args[i].stringify;
+                ptrdiff_t result = fn(buffer[offset .. capacity], null, null);
+                if (result < 0)
+                    return null;
+                offset += result;
             }
             else
             {
-                p[0..lens[i]] = args[i].ptr[0..lens[i]];
-                p += lens[i];
+                buffer[offset .. offset + args[i].length] = (cast(const(char)*)args[i].data)[0 .. args[i].length];
+                offset += args[i].length;
             }
         }
     }
-    return buffer.ptr[0 .. length];
+    return buffer[0 .. length];
 }
 
 char[] format(Args...)(char[] buffer, const(char)[] fmt, auto ref Args args)
@@ -178,47 +197,6 @@ private:
 private:
 
 import urt.array;
-enum is_some_string(T) = is(T == char) || is(T : const char[]) || is(T : const(String)) || is(T : const(MutableString!N), size_t N) || is(T : const(Array!(char, N)), size_t N);
-
-template num_string_args(Args...)
-{
-    static if (Args.length == 0)
-        enum num_string_args = 0;
-    else static if (is_some_string!(Args[0]))
-        enum num_string_args = 1 + num_string_args!(Args[1 .. $]);
-    else
-        enum num_string_args = 0;
-}
-
-template NormaliseArgs(Args...)
-{
-    import urt.meta : AliasSeq;
-    alias NormaliseArgs = AliasSeq!();
-    static foreach (Arg; Args)
-        NormaliseArgs = AliasSeq!(NormaliseArgs, NormaliseOthers!(NormaliseConst!Arg));
-}
-
-template NormaliseOthers(T)
-{
-    static if (is(T : const(char)[]) || is(T == char))
-        alias NormaliseOthers = T;
-    else static if (is(T == String) || is(T == Array!char) || is(T == MutableString!N, size_t N))
-        alias NormaliseOthers = const(char)[];
-    else
-        alias NormaliseOthers = Arg;
-}
-
-template NormaliseConst(T)
-{
-    static if (is(T == const(U), U) || is(T == immutable(U), U))
-        alias NormaliseConst = NormaliseConst!U;
-    else static if (is(T == immutable(U)[], U) || is(T == U[], U))
-        alias NormaliseConst = const(U)[];
-    else static if (is(T == U[N], U, size_t N))
-        alias NormaliseConst = const(U)[];
-    else
-        alias NormaliseConst = T;
-}
 
 alias StringifyFuncReduced = ptrdiff_t delegate(char[] buffer, const(char)[] format) nothrow @nogc;
 alias StringifyFuncReduced2 = ptrdiff_t delegate(char[] buffer) nothrow @nogc;
@@ -830,19 +808,6 @@ ptrdiff_t format_int(ulong value, bool signed, char[] buffer, const(char)[] form
     return len;
 }
 
-char[] concat_impl(char[] buffer, const(StringifyFunc)[] args) nothrow @nogc
-{
-    size_t len = 0;
-    foreach (a; args)
-    {
-        ptrdiff_t r = a(buffer.ptr ? buffer[len..$] : null, null, null);
-        if (r < 0)
-            return null;
-        len += r;
-    }
-    return buffer.ptr[0..len];
-}
-
 char[] formatImpl(char[] buffer, const(char)[] format, const(FormatArg)[] args) nothrow @nogc
 {
     char *pBuffer = buffer.ptr;
@@ -1067,7 +1032,19 @@ unittest
 {
     char[1024] tmp;
 
-    char[] r = format(tmp, "hello");
+    char[] r = concat(tmp, "value=", 10, '!');
+    assert(r == "value=10!");
+
+    int value = 10;
+    r = concat(tmp, "value=", Format(value, "04"), '!');
+    assert(r == "value=0010!");
+    assert(concat(tmp[0 .. 4], "value=", 10) is null);
+
+    MutableString!0 text = MutableString!0("value");
+    r = concat(tmp, text, '=', 10);
+    assert(r == "value=10");
+
+    r = format(tmp, "hello");
     assert(r == "hello");
 
     r = format(tmp, "hello {0}", null);

--- a/src/urt/string/string.d
+++ b/src/urt/string/string.d
@@ -1010,10 +1010,10 @@ nothrow @nogc:
 
     ref MutableString!Embed append(Things...)(auto ref Things things)
     {
-        import urt.string.format : ConcatArg, make_concat_args;
+        import urt.string.format : ConcatArg, concat_mask, make_concat_args;
         ConcatArg[Things.length] args = void;
         make_concat_args(things, args.ptr);
-        return insert_impl(length(), args.ptr, args.length);
+        return insert_impl(length(), args.ptr, concat_mask!Things);
     }
 
     ref MutableString!Embed append_format(Things...)(const(char)[] format, auto ref Things args)
@@ -1025,10 +1025,10 @@ nothrow @nogc:
     {
         if (ptr)
             writeLength(0);
-        import urt.string.format : ConcatArg, make_concat_args;
+        import urt.string.format : ConcatArg, concat_mask, make_concat_args;
         ConcatArg[Things.length] args = void;
         make_concat_args(things, args.ptr);
-        return insert_impl(0, args.ptr, args.length);
+        return insert_impl(0, args.ptr, concat_mask!Things);
     }
 
     ref MutableString!Embed format(Args...)(const(char)[] format, auto ref Args args)
@@ -1040,10 +1040,10 @@ nothrow @nogc:
 
     ref MutableString!Embed insert(Things...)(size_t offset, auto ref Things things)
     {
-        import urt.string.format : ConcatArg, make_concat_args;
+        import urt.string.format : ConcatArg, concat_mask, make_concat_args;
         ConcatArg[Things.length] args = void;
         make_concat_args(things, args.ptr);
-        return insert_impl(offset, args.ptr, args.length);
+        return insert_impl(offset, args.ptr, concat_mask!Things);
     }
 
     ref MutableString!Embed insert_format(Things...)(size_t offset, const(char)[] format, auto ref Things args)
@@ -1181,7 +1181,7 @@ private:
         defaultAllocator().free(buffer[0 .. 4 + *cast(ushort*)buffer]);
     }
 
-    ref MutableString!Embed insert_impl(size_t offset, const(void)* raw_args, size_t count)
+    ref MutableString!Embed insert_impl(size_t offset, const(void)* raw_args, size_t arg_mask)
     {
         import urt.string.format : ConcatArg, concat_impl;
         const(ConcatArg)* args = cast(const(ConcatArg)*)raw_args;
@@ -1189,7 +1189,7 @@ private:
         char* oldPtr = ptr;
         size_t oldLen = length();
 
-        size_t insertLen = concat_impl(null, 0, args, count).length;
+        size_t insertLen = concat_impl(null, 0, args, arg_mask).length;
         size_t newLen = oldLen + insertLen;
         if (newLen == oldLen)
             return this;
@@ -1198,7 +1198,7 @@ private:
         size_t oldAlloc = allocated();
         ptr = newLen <= oldAlloc ? oldPtr : allocStringBuffer(grow_capacity(newLen, oldAlloc));
         memmove(ptr + offset + insertLen, oldPtr + offset, oldLen - offset);
-        concat_impl(ptr + offset, insertLen, args, count);
+        concat_impl(ptr + offset, insertLen, args, arg_mask);
         writeLength(newLen);
 
         if (oldPtr && ptr != oldPtr)

--- a/src/urt/string/string.d
+++ b/src/urt/string/string.d
@@ -1010,8 +1010,10 @@ nothrow @nogc:
 
     ref MutableString!Embed append(Things...)(auto ref Things things)
     {
-        import urt.string.format : normalise_args;
-        return insert_impl(length(), normalise_args(things));
+        import urt.string.format : ConcatArg, make_concat_args;
+        ConcatArg[Things.length] args = void;
+        make_concat_args(things, args.ptr);
+        return insert_impl(length(), args.ptr, args.length);
     }
 
     ref MutableString!Embed append_format(Things...)(const(char)[] format, auto ref Things args)
@@ -1021,10 +1023,12 @@ nothrow @nogc:
 
     ref MutableString!Embed concat(Things...)(auto ref Things things)
     {
-        import urt.string.format : normalise_args;
         if (ptr)
             writeLength(0);
-        return insert_impl(0, normalise_args(things));
+        import urt.string.format : ConcatArg, make_concat_args;
+        ConcatArg[Things.length] args = void;
+        make_concat_args(things, args.ptr);
+        return insert_impl(0, args.ptr, args.length);
     }
 
     ref MutableString!Embed format(Args...)(const(char)[] format, auto ref Args args)
@@ -1036,9 +1040,10 @@ nothrow @nogc:
 
     ref MutableString!Embed insert(Things...)(size_t offset, auto ref Things things)
     {
-        import urt.string.format : normalise_args;
-        auto args = normalise_args(things);
-        return insert_impl(offset, args);
+        import urt.string.format : ConcatArg, make_concat_args;
+        ConcatArg[Things.length] args = void;
+        make_concat_args(things, args.ptr);
+        return insert_impl(offset, args.ptr, args.length);
     }
 
     ref MutableString!Embed insert_format(Things...)(size_t offset, const(char)[] format, auto ref Things args)
@@ -1176,15 +1181,15 @@ private:
         defaultAllocator().free(buffer[0 .. 4 + *cast(ushort*)buffer]);
     }
 
-    import urt.meta.tuple : Tuple;
-    ref MutableString!Embed insert_impl(Things...)(size_t offset, Tuple!Things args)
+    ref MutableString!Embed insert_impl(size_t offset, const(void)* raw_args, size_t count)
     {
-        import urt.string.format : concat_impl;
+        import urt.string.format : ConcatArg, concat_impl;
+        const(ConcatArg)* args = cast(const(ConcatArg)*)raw_args;
 
         char* oldPtr = ptr;
         size_t oldLen = length();
 
-        size_t insertLen = concat_impl(null, args).length;
+        size_t insertLen = concat_impl(null, 0, args, count).length;
         size_t newLen = oldLen + insertLen;
         if (newLen == oldLen)
             return this;
@@ -1193,7 +1198,7 @@ private:
         size_t oldAlloc = allocated();
         ptr = newLen <= oldAlloc ? oldPtr : allocStringBuffer(grow_capacity(newLen, oldAlloc));
         memmove(ptr + offset + insertLen, oldPtr + offset, oldLen - offset);
-        concat_impl(ptr[offset .. offset + insertLen], args);
+        concat_impl(ptr + offset, insertLen, args, count);
         writeLength(newLen);
 
         if (oldPtr && ptr != oldPtr)


### PR DESCRIPTION
## Summary

- type-erase concat and log formatting behind shared non-template backends
- pack each concat argument into two machine words instead of three
- encode text/formatter selection in a compile-time sentinel mask
- use the same representation from `Array`, `MutableString`, temporary concatenation, and logging

## Why

Typed concat and log ingress generated a large amount of repeated setup and traversal code for every argument tuple. The shared backend removes duplicated traversal, while the compact descriptor eliminates the redundant discriminator word and its runtime stores.

Controlled SmartEVSE ESP32-S3 release A/B measurements recovered 42,896 bytes from type erasure and another 5,504 bytes from descriptor compaction, for an additive 48,400-byte (47.3 KiB) reduction.

## Validation

- uRT Windows unittest configuration builds successfully
- focused `urt.string.format` unittest passes
- `git diff --check` passes
