### PR TITLE
Bucketed page pool, memory reclaim + threat watermarks

### DIFF
--- a/src/urt/driver/bl_common/alloc.d
+++ b/src/urt/driver/bl_common/alloc.d
@@ -49,6 +49,7 @@ version (BouffaloUnifiedAlloc):
 
 import urt.attribute : fast_data;
 import urt.mem.alloc : MemFlags;
+import urt.sync.critical : Critical;
 
 @nogc nothrow:
 
@@ -155,6 +156,7 @@ struct PoolStats
 
 void query_pool_stats(size_t idx, out PoolStats stats) nothrow @nogc
 {
+    auto guard = _heap_lock.acquire();
     init_pools();
     auto p = &_pools[idx];
     stats.name = p.name;
@@ -367,40 +369,52 @@ enum TLSF_CONTROL_BYTES = 3200;
 @fast_data __gshared Pool[num_pools] _pools;
 @fast_data __gshared bool _initialized;
 
+// TLSF has no internal locking, and vendor C (libwifi etc) enters through the
+// extern(C) malloc overrides from other tasks; every touch of the pools goes
+// under this lock. Log calls stay outside it -- they format strings.
+@fast_data __gshared Critical _heap_lock;
+
 
 void[] alloc_impl(size_t size, size_t alignment, MemFlags flags) nothrow @nogc
 {
-    init_pools();
-
     bool dma = (flags & MemFlags.dma) != 0;
-    size_t primary = pool_for(flags);
-
-    void* p = tlsf_memalign(_pools[primary].tlsf, alignment, size);
-    size_t allocated_in = primary;
-    if (p is null && !dma)
+    bool failed_over = false;
+    void* p;
     {
-        foreach (i, ref f; _pools)
+        auto guard = _heap_lock.acquire();
+        init_pools();
+
+        size_t primary = pool_for(flags);
+        p = tlsf_memalign(_pools[primary].tlsf, alignment, size);
+        size_t allocated_in = primary;
+        if (p is null && !dma)
         {
-            if (i == primary)
-                continue;
-            p = tlsf_memalign(f.tlsf, alignment, size);
-            if (p !is null)
+            foreach (i, ref f; _pools)
             {
-                allocated_in = i;
-                log_failover(size, alignment, flags);
-                break;
+                if (i == primary)
+                    continue;
+                p = tlsf_memalign(f.tlsf, alignment, size);
+                if (p !is null)
+                {
+                    allocated_in = i;
+                    failed_over = true;
+                    break;
+                }
             }
+        }
+
+        if (p !is null)
+        {
+            size_t block = tlsf_block_size(p);
+            _pools[allocated_in].used += block;
+            if (_pools[allocated_in].used > _pools[allocated_in].peak_used)
+                _pools[allocated_in].peak_used = _pools[allocated_in].used;
         }
     }
 
-    if (p !is null)
-    {
-        size_t block = tlsf_block_size(p);
-        _pools[allocated_in].used += block;
-        if (_pools[allocated_in].used > _pools[allocated_in].peak_used)
-            _pools[allocated_in].peak_used = _pools[allocated_in].used;
-    }
-    else
+    if (failed_over)
+        log_failover(size, alignment, flags);
+    if (p is null)
         log_oom(size, alignment, flags);
 
     return p ? p[0 .. size] : null;
@@ -415,6 +429,8 @@ void[] realloc_impl(void[] mem, size_t new_size, size_t alignment, MemFlags flag
         free_impl(mem.ptr);
         return null;
     }
+
+    auto guard = _heap_lock.acquire();
     Pool* owner = pool_of(mem.ptr);
     if (owner is null)
         return null;
@@ -431,6 +447,7 @@ void[] realloc_impl(void[] mem, size_t new_size, size_t alignment, MemFlags flag
 
 void free_impl(void* ptr) nothrow @nogc
 {
+    auto guard = _heap_lock.acquire();
     Pool* owner = pool_of(ptr);
     if (owner is null)
         return;

--- a/src/urt/mem/alloc.d
+++ b/src/urt/mem/alloc.d
@@ -38,6 +38,12 @@ void[] alloc(size_t size, size_t alignment, MemFlags flags = MemFlags.none) pure
         if ((cast(ReclaimFn) &reclaim_memory)(size) > 0)
             mem = _alloc(size, alignment, flags);
     }
+    if (mem.ptr !is null)
+    {
+        import urt.mem.reclaim : account_alloc;
+        alias AccountFn = void function(size_t) pure nothrow @nogc;
+        (cast(AccountFn) &account_alloc)(mem.length);
+    }
     version (AllocTracking)
     {
         import urt.mem.profile.record : track_alloc;
@@ -83,6 +89,15 @@ void[] realloc(void[] mem, size_t new_size, size_t alignment = 8, MemFlags flags
             if ((cast(ReclaimFn) &reclaim_memory)(new_size) > 0)
                 new_mem = _realloc(mem, new_size, alignment, flags);
         }
+        if (new_mem.ptr !is null)
+        {
+            import urt.mem.reclaim : account_alloc, account_free;
+            alias AccountFn = void function(size_t) pure nothrow @nogc;
+            if (new_mem.length > old_size)
+                (cast(AccountFn) &account_alloc)(new_mem.length - old_size);
+            else if (new_mem.length < old_size)
+                (cast(AccountFn) &account_free)(old_size - new_mem.length);
+        }
         version (AllocTracking)
         {
             import urt.mem.profile.record : track_realloc;
@@ -121,6 +136,11 @@ void free(void[] mem) pure
 {
     if (mem.ptr is null)
         return;
+    {
+        import urt.mem.reclaim : account_free;
+        alias AccountFn = void function(size_t) pure nothrow @nogc;
+        (cast(AccountFn) &account_free)(mem.length);
+    }
     version (AllocTracking)
     {
         import urt.mem.profile.record : untrack_alloc;
@@ -152,6 +172,15 @@ void[] expand(void[] mem, size_t new_size) pure
     {
         void[] new_mem = null;
         assert(false, "unsupported");
+    }
+    if (new_mem.ptr !is null && new_mem.length != mem.length)
+    {
+        import urt.mem.reclaim : account_alloc, account_free;
+        alias AccountFn = void function(size_t) pure nothrow @nogc;
+        if (new_mem.length > mem.length)
+            (cast(AccountFn) &account_alloc)(new_mem.length - mem.length);
+        else
+            (cast(AccountFn) &account_free)(mem.length - new_mem.length);
     }
     version (AllocProfile)
     {

--- a/src/urt/mem/alloc.d
+++ b/src/urt/mem/alloc.d
@@ -31,6 +31,13 @@ void[] alloc(size_t size, size_t alignment, MemFlags flags = MemFlags.none) pure
     assert(is_power_of_2(alignment), "Alignment must be a power of two!");
 
     void[] mem = _alloc(size, alignment, flags);
+    if (mem.ptr is null && size > 0)
+    {
+        import urt.mem.reclaim : reclaim_memory;
+        alias ReclaimFn = size_t function(size_t) pure nothrow @nogc;
+        if ((cast(ReclaimFn) &reclaim_memory)(size) > 0)
+            mem = _alloc(size, alignment, flags);
+    }
     version (AllocTracking)
     {
         import urt.mem.profile.record : track_alloc;
@@ -69,6 +76,13 @@ void[] realloc(void[] mem, size_t new_size, size_t alignment = 8, MemFlags flags
         void* old_ptr = mem.ptr;
         size_t old_size = mem.length;
         void[] new_mem = _realloc(mem, new_size, alignment, flags);
+        if (new_mem.ptr is null)
+        {
+            import urt.mem.reclaim : reclaim_memory;
+            alias ReclaimFn = size_t function(size_t) pure nothrow @nogc;
+            if ((cast(ReclaimFn) &reclaim_memory)(new_size) > 0)
+                new_mem = _realloc(mem, new_size, alignment, flags);
+        }
         version (AllocTracking)
         {
             import urt.mem.profile.record : track_realloc;

--- a/src/urt/mem/pagepool.d
+++ b/src/urt/mem/pagepool.d
@@ -1,0 +1,494 @@
+module urt.mem.pagepool;
+
+import urt.mem.alloc;
+import urt.mem.reclaim;
+import urt.sync.critical;
+
+nothrow @nogc:
+
+
+// Bucketed page pool: fixed-size pages in a few size categories, carved from slabs.
+// Allocation prefers the most-occupied slab so lightly-used slabs drain to fully-idle
+// and can be returned to the heap; the pool registers itself as a memory reclaimer.
+// Requests beyond the largest category get a heap-backed page with the same header,
+// so page_free() is uniform. Pop/push run under a Critical; slab allocation and
+// release always happen outside it.
+
+enum max_page_categories = 4;
+enum ubyte page_category_heap = 0xFF;
+
+struct PageHeader
+{
+    PageHeader* next;       // freelist link; reserved as a chain link for in-use pages
+    uint slab_offset;       // pool page: bytes back to the SlabHeader; heap-backed: total block size
+    ubyte category;
+    ubyte flags;
+    ushort refcount;        // reserved; pages are single-owner for now
+}
+enum page_header_size = (PageHeader.sizeof + 15) & ~15;
+
+enum ubyte page_flag_heap = 0x01;
+
+struct PageCategoryConfig
+{
+    uint page_size;         // total bytes per page, including header; multiple of 16
+    ushort pages_per_slab;
+    ushort max_slabs;       // hard cap; allocation past this fails
+    ushort prealloc_slabs;  // floor kept resident through trim
+}
+
+struct PagePoolStats
+{
+    uint pages_in_use;
+    uint pages_free;
+    uint slab_count;
+    uint high_water;        // peak pages_in_use
+    ulong alloc_count;
+    ulong fail_count;
+    ulong[8] size_histogram;    // page_alloc_for() requests: <=64, <=128, ... <=4096, larger
+}
+
+
+// Categories must be given in ascending page_size order. Idempotent; returns false if
+// the pool is already initialised.
+bool page_pool_init(const(PageCategoryConfig)[] categories)
+{
+    assert(categories.length > 0 && categories.length <= max_page_categories);
+
+    {
+        auto guard = _lock.acquire();
+        if (_num_categories != 0)
+            return false;
+
+        foreach (i, ref cfg; categories)
+        {
+            assert(cfg.page_size % 16 == 0 && cfg.page_size > page_header_size);
+            assert(cfg.pages_per_slab > 0 && cfg.max_slabs > 0);
+            assert(cfg.prealloc_slabs <= cfg.max_slabs);
+            assert(i == 0 || cfg.page_size > categories[i - 1].page_size);
+            _categories[i].cfg = cfg;
+        }
+        _num_categories = cast(uint)categories.length;
+    }
+
+    foreach (i; 0 .. categories.length)
+    {
+        foreach (s; 0 .. categories[i].prealloc_slabs)
+        {
+            if (!add_slab(&_categories[i]))
+                break;
+        }
+    }
+
+    register_reclaimer(&trim_handler, 200, true);
+    return true;
+}
+
+void[] page_alloc(ubyte category)
+{
+    assert(category < _num_categories);
+    Category* c = &_categories[category];
+
+    for (;;)
+    {
+        {
+            auto guard = _lock.acquire();
+
+            SlabHeader* best = null;
+            for (SlabHeader* s = c.slabs; s; s = s.next)
+            {
+                if (s.free_count != 0 && (!best || s.free_count < best.free_count))
+                    best = s;
+            }
+            if (best)
+            {
+                PageHeader* p = best.free_list;
+                best.free_list = p.next;
+                --best.free_count;
+                p.next = null;
+                p.flags = 0;
+                p.refcount = 0;
+
+                ++c.stats.alloc_count;
+                --c.stats.pages_free;
+                if (++c.stats.pages_in_use > c.stats.high_water)
+                    c.stats.high_water = c.stats.pages_in_use;
+                return payload_of(p, c.cfg.page_size);
+            }
+            if (c.stats.slab_count >= c.cfg.max_slabs)
+            {
+                ++c.stats.fail_count;
+                return null;
+            }
+        }
+
+        if (!add_slab(c))
+        {
+            auto guard = _lock.acquire();
+            ++c.stats.fail_count;
+            return null;
+        }
+    }
+}
+
+// Smallest category whose payload fits `bytes`; beyond the largest, a heap-backed
+// page. A capped-out category escalates to the next (still cap-bounded); an in-range
+// request never falls through to the heap, so the caps stay meaningful under flood.
+void[] page_alloc_for(size_t bytes)
+{
+    ubyte cat = ubyte.max;
+    uint num_categories;
+    {
+        auto guard = _lock.acquire();
+        num_categories = _num_categories;
+        foreach (i; 0 .. _num_categories)
+        {
+            if (bytes <= _categories[i].cfg.page_size - page_header_size)
+            {
+                cat = cast(ubyte)i;
+                ++_categories[i].stats.size_histogram[histogram_bucket(bytes)];
+                break;
+            }
+        }
+    }
+    if (cat != ubyte.max)
+    {
+        foreach (i; cat .. num_categories)
+        {
+            void[] r = page_alloc(cast(ubyte)i);
+            if (r)
+                return r[0 .. bytes];
+        }
+        return null;
+    }
+
+    size_t block_size = page_header_size + bytes;
+    void[] mem = alloc(block_size, 16);
+    if (!mem.ptr)
+    {
+        auto guard = _lock.acquire();
+        ++_jumbo_stats.fail_count;
+        return null;
+    }
+    PageHeader* h = cast(PageHeader*)mem.ptr;
+    h.next = null;
+    h.slab_offset = cast(uint)block_size;
+    h.category = page_category_heap;
+    h.flags = page_flag_heap;
+    h.refcount = 0;
+
+    {
+        auto guard = _lock.acquire();
+        ++_jumbo_stats.alloc_count;
+        ++_jumbo_stats.size_histogram[histogram_bucket(bytes)];
+        if (++_jumbo_stats.pages_in_use > _jumbo_stats.high_water)
+            _jumbo_stats.high_water = _jumbo_stats.pages_in_use;
+    }
+    return (mem.ptr + page_header_size)[0 .. bytes];
+}
+
+void page_free(void* payload)
+{
+    PageHeader* h = header_of(payload);
+    if (h.flags & page_flag_heap)
+    {
+        size_t block_size = h.slab_offset;
+        {
+            auto guard = _lock.acquire();
+            --_jumbo_stats.pages_in_use;
+        }
+        free((cast(void*)h)[0 .. block_size]);
+        return;
+    }
+
+    assert(h.category < _num_categories);
+    Category* c = &_categories[h.category];
+    SlabHeader* slab = cast(SlabHeader*)(cast(void*)h - h.slab_offset);
+
+    auto guard = _lock.acquire();
+    h.next = slab.free_list;
+    slab.free_list = h;
+    ++slab.free_count;
+    --c.stats.pages_in_use;
+    ++c.stats.pages_free;
+}
+
+ubyte page_category(const(void)* payload)
+    => header_of(payload).category;
+
+size_t page_payload_size(ubyte category)
+{
+    assert(category < _num_categories);
+    return _categories[category].cfg.page_size - page_header_size;
+}
+
+// Release fully-idle slabs (above each category's prealloc floor) back to the heap.
+// Returns bytes freed; stops once bytes_needed is covered.
+size_t page_pool_trim(size_t bytes_needed = size_t.max)
+{
+    size_t freed = 0;
+    foreach (i; 0 .. _num_categories)
+    {
+        Category* c = &_categories[i];
+        SlabHeader* release_chain = null;
+
+        {
+            auto guard = _lock.acquire();
+            SlabHeader** link = &c.slabs;
+            while (*link)
+            {
+                SlabHeader* s = *link;
+                if (s.free_count == s.page_count && c.stats.slab_count > c.cfg.prealloc_slabs
+                    && freed < bytes_needed)
+                {
+                    *link = s.next;
+                    --c.stats.slab_count;
+                    c.stats.pages_free -= s.page_count;
+                    s.next = release_chain;
+                    release_chain = s;
+                    freed += slab_bytes(c.cfg);
+                }
+                else
+                    link = &s.next;
+            }
+        }
+
+        while (release_chain)
+        {
+            SlabHeader* s = release_chain;
+            release_chain = s.next;
+            free((cast(void*)s)[0 .. slab_bytes(c.cfg)]);
+        }
+
+        if (freed >= bytes_needed)
+            break;
+    }
+    return freed;
+}
+
+PagePoolStats page_pool_stats(ubyte category)
+{
+    auto guard = _lock.acquire();
+    if (category == page_category_heap)
+        return _jumbo_stats;
+    assert(category < _num_categories);
+    return _categories[category].stats;
+}
+
+uint page_pool_num_categories()
+    => _num_categories;
+
+// Releases all slabs and returns the pool to its uninitialised state. No page may be
+// in use. Primarily for tests and orderly shutdown.
+void page_pool_deinit()
+{
+    if (_num_categories == 0)
+        return;
+    unregister_reclaimer(&trim_handler);
+    foreach (i; 0 .. _num_categories)
+    {
+        Category* c = &_categories[i];
+        assert(c.stats.pages_in_use == 0, "Page pool deinit with pages in use!");
+        SlabHeader* s = c.slabs;
+        while (s)
+        {
+            SlabHeader* n = s.next;
+            free((cast(void*)s)[0 .. slab_bytes(c.cfg)]);
+            s = n;
+        }
+        *c = Category();
+    }
+    _num_categories = 0;
+    _jumbo_stats = PagePoolStats();
+}
+
+
+private:
+
+struct SlabHeader
+{
+    SlabHeader* next;
+    PageHeader* free_list;
+    ushort free_count;
+    ushort page_count;
+}
+enum slab_header_size = (SlabHeader.sizeof + 15) & ~15;
+
+struct Category
+{
+    SlabHeader* slabs;
+    PageCategoryConfig cfg;
+    PagePoolStats stats;
+}
+
+__gshared Critical _lock;
+__gshared Category[max_page_categories] _categories;
+__gshared uint _num_categories;
+__gshared PagePoolStats _jumbo_stats;
+
+size_t slab_bytes(ref const PageCategoryConfig cfg)
+    => slab_header_size + cfg.page_size * cfg.pages_per_slab;
+
+PageHeader* header_of(const(void)* payload)
+    => cast(PageHeader*)(payload - page_header_size);
+
+void[] payload_of(PageHeader* h, uint page_size)
+    => (cast(void*)h + page_header_size)[0 .. page_size - page_header_size];
+
+size_t histogram_bucket(size_t bytes)
+{
+    size_t bucket = 0;
+    size_t threshold = 64;
+    while (bytes > threshold && bucket < 7)
+    {
+        threshold <<= 1;
+        ++bucket;
+    }
+    return bucket;
+}
+
+// Allocates and carves a slab OUTSIDE the pool lock, then links it in; if a concurrent
+// refill won the race to the cap, the extra slab is released (again outside the lock).
+bool add_slab(Category* c)
+{
+    size_t bytes = slab_bytes(c.cfg);
+    void[] mem = alloc(bytes, 16);
+    if (!mem.ptr)
+        return false;
+
+    SlabHeader* slab = cast(SlabHeader*)mem.ptr;
+    slab.next = null;
+    slab.page_count = c.cfg.pages_per_slab;
+    slab.free_count = c.cfg.pages_per_slab;
+
+    PageHeader* prev = null;
+    ubyte category = cast(ubyte)(c - _categories.ptr);
+    foreach_reverse (i; 0 .. c.cfg.pages_per_slab)
+    {
+        uint offset = cast(uint)(slab_header_size + i * c.cfg.page_size);
+        PageHeader* p = cast(PageHeader*)(mem.ptr + offset);
+        p.next = prev;
+        p.slab_offset = offset;
+        p.category = category;
+        p.flags = 0;
+        p.refcount = 0;
+        prev = p;
+    }
+    slab.free_list = prev;
+
+    {
+        auto guard = _lock.acquire();
+        if (c.stats.slab_count < c.cfg.max_slabs)
+        {
+            slab.next = c.slabs;
+            c.slabs = slab;
+            ++c.stats.slab_count;
+            c.stats.pages_free += slab.page_count;
+            return true;
+        }
+    }
+    free(mem);
+    return true;    // the cap was reached by someone else; a page is available
+}
+
+size_t trim_handler(size_t bytes_needed)
+    => page_pool_trim(bytes_needed);
+
+
+unittest
+{
+    static immutable PageCategoryConfig[2] test_cfg = [
+        PageCategoryConfig(64, 4, 2, 1),
+        PageCategoryConfig(256, 2, 2, 0),
+    ];
+
+    static void* slab_of(void* payload)
+    {
+        PageHeader* h = header_of(payload);
+        return cast(void*)h - h.slab_offset;
+    }
+
+    // another module's test may have lazily initialised the pool already; start clean
+    // (deinit asserts nothing is still in use, which doubles as a leak check)
+    page_pool_deinit();
+
+    assert(page_pool_init(test_cfg));
+    assert(!page_pool_init(test_cfg));
+    assert(page_pool_num_categories() == 2);
+    assert(page_payload_size(0) == 64 - page_header_size);
+
+    // prealloc: category 0 has one resident slab
+    PagePoolStats s = page_pool_stats(0);
+    assert(s.slab_count == 1 && s.pages_free == 4 && s.pages_in_use == 0);
+
+    // round-trip + category lookup
+    void[] a = page_alloc(0);
+    assert(a.length == 64 - page_header_size);
+    assert(page_category(a.ptr) == 0);
+    s = page_pool_stats(0);
+    assert(s.pages_in_use == 1 && s.alloc_count == 1 && s.high_water == 1);
+    page_free(a.ptr);
+    s = page_pool_stats(0);
+    assert(s.pages_in_use == 0 && s.pages_free == 4);
+
+    // exhaustion: 2 slabs * 4 pages, then fail
+    void[][8] pages;
+    foreach (i; 0 .. 8)
+    {
+        pages[i] = page_alloc(0);
+        assert(pages[i] !is null);
+    }
+    assert(page_alloc(0) is null);
+    s = page_pool_stats(0);
+    assert(s.slab_count == 2 && s.fail_count == 1 && s.high_water == 8);
+
+    // packing: with both slabs idle, sequential allocs must all land in the same slab
+    // (first alloc breaks the tie, the partially-used slab is then preferred)
+    foreach (i; 0 .. 8)
+        page_free(pages[i].ptr);
+    void[] keep = page_alloc(0);
+    foreach (i; 0 .. 3)
+    {
+        void[] p = page_alloc(0);
+        assert(slab_of(p.ptr) is slab_of(keep.ptr));
+        pages[i] = p;
+    }
+    void[] other = page_alloc(0);
+    assert(slab_of(other.ptr) !is slab_of(keep.ptr));
+    foreach (i; 0 .. 3)
+        page_free(pages[i].ptr);
+    page_free(other.ptr);
+
+    // trim: the now fully-idle slab (above the prealloc floor of 1) gets released;
+    // the slab holding `keep` survives
+    size_t freed = page_pool_trim();
+    assert(freed == slab_header_size + 64 * 4);
+    s = page_pool_stats(0);
+    assert(s.slab_count == 1 && s.pages_in_use == 1);
+    page_free(keep.ptr);
+
+    // size-class selection + jumbo
+    void[] small = page_alloc_for(32);
+    assert(small.length == 32 && page_category(small.ptr) == 0);
+    void[] mid = page_alloc_for(100);
+    assert(page_category(mid.ptr) == 1);
+    void[] jumbo = page_alloc_for(1000);
+    assert(jumbo.length == 1000 && page_category(jumbo.ptr) == page_category_heap);
+    PagePoolStats js = page_pool_stats(page_category_heap);
+    assert(js.pages_in_use == 1 && js.alloc_count == 1);
+    page_free(jumbo.ptr);
+    js = page_pool_stats(page_category_heap);
+    assert(js.pages_in_use == 0);
+    page_free(mid.ptr);
+    page_free(small.ptr);
+
+    // reclaimer is registered: an explicit walk trims the pool (nothing idle now
+    // above floors, so this just proves the plumbing runs)
+    import urt.mem.reclaim : reclaim_memory;
+    reclaim_memory(1);
+
+    page_pool_deinit();
+    assert(page_pool_num_categories() == 0);
+    assert(page_pool_init(test_cfg));
+    page_pool_deinit();
+}

--- a/src/urt/mem/reclaim.d
+++ b/src/urt/mem/reclaim.d
@@ -1,5 +1,6 @@
 module urt.mem.reclaim;
 
+import urt.atomic;
 import urt.sync.critical;
 import urt.thread : is_main_thread;
 
@@ -51,6 +52,48 @@ size_t reclaim_memory(size_t bytes_needed)
             break;
     }
     return freed;
+}
+
+
+// Memory-threat watermarks: when allocated bytes cross an entry's high watermark the
+// handler fires ONCE, re-arming only after usage falls back below the low watermark.
+// Handlers run inside the allocator on whatever thread allocated: they must not block
+// and must not do work -- post an event to a queue and return. Usage is accounted in
+// requested bytes, excluding allocator headers and fragmentation, so watermarks are a
+// proxy for heap footprint, not an exact measure.
+
+alias MemoryThreatHandler  = void delegate(size_t used) nothrow @nogc;
+alias MemoryThreatFunction = void function(size_t used) nothrow @nogc;
+
+size_t memory_in_use()
+    => atomicLoad(_used);
+
+bool register_memory_threat(MemoryThreatHandler handler, size_t high, size_t low)
+    => add_threat(Threat(handler.funcptr, handler.ptr, high, low, false, true));
+
+bool register_memory_threat(MemoryThreatFunction handler, size_t high, size_t low)
+    => add_threat(Threat(handler, null, high, low, false, false));
+
+bool unregister_memory_threat(MemoryThreatHandler handler)
+    => remove_threat(Threat(handler.funcptr, handler.ptr, 0, 0, false, true));
+
+bool unregister_memory_threat(MemoryThreatFunction handler)
+    => remove_threat(Threat(handler, null, 0, 0, false, false));
+
+// Called by urt.mem.alloc on every successful alloc/free (and realloc/expand deltas);
+// must stay one atomic + one compare on the uncrossed path.
+void account_alloc(size_t bytes)
+{
+    size_t used = atomicFetchAdd(_used, bytes) + bytes;
+    if (used >= atomicLoad(_next_high))
+        threat_crossed(used);
+}
+
+void account_free(size_t bytes)
+{
+    size_t used = atomicFetchSub(_used, bytes) - bytes;
+    if (used <= atomicLoad(_max_low))
+        threat_rearm(used);
 }
 
 
@@ -129,6 +172,114 @@ __gshared Critical _lock;
 __gshared bool _walking;
 __gshared Reclaimer[8] _reclaimers;
 __gshared uint _num_reclaimers;
+
+struct Threat
+{
+nothrow @nogc:
+    MemoryThreatFunction fn;
+    void* context;
+    size_t high;
+    size_t low;
+    bool fired;
+    bool is_delegate;   // see Reclaimer.is_delegate
+
+    void fire(size_t used)
+    {
+        if (is_delegate)
+        {
+            MemoryThreatHandler dg;
+            dg.ptr = context;
+            dg.funcptr = fn;
+            dg(used);
+        }
+        else
+            fn(used);
+    }
+
+    bool matches(ref const Threat other) const
+        => fn is other.fn && context is other.context && is_delegate == other.is_delegate;
+}
+
+__gshared Threat[4] _threats;
+__gshared uint _num_threats;
+shared size_t _used;
+shared size_t _next_high = size_t.max;  // min high among armed entries
+shared size_t _max_low;                 // max low among fired entries
+
+bool add_threat(Threat t)
+{
+    assert(t.low < t.high, "Threat low watermark must be below high");
+
+    auto guard = _lock.acquire();
+    if (_num_threats == _threats.length)
+        return false;
+    foreach (ref e; _threats[0 .. _num_threats])
+    {
+        if (e.matches(t))
+            return false;
+    }
+    _threats[_num_threats++] = t;
+    update_thresholds();
+    return true;
+}
+
+bool remove_threat(Threat t)
+{
+    auto guard = _lock.acquire();
+    foreach (i; 0 .. _num_threats)
+    {
+        if (_threats[i].matches(t))
+        {
+            foreach (j; i .. _num_threats - 1)
+                _threats[j] = _threats[j + 1];
+            --_num_threats;
+            update_thresholds();
+            return true;
+        }
+    }
+    return false;
+}
+
+// under _lock
+void update_thresholds()
+{
+    size_t nh = size_t.max;
+    size_t ml = 0;
+    foreach (ref t; _threats[0 .. _num_threats])
+    {
+        if (!t.fired && t.high < nh)
+            nh = t.high;
+        if (t.fired && t.low > ml)
+            ml = t.low;
+    }
+    atomicStore(_next_high, nh);
+    atomicStore(_max_low, ml);
+}
+
+void threat_crossed(size_t used)
+{
+    auto guard = _lock.acquire();
+    foreach (ref t; _threats[0 .. _num_threats])
+    {
+        if (!t.fired && used >= t.high)
+        {
+            t.fired = true;
+            t.fire(used);
+        }
+    }
+    update_thresholds();
+}
+
+void threat_rearm(size_t used)
+{
+    auto guard = _lock.acquire();
+    foreach (ref t; _threats[0 .. _num_threats])
+    {
+        if (t.fired && used <= t.low)
+            t.fired = false;
+    }
+    update_thresholds();
+}
 
 
 unittest
@@ -218,4 +369,55 @@ unittest
     assert(unregister_reclaimer(&take_fn));
     assert(unregister_reclaimer(&ctx.take));
     assert(unregister_reclaimer(nocapture));
+
+    // memory-threat watermarks: fires once per episode, re-arms below low
+    import urt.mem.alloc : alloc, free;
+
+    static int threat_fires;
+    static size_t threat_used;
+    static void on_threat(size_t used)
+    {
+        ++threat_fires;
+        threat_used = used;
+    }
+
+    size_t base = memory_in_use();
+    assert(register_memory_threat(&on_threat, base + 3000, base + 1000));
+    assert(!register_memory_threat(&on_threat, base + 5000, base + 1000));
+
+    void[] a = alloc(2000);
+    assert(threat_fires == 0);
+    void[] b = alloc(2000);
+    assert(threat_fires == 1 && threat_used >= base + 3000);
+    void[] c = alloc(2000);
+    assert(threat_fires == 1);          // still in the same episode
+
+    free(c);
+    free(b);
+    assert(threat_fires == 1);          // above low: not re-armed yet
+    void[] d = alloc(4000);
+    assert(threat_fires == 1);          // crossing high again while fired: no refire
+    free(d);
+    free(a);                            // below low: re-arms
+    void[] e = alloc(4000);
+    assert(threat_fires == 2);
+    free(e);
+
+    assert(unregister_memory_threat(&on_threat));
+    assert(!unregister_memory_threat(&on_threat));
+
+    // delegate threat: the fired handler must receive the usage value
+    static struct Watcher
+    {
+    nothrow @nogc:
+        size_t seen;
+        void on(size_t used) { seen = used; }
+    }
+    Watcher w;
+    base = memory_in_use();
+    assert(register_memory_threat(&w.on, base + 3000, base + 1000));
+    void[] f = alloc(4000);
+    assert(w.seen >= base + 3000);
+    free(f);
+    assert(unregister_memory_threat(&w.on));
 }

--- a/src/urt/mem/reclaim.d
+++ b/src/urt/mem/reclaim.d
@@ -1,0 +1,221 @@
+module urt.mem.reclaim;
+
+import urt.sync.critical;
+import urt.thread : is_main_thread;
+
+nothrow @nogc:
+
+
+// Cache-pressure protocol: subsystems holding reclaimable memory (freelists, caches)
+// register a handler; on allocation failure the allocator walks handlers most-willing
+// first until enough is freed. Willingness reflects rebuild cost, not importance.
+// Handlers must not block, must not allocate, and should free whole heap blocks
+// (individual pages returned to an internal freelist don't help the heap).
+// Handlers registered !thread_safe are only invoked from the main thread.
+
+alias ReclaimHandler = size_t delegate(size_t bytes_needed) nothrow @nogc;
+alias ReclaimFunction = size_t function(size_t bytes_needed) nothrow @nogc;
+
+bool register_reclaimer(ReclaimHandler handler, ubyte willingness, bool thread_safe)
+    => add_reclaimer(Reclaimer(handler.funcptr, handler.ptr, willingness, thread_safe, true));
+
+bool register_reclaimer(ReclaimFunction handler, ubyte willingness, bool thread_safe)
+    => add_reclaimer(Reclaimer(handler, null, willingness, thread_safe, false));
+
+bool unregister_reclaimer(ReclaimHandler handler)
+    => remove_reclaimer(Reclaimer(handler.funcptr, handler.ptr, 0, false, true));
+
+bool unregister_reclaimer(ReclaimFunction handler)
+    => remove_reclaimer(Reclaimer(handler, null, 0, false, false));
+
+// Returns the (approximate) number of bytes released. Reentry from a handler that
+// allocates returns 0 rather than recursing.
+size_t reclaim_memory(size_t bytes_needed)
+{
+    auto guard = _lock.acquire();
+
+    if (_walking)
+        return 0;
+    _walking = true;
+    scope (exit) _walking = false;
+
+    bool main_thread = is_main_thread();
+    size_t freed = 0;
+    foreach (ref r; _reclaimers[0 .. _num_reclaimers])
+    {
+        if (!r.thread_safe && !main_thread)
+            continue;
+        size_t remaining = bytes_needed > freed ? bytes_needed - freed : 0;
+        freed += r.reclaim(remaining);
+        if (freed >= bytes_needed)
+            break;
+    }
+    return freed;
+}
+
+
+private:
+
+struct Reclaimer
+{
+nothrow @nogc:
+    ReclaimFunction fn;
+    void* context;
+    ubyte willingness;
+    bool thread_safe;
+    // A delegate's context is null when it captures nothing, so the caller kind cannot
+    // be recovered from `context` -- and calling a delegate's funcptr directly passes
+    // arguments in the wrong places (extern(D) hands the context register to the last
+    // parameter for a plain function).
+    bool is_delegate;
+
+    size_t reclaim(size_t bytes_needed)
+    {
+        if (is_delegate)
+        {
+            ReclaimHandler dg;
+            dg.ptr = context;
+            dg.funcptr = fn;
+            return dg(bytes_needed);
+        }
+        return fn(bytes_needed);
+    }
+
+    bool matches(ref const Reclaimer other) const
+        => fn is other.fn && context is other.context && is_delegate == other.is_delegate;
+}
+
+bool add_reclaimer(Reclaimer r)
+{
+    auto guard = _lock.acquire();
+
+    if (_num_reclaimers == _reclaimers.length)
+        return false;
+    foreach (ref e; _reclaimers[0 .. _num_reclaimers])
+    {
+        if (e.matches(r))
+            return false;
+    }
+
+    size_t i = _num_reclaimers;
+    while (i > 0 && _reclaimers[i - 1].willingness < r.willingness)
+    {
+        _reclaimers[i] = _reclaimers[i - 1];
+        --i;
+    }
+    _reclaimers[i] = r;
+    ++_num_reclaimers;
+    return true;
+}
+
+bool remove_reclaimer(Reclaimer r)
+{
+    auto guard = _lock.acquire();
+
+    foreach (i; 0 .. _num_reclaimers)
+    {
+        if (_reclaimers[i].matches(r))
+        {
+            foreach (j; i .. _num_reclaimers - 1)
+                _reclaimers[j] = _reclaimers[j + 1];
+            --_num_reclaimers;
+            return true;
+        }
+    }
+    return false;
+}
+
+__gshared Critical _lock;
+__gshared bool _walking;
+__gshared Reclaimer[8] _reclaimers;
+__gshared uint _num_reclaimers;
+
+
+unittest
+{
+    static size_t[3] freed_arg;
+    static int[3] call_order;
+    static int calls;
+
+    static size_t make_handler(int idx, size_t frees)(size_t needed)
+    {
+        freed_arg[idx] = needed;
+        call_order[idx] = calls++;
+        return frees;
+    }
+
+    ReclaimHandler h0 = (size_t n) => make_handler!(0, 100)(n);
+    ReclaimHandler h1 = (size_t n) => make_handler!(1, 200)(n);
+    ReclaimHandler h2 = (size_t n) => make_handler!(2, 400)(n);
+
+    assert(register_reclaimer(h0, 50, true));
+    assert(register_reclaimer(h1, 200, true));
+    assert(register_reclaimer(h2, 100, true));
+    assert(!register_reclaimer(h0, 10, true));
+
+    // willingness order: h1 (200), h2 (100), h0 (50); stops once covered
+    calls = 0;
+    size_t freed = reclaim_memory(500);
+    assert(freed == 600);
+    assert(call_order[1] == 0 && call_order[2] == 1);
+    assert(freed_arg[1] == 500 && freed_arg[2] == 300);
+    assert(calls == 2);
+
+    // early exit when first handler covers the request
+    calls = 0;
+    freed = reclaim_memory(150);
+    assert(freed == 200 && calls == 1);
+
+    // reentry returns 0
+    ReclaimHandler reenter = (size_t n) => reclaim_memory(n);
+    assert(register_reclaimer(reenter, 255, true));
+    calls = 0;
+    freed = reclaim_memory(10_000);
+    assert(freed == 700);
+    assert(unregister_reclaimer(reenter));
+
+    assert(unregister_reclaimer(h0));
+    assert(unregister_reclaimer(h1));
+    assert(unregister_reclaimer(h2));
+    assert(!unregister_reclaimer(h0));
+    assert(reclaim_memory(100) == 0);
+
+    // every handler kind must receive its argument intact: a plain function, a
+    // capturing delegate, and a non-capturing delegate (whose context is null, so
+    // the kind cannot be inferred from the context pointer)
+    static size_t fn_arg, lambda_arg;
+    static size_t take_fn(size_t needed)
+    {
+        fn_arg = needed;
+        return 10;
+    }
+    static size_t take_lambda(size_t needed)
+    {
+        lambda_arg = needed;
+        return 10;
+    }
+
+    static struct Ctx
+    {
+    nothrow @nogc:
+        size_t arg;
+        size_t take(size_t needed)
+        {
+            arg = needed;
+            return 10;
+        }
+    }
+    Ctx ctx;
+    ReclaimHandler nocapture = (size_t n) => take_lambda(n);
+
+    assert(register_reclaimer(&take_fn, 30, true));
+    assert(register_reclaimer(&ctx.take, 20, true));
+    assert(register_reclaimer(nocapture, 10, true));
+    assert(reclaim_memory(1000) == 30);
+    assert(fn_arg == 1000);
+    assert(ctx.arg == 990);
+    assert(lambda_arg == 980);
+    assert(unregister_reclaimer(&take_fn));
+    assert(unregister_reclaimer(&ctx.take));
+    assert(unregister_reclaimer(nocapture));
+}

--- a/src/urt/package.d
+++ b/src/urt/package.d
@@ -40,6 +40,9 @@ extern(C) int main(int argc, char** argv) nothrow @nogc @trusted
 {
     import urt.mem;
 
+    import urt.thread : set_main_thread;
+    set_main_thread();
+
     import urt.mem.string : init_string_heap, deinit_string_heap;
     init_string_heap(ushort.max);
 

--- a/src/urt/sync/critical.d
+++ b/src/urt/sync/critical.d
@@ -4,14 +4,19 @@ import urt.atomic;
 
 nothrow @nogc:
 
+version (Windows) version = OwnerTracked;
+version (Posix)   version = OwnerTracked;
+
 
 // Scope-based "nothing else touches the protected state right now" guard.
 // Critical sections are SHORT by contract - a handful of instructions.
 // Long-held sections will starve other threads/cores; for long sections
 // use a Mutex.
 //
-// Reentrant on every platform. Place a Critical as a field of the object
-// it protects (or __gshared if it protects global state).
+// Reentrant on every platform. Zero-init is the valid initial state on
+// every platform, so a __gshared Critical needs no init() call. Place a
+// Critical as a field of the object it protects (or __gshared if it
+// protects global state).
 
 struct Critical
 {
@@ -19,31 +24,18 @@ nothrow @nogc:
     @disable this(this);
 
     bool init()
-    {
-        version (Windows)
-            InitializeCriticalSection(&_cs);
-        // POSIX/FreeRTOS/bare-metal: zero-init is the valid initial state.
-        return true;
-    }
+        => true;
 
     void destroy()
     {
-        version (Windows)
-            DeleteCriticalSection(&_cs);
-        // other platforms: nothing to release
     }
 
     CriticalGuard acquire() return
     {
         CriticalGuard g = void;
-        version (Windows)
+        version (OwnerTracked)
         {
-            EnterCriticalSection(&_cs);
-            g._critical = &this;
-        }
-        else version (Posix)
-        {
-            auto self = cast(size_t)pthread_self();
+            auto self = _current_id();
             if (atomicLoad(_owner) == self)
             {
                 // already own it -- just bump the recursion count
@@ -51,8 +43,16 @@ nothrow @nogc:
             }
             else
             {
-                while (!cas(&_owner, cast(size_t)0, self))
-                    pause();
+                version (Windows)
+                {
+                    AcquireSRWLockExclusive(&_srw);
+                    atomicStore(_owner, self);
+                }
+                else
+                {
+                    while (!cas(&_owner, cast(size_t)0, self))
+                        pause();
+                }
                 _count = 1;
             }
             g._critical = &this;
@@ -92,12 +92,10 @@ nothrow @nogc:
     }
 
 private:
-    version (Windows)
+    version (OwnerTracked)
     {
-        CRITICAL_SECTION _cs;
-    }
-    else version (Posix)
-    {
+        version (Windows)
+            SRWLOCK _srw;       // waiters block here; owner/count layer reentrancy on top
         shared size_t _owner;   // current thread id, or 0 when unowned
         int _count;             // recursion depth (touched only by owner)
     }
@@ -121,12 +119,14 @@ private:
 
     void _leave()
     {
-        version (Windows)
-            LeaveCriticalSection(&_cs);
-        else version (Posix)
+        version (OwnerTracked)
         {
             if (--_count == 0)
+            {
                 atomicStore!(MemoryOrder.release)(_owner, cast(size_t)0);
+                version (Windows)
+                    ReleaseSRWLockExclusive(&_srw);
+            }
         }
         else version (FreeRTOS)
         {
@@ -156,8 +156,7 @@ nothrow @nogc:
 
     ~this()
     {
-        version (Windows)       _critical._leave();
-        else version (Posix)    _critical._leave();
+        version (OwnerTracked)  _critical._leave();
         else version (FreeRTOS) _critical._leave();
         else
         {
@@ -169,8 +168,7 @@ nothrow @nogc:
     }
 
 private:
-    version (Windows)       Critical* _critical;
-    else version (Posix)    Critical* _critical;
+    version (OwnerTracked)  Critical* _critical;
     else version (FreeRTOS) Critical* _critical;
     else
     {
@@ -222,18 +220,21 @@ private:
 
 version (Windows)
 {
-    import urt.internal.sys.windows.winbase : CRITICAL_SECTION;
+    // SRWLOCK is a single pointer-sized opaque value; zero-init is valid.
+    struct SRWLOCK { void* Ptr; }
 
-    // Re-declare with the attribute set we need (winbase declares these
-    // without nothrow @nogc). Linker resolves to the same Win32 symbols.
     extern(Windows) nothrow @nogc:
-    void InitializeCriticalSection(CRITICAL_SECTION*);
-    void DeleteCriticalSection(CRITICAL_SECTION*);
-    void EnterCriticalSection(CRITICAL_SECTION*);
-    void LeaveCriticalSection(CRITICAL_SECTION*);
+    uint GetCurrentThreadId();
+    void AcquireSRWLockExclusive(SRWLOCK*);
+    void ReleaseSRWLockExclusive(SRWLOCK*);
+
+    size_t _current_id()
+        => GetCurrentThreadId();
 }
 else version (Posix)
 {
-    extern(C) nothrow @nogc:
-    void* pthread_self();
+    extern(C) nothrow @nogc void* pthread_self();
+
+    size_t _current_id()
+        => cast(size_t)pthread_self();
 }

--- a/src/urt/thread.d
+++ b/src/urt/thread.d
@@ -12,7 +12,47 @@ else                    enum ThreadsSupported = false;
 
 
 alias Thread      = void*;
+alias ThreadId    = size_t;
 alias ThreadEntry = void delegate() nothrow @nogc;
+
+
+ThreadId current_thread_id()
+{
+    version (Windows)
+    {
+        import urt.internal.sys.windows.winbase : GetCurrentThreadId;
+        return GetCurrentThreadId();
+    }
+    else version (Posix)
+        return cast(ThreadId)pthread_self();
+    else version (FreeRTOS)
+    {
+        import urt.internal.sys.freertos : xTaskGetCurrentTaskHandle;
+        return cast(ThreadId)xTaskGetCurrentTaskHandle();
+    }
+    else
+    {
+        import urt.driver.irq : has_smp;
+        static if (has_smp)
+        {
+            import urt.driver.irq : cpu_id;
+            return cpu_id();
+        }
+        else
+            return 0;
+    }
+}
+
+// Until set_main_thread() is called, every thread is considered main; single-threaded
+// targets and test harnesses need no setup.
+void set_main_thread()
+{
+    _main_thread = current_thread_id();
+    _main_thread_set = true;
+}
+
+bool is_main_thread()
+    => !_main_thread_set || current_thread_id() == _main_thread;
 
 
 // Spawn an OS thread. Returns null on failure.
@@ -90,6 +130,9 @@ void thread_join(Thread t)
 
 private:
 
+__gshared ThreadId _main_thread;
+__gshared bool _main_thread_set;
+
 version (Windows)
 {
     extern(Windows) uint _win_entry(void* arg) nothrow @nogc
@@ -157,6 +200,7 @@ version (Posix)
         static assert(false, "pthread_attr_t size not configured for this POSIX target");
 
     alias PthreadStart = extern(C) void* function(void*) nothrow @nogc;
+    pthread_t pthread_self();
     int pthread_create(pthread_t*, const(pthread_attr_t)*, PthreadStart, void*);
     int pthread_join(pthread_t, void**);
     int pthread_attr_init(pthread_attr_t*);
@@ -182,5 +226,15 @@ static if (_has_smoke)
         assert(t !is null);
         thread_join(t);
         assert(atomicLoad(_smoke_counter) == 1);
+
+        static shared bool _worker_is_main;
+
+        assert(is_main_thread());
+        set_main_thread();
+        assert(is_main_thread());
+        t = thread_spawn(() nothrow @nogc { atomicStore(_worker_is_main, is_main_thread()); });
+        assert(t !is null);
+        thread_join(t);
+        assert(!atomicLoad(_worker_is_main));
     }
 }


### PR DESCRIPTION
Memory-pressure toolkit for shared-heap targets, in three mechanisms plus groundwork:

**Page pool** (`urt.mem.pagepool`): fixed-size pages in configurable size categories, carved from slabs with per-slab freelists. Allocation always pops from the most-occupied slab, so lightly-used slabs drain to fully-idle and trim can return them to the heap whole. Hard per-category caps (failure = caller drops + counter, never heap growth), low-water preallocation, stats with size histogram. Oversize requests get a heap-backed page behind the same header so `page_free` is uniform; in-range requests never fall through to the heap, keeping the caps meaningful under flood. Pop/push run under a Critical; slab alloc/release always happens outside it.

**Reclaimer registry** (`urt.mem.reclaim`): subsystems holding reclaimable cache register a handler with a willingness value (reflecting rebuild cost). On allocation failure the allocator walks handlers most-willing-first and retries; `!thread_safe` handlers only run from the main thread; reentry from a handler that allocates returns 0 instead of recursing. Handlers are stored as a decomposed function/context pair (delegates recomposed at the call), so function-pointer and delegate registration share one entry shape. The page pool registers its trim at high willingness.

**Memory-threat watermarks** (same module): allocated bytes are accounted at the alloc/free/realloc/expand choke points (one atomic + one compare on the fast path); crossing a registered high watermark fires the handler once, re-arming only below the low watermark, so a pressure episode costs one callback rather than one per allocation. Handler contract is post-an-event-and-return. This is the proactive half: it buys time to convert expensive-to-reclaim state to cheap (e.g. flushing dirty history so its blocks become droppable) before the reclaim walk needs it.

**Groundwork**: `Critical` is now zero-init valid on every platform -- the Windows backing becomes SRWLOCK (zero-init by design, waiters block) with the same owner/count reentrancy layer the Posix owner-spin branch uses -- so `__gshared Critical` needs no init hook; `urt.thread` gains `current_thread_id`/`set_main_thread`/`is_main_thread`, with urt's own `main()` stamping the main thread during bootstrap; and the Bouffalo TLSF heap is now locked (it had no locking while vendor C enters via the extern(C) malloc overrides) -- a prerequisite once anything above it takes locks.

Unittests cover pool round-trip/exhaustion/packing/trim/jumbo, reclaim ordering/early-exit/reentrancy, watermark fire-once/re-arm, and thread identity. openwatt consumer: open-watt/openwatt#518.