### PR TITLE
esp32: include dirent for SPIFFS enumeration

### DIFF
--- a/src/urt/driver/esp32/ow_shim.c
+++ b/src/urt/driver/esp32/ow_shim.c
@@ -2119,6 +2119,7 @@ void ow_lwip_freeaddrinfo(struct addrinfo *ai)
 
 #ifdef OW_USE_SPIFFS
 
+#include <dirent.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
Summary:
- include dirent.h before using DIR, opendir, readdir, and closedir in the ESP32 SPIFFS backend

Without this include, SPIFFS-enabled ESP-IDF builds fail while compiling ow_shim.c.

Validation:
- clean OpenWatt SmartEVSE ESP-IDF release link completed with this include
- produced openwatt.bin with 14 percent app-slot headroom