### PR TITLE
Filesystem groundwork for the HTTP fileserver

### DIFF
--- a/src/urt/driver/esp32/littlefs_port.c
+++ b/src/urt/driver/esp32/littlefs_port.c
@@ -231,6 +231,15 @@ int urt_littlefs_unlink(const char *path, size_t path_len)
     return lfs_remove(&ow_lfs, buffer) == 0 ? 0 : -1;
 }
 
+int urt_littlefs_mkdir(const char *path, size_t path_len)
+{
+    char buffer[OW_LFS_NAME_MAX + 1];
+    if (!ow_lfs_ready() || !ow_lfs_path(path, path_len, buffer, sizeof(buffer)))
+        return -1;
+    int err = lfs_mkdir(&ow_lfs, buffer);
+    return (err == 0 || err == LFS_ERR_EXIST) ? 0 : -1;
+}
+
 // littlefs renames atomically over an existing target, which SPIFFS cannot do.
 int urt_littlefs_rename(const char *from, size_t from_len, const char *to, size_t to_len)
 {

--- a/src/urt/file.d
+++ b/src/urt/file.d
@@ -546,6 +546,34 @@ Result create_directory(const(char)[] path)
     return r;
 }
 
+// Removes an empty directory; a populated one is refused by the filesystem.
+Result remove_directory(const(char)[] path)
+{
+    version (Windows)
+    {
+        if (!RemoveDirectoryW(path.twstringz))
+            return getlasterror_result();
+    }
+    else version (Posix)
+    {
+        if (urt.internal.sys.posix.rmdir(tconcat(path, "\0").ptr) != 0)
+            return errno_result();
+    }
+    else version (HasFileBackend)
+    {
+        static foreach (B; FileBackends)
+        {
+            if (B.exists(path))
+                return B.remove(path) ? Result.success : InternalResult.failed;
+        }
+        return InternalResult.failed;
+    }
+    else
+        return InternalResult.unsupported; // no filesystem on this platform
+
+    return Result.success;
+}
+
 Result open(ref Directory dir, const(char)[] path)
 {
     version (Windows)

--- a/src/urt/file.d
+++ b/src/urt/file.d
@@ -267,16 +267,49 @@ Result copy_file(const(char)[] oldPath, const(char)[] newPath, bool overwriteExi
     {
         if (!CopyFileW(oldPath.twstringz, newPath.twstringz, !overwriteExisting))
             return getlasterror_result();
-    }
-    else version (Posix)
-    {
-        // TODO
-        assert(false);
+        return Result.success;
     }
     else
-        return InternalResult.unsupported; // no filesystem on this platform
+    {
+        // byte-copy through this module's own File API, which covers every
+        // backend alike; only Windows has a native copy worth preferring
+        if (!overwriteExisting && file_exists(newPath))
+            return InternalResult.already_exists;
 
-    return Result.success;
+        File src, dst;
+        Result r = src.open(oldPath, FileOpenMode.ReadExisting, FileOpenFlags.Sequential);
+        if (!r)
+            return r;
+        r = dst.open(newPath, FileOpenMode.WriteTruncate);
+        if (!r)
+        {
+            src.close();
+            return r;
+        }
+
+        ubyte[4096] buffer = void;
+        for (;;)
+        {
+            size_t got;
+            r = src.read(buffer[], got);
+            if (!r || got == 0)
+                break;
+            size_t written;
+            r = dst.write(buffer[0 .. got], written);
+            if (!r)
+                break;
+            if (written != got)
+            {
+                r = InternalResult.failed;
+                break;
+            }
+        }
+        src.close();
+        dst.close();
+        if (!r)
+            delete_file(newPath); // don't leave a half-written target behind
+        return r;
+    }
 }
 
 Result get_path(ref const File file, ref char[] buffer)
@@ -360,8 +393,23 @@ Result get_file_attributes(const(char)[] path, out FileAttributes outAttributes)
     }
     else version (Posix)
     {
-        // TODO
-        assert(false);
+        stat_t st;
+        if (stat(path.tstringz, &st) != 0)
+            return errno_result();
+
+        outAttributes.attributes = FileAttributeFlag.None;
+        if (S_ISDIR(st.st_mode))
+        {
+            outAttributes.attributes |= FileAttributeFlag.Directory;
+            outAttributes.size = 0;
+        }
+        else
+            outAttributes.size = st.st_size;
+
+        // st_ctim is inode-change time; POSIX has no creation time, this is the nearest thing
+        outAttributes.createTime = from_unix_time_ns(st.st_ctim.tv_sec * 1_000_000_000UL + st.st_ctim.tv_nsec);
+        outAttributes.accessTime = from_unix_time_ns(st.st_atim.tv_sec * 1_000_000_000UL + st.st_atim.tv_nsec);
+        outAttributes.writeTime = from_unix_time_ns(st.st_mtim.tv_sec * 1_000_000_000UL + st.st_mtim.tv_nsec);
     }
     else version (HasFileBackend)
     {

--- a/src/urt/file.d
+++ b/src/urt/file.d
@@ -536,6 +536,16 @@ Result create_directory(const(char)[] path)
             return Result.success;
         r = errno_result();
     }
