### PR TITLE
file: directory enumeration

### DIFF
--- a/src/urt/driver/esp32/littlefs_port.c
+++ b/src/urt/driver/esp32/littlefs_port.c
@@ -26,6 +26,8 @@
 #define OW_LFS_MAX_FILES       8
 #define OW_LFS_NAME_MAX      127
 
+#define OW_LFS_MAX_DIRS        2
+
 // Distinct from any LFS_ERR_*, so an exhausted handle table cannot be misread
 // as a filesystem fault.
 #define OW_LFS_ERR_NO_HANDLES (-1000)
@@ -47,6 +49,12 @@ static struct
     struct lfs_file_config config;
     bool used;
 } ow_lfs_files[OW_LFS_MAX_FILES];
+
+static struct
+{
+    lfs_dir_t dir;
+    bool used;
+} ow_lfs_dirs[OW_LFS_MAX_DIRS];
 
 static struct lfs_config ow_lfs_config;
 
@@ -327,6 +335,72 @@ int urt_littlefs_sync(int h)
     if (!ow_lfs_valid(h))
         return -1;
     return lfs_file_sync(&ow_lfs, &ow_lfs_files[h].file) == 0 ? 0 : -1;
+}
+
+
+int urt_littlefs_dir_open(const char *path, size_t path_len)
+{
+    char buffer[OW_LFS_NAME_MAX + 1];
+    if (!ow_lfs_ready() || !ow_lfs_path(path, path_len, buffer, sizeof(buffer)))
+        return -1;
+
+    int h = -1;
+    for (int i = 0; i < OW_LFS_MAX_DIRS; ++i)
+    {
+        if (!ow_lfs_dirs[i].used)
+        {
+            h = i;
+            break;
+        }
+    }
+    if (h < 0)
+    {
+        ow_lfs_last_error = OW_LFS_ERR_NO_HANDLES;
+        return -1;
+    }
+
+    // An empty path is the root, which littlefs spells "/".
+    int err = lfs_dir_open(&ow_lfs, &ow_lfs_dirs[h].dir, buffer[0] ? buffer : "/");
+    if (err != 0)
+    {
+        ow_lfs_last_error = err;
+        return -1;
+    }
+    ow_lfs_dirs[h].used = true;
+    return h;
+}
+
+// Returns the name length, 0 at the end of the directory, negative on error.
+ptrdiff_t urt_littlefs_dir_read(int h, char *name, size_t name_len, uint64_t *size, int *is_dir)
+{
+    if (h < 0 || h >= OW_LFS_MAX_DIRS || !ow_lfs_dirs[h].used)
+        return -1;
+
+    struct lfs_info info;
+    int r = lfs_dir_read(&ow_lfs, &ow_lfs_dirs[h].dir, &info);
+    if (r < 0)
+    {
+        ow_lfs_last_error = r;
+        return -1;
+    }
+    if (r == 0)
+        return 0;
+
+    size_t len = strlen(info.name);
+    if (len > name_len)
+        len = name_len;
+    memcpy(name, info.name, len);
+    *size = info.size;
+    *is_dir = (info.type == LFS_TYPE_DIR);
+    return (ptrdiff_t)len;
+}
+
+void urt_littlefs_dir_close(int h)
+{
+    if (h < 0 || h >= OW_LFS_MAX_DIRS || !ow_lfs_dirs[h].used)
+        return;
+    lfs_dir_close(&ow_lfs, &ow_lfs_dirs[h].dir);
+    ow_lfs_dirs[h].used = false;
 }
 
 

--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -2212,6 +2212,83 @@ int urt_spiffs_last_error(void)
     return ow_spiffs_last_errno;
 }
 
