### PR TITLE
wifi: report the negotiated PHY and the radio's ceiling

### DIFF
--- a/src/urt/driver/esp32/wifi.d
+++ b/src/urt/driver/esp32/wifi.d
@@ -342,10 +342,51 @@ bool wifi_hw_get_sta_link_info(uint port, ref WifiStaLinkInfo info)
 {
     if (port >= num_wifi)
         return false;
+    info = WifiStaLinkInfo.init;
     int rssi;
     if (ow_wifi_sta_get_ap_info(info.bssid.ptr, &rssi) == 0)
         return false;
     info.rssi = cast(byte)rssi;
+    info.nss = 1; // every ESP32 radio is 1x1
+
+    ubyte channel;
+    int secondary;
+    if (esp_wifi_get_channel(&channel, &secondary) == ESP_OK)
+        info.band = channel >= 36 ? WifiBand._5ghz : WifiBand._2_4ghz;
+
+    // ESP-IDF exposes no live bitrate, only the mode the association settled on, so the bitrates stay
+    // unknown and the caller derives a peak from the mode. wifi_phy_mode_t folds bandwidth into the
+    // mode and HT40 is the widest it can name, so a VHT80/HE80 link reads back understated.
+    int phymode;
+    if (esp_wifi_sta_get_negotiated_phymode(&phymode) != ESP_OK)
+        return true;
+    switch (phymode)
+    {
+        case WIFI_PHY_MODE_LR:
+            info.phy_mode = WifiPhyMode.lr;
+            break;
+        case WIFI_PHY_MODE_11B:
+            info.phy_mode = WifiPhyMode.b;
+            break;
+        case WIFI_PHY_MODE_11G, WIFI_PHY_MODE_11A:
+            info.phy_mode = WifiPhyMode.g;
+            break;
+        case WIFI_PHY_MODE_HT20:
+            info.phy_mode = WifiPhyMode.n;
+            break;
+        case WIFI_PHY_MODE_HT40:
+            info.phy_mode = WifiPhyMode.n;
+            info.bandwidth = WifiBandwidth.bw_40mhz;
+            break;
+        case WIFI_PHY_MODE_VHT20:
+            info.phy_mode = WifiPhyMode.ac;
+            break;
+        case WIFI_PHY_MODE_HE20:
+            info.phy_mode = WifiPhyMode.ax;
+            break;
+        default:
+            break;
+    }
     return true;
 }
 
@@ -497,6 +538,19 @@ enum : int
     WIFI_EVENT_AP_STOP            = 13,
     WIFI_EVENT_AP_STACONNECTED    = 14,
     WIFI_EVENT_AP_STADISCONNECTED = 15,
+}
+
+// wifi_phy_mode_t (from esp_wifi_types_generic.h)
+enum : int
+{
+    WIFI_PHY_MODE_LR    = 0,
+    WIFI_PHY_MODE_11B   = 1,
+    WIFI_PHY_MODE_11G   = 2,
+    WIFI_PHY_MODE_11A   = 3,
+    WIFI_PHY_MODE_HT20  = 4,
+    WIFI_PHY_MODE_HT40  = 5,
+    WIFI_PHY_MODE_HE20  = 6,
+    WIFI_PHY_MODE_VHT20 = 7,
 }
 
 __gshared bool _opened;
@@ -880,6 +934,7 @@ extern(C) nothrow @nogc
     int esp_wifi_set_max_tx_power(byte power);
     int esp_wifi_set_band_mode(int band_mode);
     int esp_wifi_get_channel(ubyte* primary, int* second);
+    int esp_wifi_sta_get_negotiated_phymode(int* phymode);
     int esp_read_mac(ubyte* mac, int type);
     int esp_wifi_internal_tx(int ifx, void* buffer, ushort len);
 }

--- a/src/urt/driver/esp32/wifi.d
+++ b/src/urt/driver/esp32/wifi.d
@@ -338,6 +338,79 @@ byte wifi_hw_get_rssi(uint port)
     return wifi_hw_get_sta_link_info(port, info) ? info.rssi : 0;
 }
 