+    else version (HasFileBackend)
+    {
+        // create in the backend new files land in (the first); a flat
+        // namespace has no directories, the name simply works as a prefix
+        alias B = FileBackends[0];
+        static if (is(typeof(B.mkdir)))
+            return B.mkdir(path) ? Result.success : InternalResult.failed;
+        else
+            return Result.success;
+    }
     else
     {
         return InternalResult.unsupported; // no filesystem on this platform

--- a/src/urt/fs/littlefs.d
+++ b/src/urt/fs/littlefs.d
@@ -49,6 +49,9 @@ static nothrow @nogc:
     bool remove(const(char)[] path)
         => urt_littlefs_unlink(path.ptr, path.length) == 0;
 
+    bool mkdir(const(char)[] path)
+        => urt_littlefs_mkdir(path.ptr, path.length) == 0;
+
     bool rename(const(char)[] from, const(char)[] to)
         => urt_littlefs_rename(from.ptr, from.length, to.ptr, to.length) == 0;
 
@@ -103,6 +106,7 @@ private extern(C)
     int urt_littlefs_exists(const(char)* path, size_t path_len);
     int urt_littlefs_stat(const(char)* path, size_t path_len, ulong* size);
     int urt_littlefs_unlink(const(char)* path, size_t path_len);
+    int urt_littlefs_mkdir(const(char)* path, size_t path_len);
     int urt_littlefs_rename(const(char)* from, size_t from_len, const(char)* to, size_t to_len);
     int urt_littlefs_open(const(char)* path, size_t path_len, bool write, bool truncate);
     ptrdiff_t urt_littlefs_read(int fd, void* buffer, size_t length);

--- a/src/urt/internal/sys/posix/package.d
+++ b/src/urt/internal/sys/posix/package.d
@@ -307,6 +307,7 @@ else
 // and storing the full path just to stat it.
 int dirfd(DIR* dirp);
 int mkdir(scope const char* pathname, mode_t mode);
+int rmdir(scope const char* pathname);
 pure int posix_memalign(void** memptr, size_t alignment, size_t size);
 
 // ── time ──


### PR DESCRIPTION
Fills in the file-API gaps the OpenWatt HTTP fileserver (open-watt/openwatt: tiered static mount / WebDAV rework) needs:

- **posix `get_file_attributes` and `copy_file`** were `assert(false)` TODO stubs; the fileserver's COPY handler segfaulted on Linux the moment it touched `copy_file`. `get_file_attributes` is a straight `stat` (with `st_ctim` standing in for a creation time POSIX doesn't have). `copy_file` is a byte-copy through the module's own File API, so the same code covers the embedded backends; Windows keeps native `CopyFileW` for its attribute/timestamp preservation.
- **`remove_directory`** - counterpart of `create_directory`, used by recursive collection DELETE. Delegates to backend `remove` on flat stores (littlefs's remove already handles empty directories); adds the `rmdir` posix binding.
- **littlefs `mkdir`** (backend + C shim, `LFS_ERR_EXIST` treated as success), and `create_directory` gains its missing `HasFileBackend` branch - flat SPIFFS succeeds trivially since directory names are just prefixes there.

Verified via the fileserver's end-to-end curl suites on Windows and Linux (MKCOL / COPY of trees / recursive DELETE / PROPFIND mtimes), plus the openwatt unittest config (131/131).