+// SPIFFS has no directories; its VFS reports the flat namespace as a single
+// listing at the mount root, so only the root enumerates anything.
+#define OW_SPIFFS_MAX_DIRS 2
+
+static DIR *ow_spiffs_dirs[OW_SPIFFS_MAX_DIRS];
+
+int urt_spiffs_dir_open(const char *path, size_t path_len)
+{
+    char buffer[128];
+    if (!ow_spiffs_ready() || !ow_spiffs_path(path, path_len, buffer, sizeof(buffer)))
+        return -1;
+
+    int h = -1;
+    for (int i = 0; i < OW_SPIFFS_MAX_DIRS; ++i)
+    {
+        if (!ow_spiffs_dirs[i])
+        {
+            h = i;
+            break;
+        }
+    }
+    if (h < 0)
+        return -1;
+
+    DIR *d = opendir(buffer);
+    if (!d)
+    {
+        ow_spiffs_last_errno = errno;
+        return -1;
+    }
+    ow_spiffs_dirs[h] = d;
+    return h;
+}
+
+ptrdiff_t urt_spiffs_dir_read(int h, char *name, size_t name_len, uint64_t *size, int *is_dir)
+{
+    if (h < 0 || h >= OW_SPIFFS_MAX_DIRS || !ow_spiffs_dirs[h])
+        return -1;
+
+    errno = 0;
+    struct dirent *e = readdir(ow_spiffs_dirs[h]);
+    if (!e)
+    {
+        if (errno)
+        {
+            ow_spiffs_last_errno = errno;
+            return -1;
+        }
+        return 0;
+    }
+
+    size_t len = strlen(e->d_name);
+    if (len > name_len)
+        len = name_len;
+    memcpy(name, e->d_name, len);
+    *is_dir = (e->d_type == DT_DIR);
+    *size = 0;
+    if (!*is_dir)
+    {
+        // d_name is relative to the directory, and there is no fstatat here.
+        char full[128];
+        int n = snprintf(full, sizeof(full), "%s/%s", OW_SPIFFS_ROOT, e->d_name);
+        struct stat st;
+        if (n > 0 && (size_t)n < sizeof(full) && stat(full, &st) == 0)
+            *size = (uint64_t)st.st_size;
+    }
+    return (ptrdiff_t)len;
+}
+
+void urt_spiffs_dir_close(int h)
+{
+    if (h < 0 || h >= OW_SPIFFS_MAX_DIRS || !ow_spiffs_dirs[h])
+        return;
+    closedir(ow_spiffs_dirs[h]);
+    ow_spiffs_dirs[h] = NULL;
+}
+
 ptrdiff_t urt_spiffs_write(int fd, const void *data, size_t length)
 {
     ptrdiff_t n = write(fd, data, length);

--- a/src/urt/file.d
+++ b/src/urt/file.d
@@ -148,6 +148,42 @@ struct File
         static assert(0, "File: not implemented for this platform");
 }
 