+bool wifi_hw_get_capability(uint port, WifiBand band, ref WifiCapability caps)
+{
+    if (port >= num_wifi || band == WifiBand.any || !wifi_band_supported(cast(ubyte)port, band))
+        return false;
+    caps = WifiCapability.init;
+    caps.band = band;
+    caps.nss = 1; // every ESP32 radio is 1x1
+
+    // the protocol bitmap is what the driver has enabled, which is the ceiling any association here
+    // can reach even when the silicon could do more
+    ushort protocols;
+    int bw;
+    version (DualBandRadio)
+    {
+        WifiProtocols configured_protocols;
+        if (esp_wifi_get_protocols(WIFI_IF_STA, &configured_protocols) != ESP_OK)
+            return false;
+        protocols = band == WifiBand._2_4ghz
+            ? configured_protocols.band_2_4ghz
+            : configured_protocols.band_5ghz;
+
+        WifiBandwidths configured_bandwidths;
+        if (esp_wifi_get_bandwidths(WIFI_IF_STA, &configured_bandwidths) != ESP_OK)
+            return false;
+        bw = band == WifiBand._2_4ghz
+            ? configured_bandwidths.band_2_4ghz
+            : configured_bandwidths.band_5ghz;
+    }
+    else
+    {
+        ubyte configured_protocols;
+        if (esp_wifi_get_protocol(WIFI_IF_STA, &configured_protocols) != ESP_OK)
+            return false;
+        protocols = configured_protocols;
+
+        if (esp_wifi_get_bandwidth(WIFI_IF_STA, &bw) != ESP_OK)
+            return false;
+    }
+
+    if (protocols & WIFI_PROTOCOL_11AX)
+        caps.phy_mode = WifiPhyMode.ax;
+    else if (protocols & WIFI_PROTOCOL_11AC)
+        caps.phy_mode = WifiPhyMode.ac;
+    else if (protocols & WIFI_PROTOCOL_11N)
+        caps.phy_mode = WifiPhyMode.n;
+    else if (protocols & WIFI_PROTOCOL_11A)
+        caps.phy_mode = WifiPhyMode.a;
+    else if (protocols & WIFI_PROTOCOL_11G)
+        caps.phy_mode = WifiPhyMode.g;
+    else if (protocols & WIFI_PROTOCOL_11B)
+        caps.phy_mode = WifiPhyMode.b;
+    else if (protocols & WIFI_PROTOCOL_LR)
+        caps.phy_mode = WifiPhyMode.lr;
+
+    switch (bw)
+    {
+        case WIFI_BW40:
+            caps.bandwidth = WifiBandwidth.bw_40mhz;
+            break;
+        case WIFI_BW80:
+            caps.bandwidth = WifiBandwidth.bw_80mhz;
+            break;
+        case WIFI_BW160:
+        case WIFI_BW80_BW80:    // no non-contiguous member; 160 is the closer of the two
+            caps.bandwidth = WifiBandwidth.bw_160mhz;
+            break;
+        default:
+            caps.bandwidth = WifiBandwidth.bw_20mhz;
+            break;
+    }
+    return true;
+}
+
 bool wifi_hw_get_sta_link_info(uint port, ref WifiStaLinkInfo info)
 {
     if (port >= num_wifi)
@@ -368,7 +441,10 @@ bool wifi_hw_get_sta_link_info(uint port, ref WifiStaLinkInfo info)
         case WIFI_PHY_MODE_11B:
             info.phy_mode = WifiPhyMode.b;
             break;
-        case WIFI_PHY_MODE_11G, WIFI_PHY_MODE_11A:
+        case WIFI_PHY_MODE_11A:
+            info.phy_mode = WifiPhyMode.a;
+            break;
+        case WIFI_PHY_MODE_11G:
             info.phy_mode = WifiPhyMode.g;
             break;
         case WIFI_PHY_MODE_HT20:
@@ -539,6 +615,35 @@ enum : int
     WIFI_EVENT_AP_STACONNECTED    = 14,
     WIFI_EVENT_AP_STADISCONNECTED = 15,
 }
+
+enum int WIFI_IF_STA = 0;
+
+struct WifiProtocols
+{
+    ushort band_2_4ghz;
+    ushort band_5ghz;
+}
+
+struct WifiBandwidths
+{
+    int band_2_4ghz;
+    int band_5ghz;
+}
+
+// protocol bitmap and wifi_bandwidth_t (from esp_wifi_types_generic.h)
+enum ubyte WIFI_PROTOCOL_11B  = 0x01;
+enum ubyte WIFI_PROTOCOL_11G  = 0x02;
+enum ubyte WIFI_PROTOCOL_11N  = 0x04;
+enum ubyte WIFI_PROTOCOL_LR   = 0x08;
+enum ubyte WIFI_PROTOCOL_11A  = 0x10;
+enum ubyte WIFI_PROTOCOL_11AC = 0x20;
+enum ubyte WIFI_PROTOCOL_11AX = 0x40;
+
+enum int WIFI_BW20      = 1;
+enum int WIFI_BW40      = 2;
+enum int WIFI_BW80      = 3;
+enum int WIFI_BW160     = 4;
+enum int WIFI_BW80_BW80 = 5;
 
 // wifi_phy_mode_t (from esp_wifi_types_generic.h)
 enum : int
@@ -935,6 +1040,10 @@ extern(C) nothrow @nogc
     int esp_wifi_set_band_mode(int band_mode);
     int esp_wifi_get_channel(ubyte* primary, int* second);
     int esp_wifi_sta_get_negotiated_phymode(int* phymode);
