### PR TITLE
WiFi driver model: band capability and selection

### DIFF
--- a/src/urt/driver/bl808_m0/wifi.d
+++ b/src/urt/driver/bl808_m0/wifi.d
@@ -1211,7 +1211,7 @@ extern (C) int on_scanu_result_ind(bl_hw* hw, bl_cmd* cmd, ipc_e2a_msg* msg)
     r.bssid     = body_.sa;
     r.rssi      = body_.rssi;
     r.channel   = freq_to_channel(body_.center_freq);
-    r.band      = body_.band == 0 ? WifiBand.band_2g4 : WifiBand.band_5g;
+    r.band      = body_.band == 0 ? WifiBand._2_4ghz : WifiBand._5ghz;
     r.bandwidth = WifiBandwidth.bw_20mhz;
     r.auth      = WifiAuth.open;
     r.ssid_len  = ssid.length > r.ssid_buf.length ? cast(ubyte)r.ssid_buf.length : cast(ubyte)ssid.length;
@@ -1370,7 +1370,7 @@ private bool wifi_set_monitor_mode(bool enable)
 
 private ushort channel_to_freq(ubyte ch, WifiBand band) pure
 {
-    if (band == WifiBand.band_5g || ch >= 36)
+    if (band == WifiBand._5ghz || ch >= 36)
         return cast(ushort)(5180 + (ch - 36) * 5);
     if (ch == 14)
         return 2484;

--- a/src/urt/driver/esp32/wifi.d
+++ b/src/urt/driver/esp32/wifi.d
@@ -28,6 +28,8 @@ else version (ESP32_C5) enum uint num_wifi = 1;
 else version (ESP32_C6) enum uint num_wifi = 1;
 else                    enum uint num_wifi = 0; // H2 (BT/802.15.4 only), P4 (needs external)
 
+version (ESP32_C5) version = DualBandRadio;
+
 enum ubyte wifi_max_ap_clients = 10;
 
 
@@ -53,6 +55,19 @@ bool wifi_hw_open(uint port, ref const WifiConfig cfg)
     {
         ow_wifi_deinit();
         return false;
+    }
+
+    version (DualBandRadio)
+    {
+        int band_mode = cfg.band == WifiBand._2_4ghz ? WIFI_BAND_MODE_2G_ONLY
+                      : cfg.band == WifiBand._5ghz   ? WIFI_BAND_MODE_5G_ONLY
+                      :                                WIFI_BAND_MODE_AUTO;
+        if (esp_wifi_set_band_mode(band_mode) != ESP_OK)
+        {
+            esp_wifi_stop();
+            ow_wifi_deinit();
+            return false;
+        }
     }
 
     _opened = true;
@@ -294,6 +309,14 @@ bool wifi_hw_set_channel(uint port, ubyte primary)
 
 // Queries
 
+ubyte wifi_hw_supported_bands(uint port) pure
+{
+    version (DualBandRadio)
+        return cast(ubyte)((1 << WifiBand._2_4ghz) | (1 << WifiBand._5ghz));
+    else
+        return cast(ubyte)(1 << WifiBand._2_4ghz);
+}
+
 bool wifi_hw_get_mac(uint port, WifiVif vif, ref ubyte[6] mac)
 {
     // ESP_MAC_WIFI_STA=0, ESP_MAC_WIFI_SOFTAP=1
@@ -454,6 +477,14 @@ bool dispatch_one_raw_rx(Wifi wifi)
 }
 
 enum int ESP_OK = 0;
+
+// ESP-IDF band modes (from esp_wifi_types_generic.h)
+enum : int
+{
+    WIFI_BAND_MODE_2G_ONLY = 1,
+    WIFI_BAND_MODE_5G_ONLY = 2,
+    WIFI_BAND_MODE_AUTO    = 3,
+}
 
 // ESP-IDF event IDs (from esp_wifi_types.h)
 enum : int
@@ -847,6 +878,7 @@ extern(C) nothrow @nogc
     int esp_wifi_connect();
     int esp_wifi_disconnect();
     int esp_wifi_set_max_tx_power(byte power);
+    int esp_wifi_set_band_mode(int band_mode);
     int esp_wifi_get_channel(ubyte* primary, int* second);
     int esp_read_mac(ubyte* mac, int type);
     int esp_wifi_internal_tx(int ifx, void* buffer, ushort len);

--- a/src/urt/driver/wifi.d
+++ b/src/urt/driver/wifi.d
@@ -77,9 +77,9 @@ enum WifiAuth : ubyte
 enum WifiBand : ubyte
 {
     any,
-    band_2g4,   // 2.4 GHz
-    band_5g,    // 5 GHz
-    band_6g,    // 6 GHz (Wi-Fi 6E)
+    _2_4ghz,
+    _5ghz,
+    _6ghz,
 }
 
 enum WifiBandwidth : ubyte
@@ -240,6 +240,29 @@ void wifi_deinit()
 
 // Radio operations
 
+ubyte wifi_supported_bands(ubyte port) pure
+{
+    static if (num_wifi == 0)
+        return 0;
+    else
+    {
+        if (port >= num_wifi)
+            return 0;
+        static if (__traits(compiles, wifi_hw_supported_bands(port)))
+            return wifi_hw_supported_bands(port);
+        else
+            return cast(ubyte)(1 << WifiBand._2_4ghz);
+    }
+}
+
+bool wifi_band_supported(ubyte port, WifiBand band) pure
+{
+    ubyte supported = wifi_supported_bands(port);
+    return band == WifiBand.any
+        ? supported != 0
+        : (supported & (1 << band)) != 0;
+}
+
 Result wifi_open(ref Wifi wifi, ubyte port, ref const WifiConfig cfg)
 {
     static if (num_wifi == 0)
@@ -247,6 +270,8 @@ Result wifi_open(ref Wifi wifi, ubyte port, ref const WifiConfig cfg)
     else
     {
         if (port >= num_wifi)
+            return InternalResult.invalid_parameter;
+        if (!wifi_band_supported(port, cfg.band))
             return InternalResult.invalid_parameter;
 
         if (!wifi_hw_open(port, cfg))
@@ -589,6 +614,7 @@ unittest
             assert(r2, "wifi_open failed");
             assert(port.is_open);
             assert(port.port == p);
+            assert(wifi_supported_bands(port.port) != 0);
 
             wifi_service(port);
 

--- a/src/urt/meta/enuminfo.d
+++ b/src/urt/meta/enuminfo.d
@@ -43,6 +43,11 @@ private template get_display_attr(Attrs...)
         enum get_display_attr = get_display_attr!(Attrs[1 .. $]);
 }
 
+// Canonical CLI/profile key for an enum member name: edge underscores trimmed,
+// so digit-leading keys can be expressed as identifiers (`_5g` -> "5g").
+import urt.string : trim;
+enum trim_key(string key) = key.trim!(c => c == '_');
+
 const(E)* enum_from_key(E)(const(char)[] key) pure
     if (is_enum!E)
     => enum_info!E.value_for(key);
@@ -687,9 +692,6 @@ alias GetFun = Variant function(const(void)*, const(VoidEnumInfo)*) pure;
 
 Variant get_value(T)(const(void)* ptr, const(VoidEnumInfo)* info)
     => Variant(*cast(T*)ptr, info);
-
-import urt.string : trim;
-enum trim_key(string key) = key.trim!(c => c == '_');
 
 ushort key_length(const(char)* key) pure
 {


### PR DESCRIPTION
Adds per-radio band capability and selection to the wifi driver model, modelling a radio device as one tunable RF unit: the device declares which bands it can tune, the frontend selects one.

- `WifiBands` capability mask + `wifi_supported_bands(port)` / `wifi_band_supported(port, band)` (pure, valid before open; defaults to 2.4GHz-only when a backend has no hook), with `wifi_open` rejecting configs asking for an unsupported band so every backend is guarded in one place.
- `WifiBand` members renamed to `any/_2_4ghz/_5ghz/_6ghz` so the trimmed enum keys read naturally at the openwatt CLI (`band=2_4ghz`); `trim_key` is now public as the canonical key derivation (the openwatt console now uses it too).
- ESP32 backend: C5 advertises 2.4+5 and applies `esp_wifi_set_band_mode` after `esp_wifi_start()` (values and call-order constraints verified against IDF v6.0 headers). Other Espressif parts and BL808 remain 2.4-only via the default.

Compile-verified for x86_64 windows/linux and esp32-c5 (LDC release, which builds the DualBandRadio path); C5 not yet exercised on hardware.

Pairs with the openwatt PR adding the `band` property to WiFiInterface.