+// One entry from a Directory walk. `name` points at storage owned by the
+// Directory, so it lives only until the next read or the close.
+struct DirEntry
+{
+    const(char)[] name;
+    ulong size;
+    FileAttributeFlag attributes;
+
+    bool is_directory() const pure nothrow @nogc
+        => (attributes & FileAttributeFlag.Directory) != 0;
+}
+
+struct Directory
+{
+    version (Windows)
+    {
+        void* handle = INVALID_HANDLE_VALUE;
+        WIN32_FIND_DATAW find_data = void;
+        bool pending;   // find_data holds the entry FindFirstFileW already produced
+        char[MAX_PATH * 3] name_buffer = void;
+    }
+    else version (Posix)
+        DIR* dir;
+    else version (FreeStanding)
+    {
+        int fd = -1;
+        version (HasFileBackend)
+        {
+            ubyte backend = ubyte.max;
+            char[256] name_buffer = void;
+        }
+    }
+    else
+        static assert(0, "Directory: not implemented for this platform");
+}
+
 bool file_exists(const(char)[] path)
 {
     version (Windows)
@@ -460,6 +496,201 @@ Result create_directory(const(char)[] path)
     if (r == InternalResult.already_exists)
         return Result.success;
     return r;
+}
+
+Result open(ref Directory dir, const(char)[] path)
+{
+    version (Windows)
+    {
+        import urt.mem.temp : tconcat;
+
+        // FindFirstFileW enumerates a wildcard, not a directory, and it
+        // produces the first entry up front rather than on the first read.
+        const(char)[] pattern = tconcat(path, path.length && path[$-1] != '\\' && path[$-1] != '/' ? "\\*" : "*");
+        dir.handle = FindFirstFileW(pattern.twstringz, &dir.find_data);
+        if (dir.handle == INVALID_HANDLE_VALUE)
+            return getlasterror_result();
+        dir.pending = true;
+    }
+    else version (Posix)
+    {
+        dir.dir = opendir(path.tstringz);
+        if (dir.dir is null)
+            return errno_result();
+    }
+    else version (HasFileBackend)
+    {
+        static foreach (i, B; FileBackends)
+        {
+            if (dir.fd < 0)
+            {
+                int fd = B.dir_open(path);
+                if (fd >= 0)
+                {
+                    dir.fd = fd;
+                    dir.backend = i;
+                }
+            }
+        }
+        if (dir.fd < 0)
+        {
+            static foreach (B; FileBackends)
+            {
+                if (B.available())
+                    return InternalResult.failed;
+            }
+            return InternalResult.unsupported;
+        }
+    }
+    else
+        return InternalResult.unsupported; // no filesystem on this platform
+
+    return Result.success;
+}
+
+// Returns false at the end of the directory, so a failure to open and an
+// exhausted walk read the same way at the call site.
+bool read(ref Directory dir, out DirEntry entry)
+{
+    version (Windows)
+    {
+        if (dir.handle == INVALID_HANDLE_VALUE)
+            return false;
+        for (;;)
+        {
+            if (!dir.pending && !FindNextFileW(cast(HANDLE)dir.handle, &dir.find_data))
+                return false;
+            dir.pending = false;
+
+            size_t wlen = 0;
+            while (wlen < dir.find_data.cFileName.length && dir.find_data.cFileName[wlen] != 0)
+                ++wlen;
+            char[] name = dir.name_buffer[];
+            size_t len = dir.find_data.cFileName[0 .. wlen].uni_convert(name);
+            if (len == 0)
+                continue;
+            name = dir.name_buffer[0 .. len];
+            if (name == "." || name == "..")
+                continue;
+
+            entry.name = name;
+            entry.size = (cast(ulong)dir.find_data.nFileSizeHigh << 32) | dir.find_data.nFileSizeLow;
+            if (dir.find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+                entry.attributes |= FileAttributeFlag.Directory;
+            if (dir.find_data.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN)
+                entry.attributes |= FileAttributeFlag.Hidden;
+            if (dir.find_data.dwFileAttributes & FILE_ATTRIBUTE_READONLY)
+                entry.attributes |= FileAttributeFlag.ReadOnly;
+            return true;
+        }
+    }
+    else version (Posix)
+    {
+        import urt.mem : strlen;
+
+        if (dir.dir is null)
+            return false;
+        for (;;)
+        {
+            dirent* e = readdir(dir.dir);
+            if (e is null)
+                return false;
+
+            const(char)[] name = e.d_name.ptr[0 .. strlen(e.d_name.ptr)];
+            if (name == "." || name == "..")
+                continue;
+
+            // d_type is not filled in by every filesystem, so the stat below
+            // settles both the size and the kind.
+            stat_t st;
+            if (fstatat(dirfd(dir.dir), e.d_name.ptr, &st, 0) == 0)
+            {
+                entry.size = st.st_size;
+                if (S_ISDIR(st.st_mode))
+                    entry.attributes |= FileAttributeFlag.Directory;
+            }
+            else if (e.d_type == DT_DIR)
+                entry.attributes |= FileAttributeFlag.Directory;
+
+            if (name.length && name[0] == '.')
+                entry.attributes |= FileAttributeFlag.Hidden;
+            entry.name = name;
+            return true;
+        }
+    }
+    else version (HasFileBackend)
+    {
+        if (dir.fd < 0)
+            return false;
+        static foreach (i, B; FileBackends)
+        {
+            if (dir.backend == i)
+            {
+                for (;;)
+                {
+                    bool is_dir;
+                    ulong size;
+                    ptrdiff_t len = B.dir_read(dir.fd, dir.name_buffer[], size, is_dir);
+                    if (len <= 0)
+                        return false;
+                    const(char)[] name = dir.name_buffer[0 .. len];
+                    if (name == "." || name == "..")
+                        continue;
+                    entry.name = name;
+                    entry.size = size;
+                    if (is_dir)
+                        entry.attributes |= FileAttributeFlag.Directory;
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    else
+        return false;
+}
+
+void close(ref Directory dir)
+{
+    version (Windows)
+    {
+        if (dir.handle == INVALID_HANDLE_VALUE)
+            return;
+        FindClose(cast(HANDLE)dir.handle);
+        dir.handle = INVALID_HANDLE_VALUE;
+        dir.pending = false;
+    }
+    else version (Posix)
+    {
+        if (dir.dir is null)
+            return;
+        closedir(dir.dir);
+        dir.dir = null;
+    }
+    else version (HasFileBackend)
+    {
+        if (dir.fd < 0)
+            return;
+        static foreach (i, B; FileBackends)
+        {
+            if (dir.backend == i)
+                B.dir_close(dir.fd);
+        }
+        dir.fd = -1;
+        dir.backend = ubyte.max;
+    }
+}
+
+bool is_open(ref const Directory dir)
+{
+    version (Windows)
+        return dir.handle != INVALID_HANDLE_VALUE;
+    else version (Posix)
+        return dir.dir !is null;
+    else version (HasFileBackend)
+        return dir.fd >= 0;
+    else
+        return false;
 }
 
 Result open(ref File file, const(char)[] path, FileOpenMode mode, FileOpenFlags openFlags = FileOpenFlags.None)
@@ -1155,4 +1386,73 @@ else unittest
     // clean up and verify
     assert(filename.delete_file());
     assert(!file_exists(filename));
+}
+
+version (FreeStanding) {}
+else unittest
+{
+    import urt.mem.temp : tconcat;
+    import urt.string;
+
+    // A temp *file* name is the only unique name on offer, so borrow one and
+    // hang a directory off it. "." rather than "" because with no directory
+    // Windows creates the file at the drive root and hands back a relative
+    // path, which then names nothing.
+    char[320] buffer = void;
+    char[] temp_name = buffer[];
+    assert(get_temp_filename(temp_name, ".", "dirtest"));
+    const(char)[] dir_path = tconcat(temp_name, ".dir");
+    assert(create_directory(dir_path));
+
+    assert(save_file(tconcat(dir_path, "/one.txt"), cast(const(void)[])"12345"));
+    assert(save_file(tconcat(dir_path, "/two.txt"), cast(const(void)[])"12345678"));
+    assert(create_directory(tconcat(dir_path, "/sub")));
+
+    Directory dir;
+    assert(dir.open(dir_path));
+    assert(dir.is_open);
+
+    size_t files, dirs;
+    bool saw_one, saw_two, saw_sub;
+    DirEntry entry;
+    while (dir.read(entry))
+    {
+        // "." and ".." are the walker's business, never the caller's
+        assert(entry.name != "." && entry.name != "..");
+        if (entry.is_directory)
+        {
+            ++dirs;
+            saw_sub |= entry.name == "sub";
+        }
+        else
+        {
+            ++files;
+            if (entry.name == "one.txt")
+            {
+                saw_one = true;
+                assert(entry.size == 5);
+            }
+            else if (entry.name == "two.txt")
+            {
+                saw_two = true;
+                assert(entry.size == 8);
+            }
+        }
+    }
+    assert(files == 2 && dirs == 1);
+    assert(saw_one && saw_two && saw_sub);
+
+    dir.close();
+    assert(!dir.is_open);
+
+    // Reading a closed walk ends rather than faulting, and so does a walk that
+    // never opened.
+    assert(!dir.read(entry));
+    Directory missing;
+    assert(!missing.open(tconcat(dir_path, "/nope")));
+    assert(!missing.read(entry));
+
+    assert(tconcat(dir_path, "/one.txt").delete_file());
+    assert(tconcat(dir_path, "/two.txt").delete_file());
+    assert(temp_name.delete_file());
 }

--- a/src/urt/fs/littlefs.d
+++ b/src/urt/fs/littlefs.d
@@ -75,6 +75,20 @@ static nothrow @nogc:
 
     bool sync(int fd)
         => urt_littlefs_sync(fd) == 0;
+
+    int dir_open(const(char)[] path)
+        => urt_littlefs_dir_open(path.ptr, path.length);
+
+    ptrdiff_t dir_read(int fd, char[] name, out ulong size, out bool is_dir)
+    {
+        int dir;
+        ptrdiff_t r = urt_littlefs_dir_read(fd, name.ptr, name.length, &size, &dir);
+        is_dir = dir != 0;
+        return r;
+    }
+
+    void dir_close(int fd)
+        => urt_littlefs_dir_close(fd);
 }
 
 
@@ -98,4 +112,7 @@ private extern(C)
     long urt_littlefs_seek(int fd, long offset, int whence);
     int urt_littlefs_truncate(int fd, ulong length);
     int urt_littlefs_sync(int fd);
+    int urt_littlefs_dir_open(const(char)* path, size_t path_len);
+    ptrdiff_t urt_littlefs_dir_read(int fd, char* name, size_t name_len, ulong* size, int* is_dir);
+    void urt_littlefs_dir_close(int fd);
 }

--- a/src/urt/fs/spiffs.d
+++ b/src/urt/fs/spiffs.d
@@ -36,6 +36,20 @@ static nothrow @nogc:
     int last_error()
         => urt_spiffs_last_error();
 
+    int dir_open(const(char)[] path)
+        => urt_spiffs_dir_open(path.ptr, path.length);
+
+    ptrdiff_t dir_read(int fd, char[] name, out ulong size, out bool is_dir)
+    {
+        int dir;
+        ptrdiff_t r = urt_spiffs_dir_read(fd, name.ptr, name.length, &size, &dir);
+        is_dir = dir != 0;
+        return r;
+    }
+
+    void dir_close(int fd)
+        => urt_spiffs_dir_close(fd);
+
     bool info(out ulong total, out ulong used)
         => urt_spiffs_info(&total, &used) == 0;
 
@@ -83,6 +97,9 @@ private extern(C)
     int urt_spiffs_format_status();
     int urt_spiffs_available();
     int urt_spiffs_last_error();
+    int urt_spiffs_dir_open(const(char)* path, size_t path_len);
+    ptrdiff_t urt_spiffs_dir_read(int fd, char* name, size_t name_len, ulong* size, int* is_dir);
+    void urt_spiffs_dir_close(int fd);
     int urt_spiffs_info(ulong* total, ulong* used);
     int urt_spiffs_exists(const(char)* path, size_t path_len);
     int urt_spiffs_stat(const(char)* path, size_t path_len, ulong* size);

--- a/src/urt/internal/sys/posix/package.d
+++ b/src/urt/internal/sys/posix/package.d
@@ -120,6 +120,64 @@ else
     ssize_t pwrite(int fd, const void* buf, size_t count, off_t offset);
 }
 int fsync(int fd);
+
+// -- dirent --
+
+struct DIR;
+
+enum : ubyte
+{
+    DT_UNKNOWN = 0,
+    DT_DIR     = 4,
+    DT_REG     = 8,
+}
+
+version (Darwin)
+{
+    struct dirent
+    {
+        ulong d_ino;
+        ulong d_seekoff;
+        ushort d_reclen;
+        ushort d_namlen;
+        ubyte d_type;
+        char[1024] d_name;
+    }
+
+    // Darwin renames the symbols rather than versioning the struct, so the
+    // 64-bit-inode layout above only matches under the suffixed names.
+    pragma(mangle, "opendir$INODE64") DIR* opendir(scope const char* name);
+    pragma(mangle, "readdir$INODE64") dirent* readdir(DIR* dirp);
+}
+else
+{
+    struct dirent
+    {
+        ino_t d_ino;
+        off_t d_off;
+        ushort d_reclen;
+        ubyte d_type;
+        char[256] d_name;
+    }
+    static assert(dirent.d_name.offsetof == 19);
+
+    version (X86)
+    {
+        // Same largefile treatment as lseek/pread above: the unsuffixed
+        // readdir returns 32-bit d_ino/d_off and would misread the struct.
+        DIR* opendir(scope const char* name);
+        dirent* readdir64(DIR* dirp);
+        alias readdir = readdir64;
+    }
+    else
+    {
+        DIR* opendir(scope const char* name);
+        dirent* readdir(DIR* dirp);
+    }
+}
+
+int closedir(DIR* dirp);
+
 int usleep(uint usec);
 long sysconf(int name);
 int gethostname(char* name, size_t len);
@@ -224,12 +282,17 @@ version (OldStatLayout)
 bool S_ISREG(mode_t mode)
     => (mode & 0xF000) == 0x8000;
 
+bool S_ISDIR(mode_t mode)
+    => (mode & 0xF000) == 0x4000;
+
 version (X86)
 {
     int stat64(scope const char* pathname, stat_t* buf);
     alias stat = stat64;
     int fstat64(int fd, stat_t* buf);
     alias fstat = fstat64;
+    int fstatat64(int dirfd, scope const char* pathname, stat_t* buf, int flags);
+    alias fstatat = fstatat64;
     int mkstemp64(char* tmpl);
     alias mkstemp = mkstemp64;
 }
@@ -237,8 +300,12 @@ else
 {
     int stat(scope const char* pathname, stat_t* buf);
     int fstat(int fd, stat_t* buf);
+    int fstatat(int dirfd, scope const char* pathname, stat_t* buf, int flags);
     int mkstemp(char* tmpl);
 }
+// Sizing a directory entry relative to its open directory avoids rebuilding
+// and storing the full path just to stat it.
+int dirfd(DIR* dirp);
 int mkdir(scope const char* pathname, mode_t mode);
 pure int posix_memalign(void** memptr, size_t alignment, size_t size);
 


### PR DESCRIPTION
There was no way to ask what a directory contains. That blocks WebDAV `PROPFIND`, and with it any frontend file browser or editor, but it is missing for its own sake too.

## Shape

`Directory` mirrors `File` deliberately: same `open`/`read`/`close`/`is_open` verbs, same version ladder, same handle discipline. Nothing allocates.

```d
Directory dir;
if (dir.open("conf"))
{
    scope(exit) dir.close();
    DirEntry entry;
    while (dir.read(entry))
        writeInfo(entry.is_directory ? "d " : "  ", entry.size, "  ", entry.name);
}
```

`read` returns false at the end of the walk, so an exhausted directory and one that never opened read the same way at the call site, and a caller that wants to stop early just stops. `entry.name` points at storage owned by the `Directory`, so it lives until the next `read` or the `close`.

`.` and `..` are never returned. Callers that had to filter them would all filter them identically, and the ones that forgot would recurse forever.

A callback visitor and a `foreach` range were both considered. The visitor inverts control, which a paging or streaming consumer like `PROPFIND` has to fight; the range still needs this handle underneath, and can be layered on later without changing anything here.

## Backends

| | enumeration | sizes |
|---|---|---|
| Windows | `FindFirstFileW`/`FindNextFileW` | free, from the find data |
| POSIX | `opendir`/`readdir` | `fstatat` against the directory's own fd |
| littlefs | `lfs_dir_open`/`read`/`close` | free, from `lfs_info` |
| SPIFFS | VFS `opendir`/`readdir` | `stat` per entry |

`fstatat` is what keeps POSIX cheap: the alternative is rebuilding and storing the full path for every entry purely to have something to hand `stat()`. `d_type` is not filled in by every filesystem, so that stat settles the kind as well.

SPIFFS has no directories. Its VFS presents the flat namespace as one listing at the mount root, so only the root enumerates anything. That is a property of the store, not of this code, and is one more reason littlefs is the one to prefer.

`dirent` is declared per-platform for the same reason `stat_t` already is.

## Verified

- **Windows**, dmd, `CONFIG=unittest`: **129/129 modules pass**
- **Linux x86_64**, ldc, `CONFIG=unittest`: **131/131 modules pass**

The new `urt.file` unit test builds a directory containing two files of known size and a subdirectory, then asserts the walk returns exactly those three with the right sizes and the right directory flag, returns no `.` or `..`, and that reading a closed walk and opening a missing path both end rather than fault.

- **littlefs on hardware**, ESP32-S3 (Waveshare RS485-CAN), release build, driven from a console session over the board's provisioning AP:

```
/system/fs/ls                          /system/fs/ls path=conf
  280   .telnet_history                d 0   device_profiles
  5     a.txt                            16  startup.conf.bad
d 0     conf                           2 entries, 16 bytes
3 entries, 285 bytes
```

Files and directories distinguished, sizes correct, two levels of nesting walked, and both error cases clean: listing a path that does not exist and listing a regular file each fail rather than returning garbage. Enumeration on a freshly formatted volume returns only what is there.

## Not verified

**SPIFFS enumeration is compile-verified only.** Nothing here runs SPIFFS any more, so that backend has not been exercised. Given SPIFFS presents its flat namespace as one root listing, the interesting cases barely exist for it, but it is untested and should be read that way.

Found while writing the test, not fixed here: `get_temp_filename` with an empty `dstDir` creates the file at the drive root on Windows, then strips the leading `\` and returns a *relative* path, so the name it hands back does not refer to the file it made. The pre-existing test only survives it by creating the file itself at the relative path first. Passing `"."` avoids it.