+    int esp_wifi_get_protocol(int ifx, ubyte* protocol_bitmap);
+    int esp_wifi_get_protocols(int ifx, WifiProtocols* protocols);
+    int esp_wifi_get_bandwidth(int ifx, int* bw);
+    int esp_wifi_get_bandwidths(int ifx, WifiBandwidths* bandwidths);
     int esp_read_mac(ubyte* mac, int type);
     int esp_wifi_internal_tx(int ifx, void* buffer, ushort len);
 }

--- a/src/urt/driver/wifi.d
+++ b/src/urt/driver/wifi.d
@@ -94,7 +94,8 @@ enum WifiPhyMode : ubyte
 {
     unknown,
     b,      // DSSS/CCK
-    g,      // ERP-OFDM, also covers 11a
+    a,      // OFDM on 5 GHz
+    g,      // ERP-OFDM on 2.4 GHz
     n,      // HT
     ac,     // VHT
     ax,     // HE
@@ -181,6 +182,14 @@ struct WifiStaInfo
 {
     ubyte[6] mac;
     byte rssi;
+}
+
+struct WifiCapability
+{
+    WifiBand band;
+    WifiPhyMode phy_mode;
+    WifiBandwidth bandwidth;
+    ubyte nss;            // spatial streams, 0 = unknown
 }
 
 struct WifiStaLinkInfo
@@ -567,6 +576,23 @@ bool wifi_get_sta_link_info(ref Wifi wifi, ref WifiStaLinkInfo info)
         return wifi_hw_get_sta_link_info(wifi.port, info);
     else
         return false;
+}
+
+// The best this radio can do on one supported band, as opposed to what a link negotiated. A
+// multi-band radio has one capability per band; 'any' is not a band and is therefore rejected.
+bool wifi_get_capability(ref Wifi wifi, WifiBand band, ref WifiCapability caps)
+{
+    static if (num_wifi == 0)
+        return false;
+    else
+    {
+        if (band == WifiBand.any || !wifi_band_supported(wifi.port, band))
+            return false;
+        static if (__traits(compiles, wifi_hw_get_capability(wifi.port, band, caps)))
+            return wifi_hw_get_capability(wifi.port, band, caps);
+        else
+            return false;
+    }
 }
 
 Result wifi_set_tx_power(ref Wifi wifi, byte power_dbm)

--- a/src/urt/driver/wifi.d
+++ b/src/urt/driver/wifi.d
@@ -90,6 +90,18 @@ enum WifiBandwidth : ubyte
     bw_160mhz,
 }
 
+enum WifiPhyMode : ubyte
+{
+    unknown,
+    b,      // DSSS/CCK
+    g,      // ERP-OFDM, also covers 11a
+    n,      // HT
+    ac,     // VHT
+    ax,     // HE
+    be,     // EHT
+    lr,     // Espressif proprietary long range
+}
+
 enum WifiEvent : ubyte
 {
     sta_connected,
@@ -173,8 +185,15 @@ struct WifiStaInfo
 
 struct WifiStaLinkInfo
 {
+    uint tx_bitrate;      // kbit/s, 0 = unknown
+    uint rx_bitrate;      // kbit/s, 0 = unknown
     ubyte[6] bssid;
     byte rssi;
+    WifiBand band;
+    WifiPhyMode phy_mode;
+    WifiBandwidth bandwidth;
+    ubyte nss;            // spatial streams, 0 = unknown
+    bool short_gi;
 }
 
 // Delivered by wifi_service() when an Ethernet frame is received on a virtual


### PR DESCRIPTION
`WifiStaLinkInfo` carried only BSSID and RSSI, so callers could measure signal strength but could not determine the negotiated PHY. There was also no API for querying the radio's own PHY ceiling.

- Extends `WifiStaLinkInfo` with the active band, platform-reported bitrates, PHY mode, bandwidth, spatial streams, and guard interval.
- Adds `WifiPhyMode`, `WifiCapability`, and `wifi_get_capability(wifi, band, caps)`.
- Capability queries require a concrete supported band. `WifiBand.any` remains a selection policy for opening WiFi, not a capability domain.
- ESP32 fills the negotiated mode using `esp_wifi_sta_get_negotiated_phymode()`. ESP-IDF exposes no live bitrate, so bitrates remain zero and consumers can derive a peak from the negotiated descriptors.
- ESP32-C5 uses the ESP-IDF 6 per-band protocol and bandwidth APIs. This describes the capabilities of its one physical radio when operating on each selectable band; it does not imply concurrent bands.

Platforms without capability hooks remain unaffected: `wifi_get_capability` is `__traits(compiles)`-gated like the station link query, and unsupported fields remain at `.init`.

The ESP-IDF constants and ABI declarations are matched against the v6.0 headers.

Consumed by open-watt/openwatt#512.