### PR TITLE
ble: harden GATT lifetime, MTU, and ESP32 central operation

### DIFF
--- a/src/urt/driver/ble.d
+++ b/src/urt/driver/ble.d
@@ -440,6 +440,16 @@ byte ble_get_rssi(ref BLE ble, BLEConn conn)
         return ble_hw_get_rssi(ble.port, conn);
 }
 
+ushort ble_get_mtu(ref BLE ble, BLEConn conn)
+{
+    static if (num_ble == 0)
+        assert(false, "no BLE on this platform");
+    else static if (__traits(compiles, ble_hw_get_mtu(ble.port, conn)))
+        return ble_hw_get_mtu(ble.port, conn);
+    else
+        return 0;
+}
+
 // --- Callbacks ---
 
 void ble_set_scan_callback(ref BLE ble, BLEScanCallback cb)

--- a/src/urt/driver/esp32/ble.d
+++ b/src/urt/driver/esp32/ble.d
@@ -11,8 +11,10 @@ module urt.driver.esp32.ble;
 
 import urt.atomic : MemoryOrder, atomicExchange, atomicFetchAdd, atomicLoad, atomicStore;
 import urt.driver.ble;
+import urt.log : log_error;
 
 import urt.sync.mpsc : MpscQueue;
+import urt.time : FixedTimer;
 import urt.uuid : GUID;
 
 nothrow @nogc:
@@ -80,6 +82,9 @@ void ble_hw_close(uint port)
     _write_cb = null;
     _notify_cb = null;
     atomicStore!(MemoryOrder.release)(_pending_connect, cast(ubyte)0);
+    atomicStore!(MemoryOrder.release)(_scan_requested, cast(ubyte)0);
+    atomicStore!(MemoryOrder.release)(_scan_restart, cast(ubyte)0);
+    _scan_retry_pending = false;
     atomicStore!(MemoryOrder.release)(_discover_phase, DiscoverPhase.idle);
     _num_discovered_svcs = 0;
     _current_svc_idx = 0;
@@ -92,22 +97,74 @@ void ble_hw_close(uint port)
 
 bool ble_hw_scan_start(uint port, ref const BLEScanConfig cfg)
 {
-    ble_gap_disc_params params;
-    params.itvl = cast(ushort)(cfg.interval_ms * 1000 / 625); // BLE units of 0.625ms
-    params.window = cast(ushort)(cfg.window_ms * 1000 / 625);
-    if (!cfg.active)
-        params.flags |= 0x02; // passive
-    if (cfg.filter_duplicates)
-        params.flags |= 0x04; // filter_duplicates
+    if (atomicLoad!(MemoryOrder.acquire)(_scan_requested) != 0)
+        return true;
 
-    if (ble_gap_disc(0, 0, &params, &gap_event_trampoline, null) != 0)
-        return false;
-    return true;
+    _scan_config = cfg;
+    atomicStore!(MemoryOrder.release)(_scan_requested, cast(ubyte)1);
+    if (start_scan())
+        return true;
+
+    atomicStore!(MemoryOrder.release)(_scan_requested, cast(ubyte)0);
+    return false;
 }
 
 void ble_hw_scan_stop(uint port)
 {
-    ble_gap_disc_cancel();
+    atomicStore!(MemoryOrder.release)(_scan_requested, cast(ubyte)0);
+    atomicStore!(MemoryOrder.release)(_scan_restart, cast(ubyte)0);
+    _scan_retry_pending = false;
+
+    int rc = ble_gap_disc_cancel();
+    if (rc != 0 && rc != BLE_HS_EALREADY)
+        log_error("ble", "could not stop scan, NimBLE status=", rc);
+}
+
+private bool start_scan()
+{
+    ble_gap_disc_params params;
+    params.itvl = cast(ushort)(_scan_config.interval_ms * 1000 / 625); // BLE units of 0.625ms
+    params.window = cast(ushort)(_scan_config.window_ms * 1000 / 625);
+    if (!_scan_config.active)
+        params.flags |= 0x02; // passive
+    if (_scan_config.filter_duplicates)
+        params.flags |= 0x04; // filter_duplicates
+
+    int rc = ble_gap_disc(0, BLE_HS_FOREVER, &params, &gap_event_trampoline, null);
+    if (rc != 0)
+    {
+        log_error("ble", "could not start scan, NimBLE status=", rc);
+        return false;
+    }
+    return true;
+}
+
+private void request_scan_resume()
+{
+    if (atomicLoad!(MemoryOrder.acquire)(_scan_requested) != 0 && ble_gap_disc_active() == 0)
+        atomicStore!(MemoryOrder.release)(_scan_restart, cast(ubyte)1);
+}
+
+private void resume_scan_if_needed()
+{
+    if (atomicExchange!(MemoryOrder.acq_rel)(&_scan_restart, cast(ubyte)0) == 0)
+    {
+        if (!_scan_retry_pending || !_scan_retry_timer.expired())
+            return;
+    }
+    _scan_retry_pending = false;
+    if (atomicLoad!(MemoryOrder.acquire)(_scan_requested) == 0 || ble_gap_disc_active() != 0)
+        return;
+    if (!start_scan())
+    {
+        _scan_retry_timer.reset();
+        _scan_retry_pending = true;
+    }
+}
+
+private ushort conn_interval_units(ushort ms) pure
+{
+    return cast(ushort)((cast(uint)ms * 1000 + 1249) / 1250);
 }
 
 // --- Advertising ---
@@ -149,6 +206,16 @@ bool ble_hw_connect(uint port, ref const ubyte[6] peer_addr, BLEAddrType addr_ty
     if (atomicLoad!(MemoryOrder.acquire)(_pending_connect) != 0)
         return false;
 
+    if (ble_gap_disc_active() != 0)
+    {
+        int rc = ble_gap_disc_cancel();
+        if (rc != 0 && rc != BLE_HS_EALREADY)
+        {
+            log_error("ble", "could not stop scan before connecting, NimBLE status=", rc);
+            return false;
+        }
+    }
+
     ble_addr_t addr;
     addr.type = cast(ubyte)addr_type;
     // NimBLE uses LSB-first byte order
@@ -156,17 +223,22 @@ bool ble_hw_connect(uint port, ref const ubyte[6] peer_addr, BLEAddrType addr_ty
         addr.val[i] = peer_addr[5 - i];
 
     ble_gap_conn_params params;
-    params.itvl_min = cast(ushort)(cfg.interval_min_ms * 1000 / 1250); // units of 1.25ms
-    params.itvl_max = cast(ushort)(cfg.interval_max_ms * 1000 / 1250);
+    params.scan_itvl = 0x0010;
+    params.scan_window = 0x0010;
+    params.itvl_min = conn_interval_units(cfg.interval_min_ms);
+    params.itvl_max = conn_interval_units(cfg.interval_max_ms);
     params.latency = cfg.latency;
     params.supervision_timeout = cast(ushort)(cfg.timeout_ms / 10); // units of 10ms
     params.min_ce_len = 0;
     params.max_ce_len = 0;
 
     atomicStore!(MemoryOrder.release)(_pending_connect, cast(ubyte)1);
-    if (ble_gap_connect(0, &addr, 30_000, &params, &gap_event_trampoline, null) != 0)
+    int rc = ble_gap_connect(0, &addr, 30_000, &params, &gap_event_trampoline, null);
+    if (rc != 0)
     {
+        log_error("ble", "could not submit connection request, NimBLE status=", rc);
         atomicStore!(MemoryOrder.release)(_pending_connect, cast(ubyte)0);
+        request_scan_resume();
         return false;
     }
     return true;
@@ -176,7 +248,10 @@ void ble_hw_connect_cancel(uint port)
 {
     // A successful cancel completes through BLE_GAP_EVENT_CONNECT; a rejected cancel has no callback.
     if (ble_gap_conn_cancel() != 0)
+    {
         atomicStore!(MemoryOrder.release)(_pending_connect, cast(ubyte)0);
+        request_scan_resume();
+    }
 }
 
 bool ble_hw_disconnect(uint port, BLEConn conn)
@@ -314,6 +389,7 @@ bool ble_hw_service(uint port, size_t budget)
 {
     if (port >= num_ble)
         return false;
+    resume_scan_if_needed();
     if (_servicing)
         return queues_pending();
 
@@ -381,6 +457,7 @@ uint ble_hw_take_event_drops(uint port)
 private:
 
 enum int ESP_OK = 0;
+enum int BLE_HS_EALREADY = 2;
 enum max_sessions = 4;
 enum max_chars_per_session = 32;
 enum scan_queue_capacity = 16;
@@ -513,6 +590,7 @@ struct ControlEvent
     ControlEventKind kind;
     ubyte conn_id;
     BLEError error;
+    int status;
 }
 
 void dispatch_scan(BLE ble, ref const ScanEvent scan)
@@ -530,6 +608,8 @@ void dispatch_control(BLE ble, ref const ControlEvent control)
                 _conn_cb(ble, BLEConn(control.conn_id), true, BLEError.none);
             break;
         case ControlEventKind.connect_failed:
+            if (control.status != 0)
+                log_error("ble", "connection failed, NimBLE status=", control.status);
             if (_conn_cb !is null)
                 _conn_cb(ble, BLEConn(control.conn_id), false, control.error);
             break;
@@ -596,7 +676,12 @@ void dispatch_notification(BLE ble, ref const NotifyEvent notification)
 __gshared bool _opened;
 __gshared bool _faulted;
 shared ubyte _pending_connect;
+shared ubyte _scan_requested;
+shared ubyte _scan_restart;
 __gshared ubyte _next_conn_id;
+__gshared BLEScanConfig _scan_config;
+__gshared FixedTimer!1000 _scan_retry_timer;
+__gshared bool _scan_retry_pending;
 
 __gshared Session[max_sessions] _sessions;
 
@@ -729,13 +814,14 @@ bool queues_pending()
     return _have_scan || _have_control || _have_gatt || _have_notification || !_scan_queue.empty || !_control_queue.empty || !_gatt_queue.empty || !_notify_queue.empty;
 }
 
-bool push_control(ControlEventKind kind, ubyte conn_id, BLEError error = BLEError.none)
+bool push_control(ControlEventKind kind, ubyte conn_id, BLEError error = BLEError.none, int status = 0)
 {
     ControlEvent event;
     event.sequence = next_event_sequence();
     event.kind = kind;
     event.conn_id = conn_id;
     event.error = error;
+    event.status = status;
     if (_control_queue.enqueue(event))
         return true;
     count_event_drop();
@@ -821,9 +907,18 @@ extern(C) int gap_event_trampoline(ble_gap_event* event, void*) nothrow @nogc
                     push_control(ControlEventKind.connect_failed, ubyte.max, BLEError.internal);
                     ble_gap_terminate(event.connect.conn_handle, 0x13);
                 }
+                request_scan_resume();
             }
             else
-                push_control(ControlEventKind.connect_failed, ubyte.max, BLEError.timeout);
+            {
+                push_control(ControlEventKind.connect_failed, ubyte.max, BLEError.timeout, event.connect.status);
+                request_scan_resume();
+            }
+            signal_wake();
+            return 0;
+
+        case BLE_GAP_EVENT_DISC_COMPLETE:
+            request_scan_resume();
             signal_wake();
             return 0;
 
@@ -838,6 +933,7 @@ extern(C) int gap_event_trampoline(ble_gap_event* event, void*) nothrow @nogc
                     atomicStore!(MemoryOrder.release)(s.state, SessionState.disconnecting);
                 else
                     atomicStore!(MemoryOrder.release)(s.state, SessionState.inactive);
+                request_scan_resume();
             }
             signal_wake();
             return 0;
@@ -1236,8 +1332,12 @@ enum : ubyte
     BLE_GAP_EVENT_CONNECT       = 0,
     BLE_GAP_EVENT_DISCONNECT    = 1,
     BLE_GAP_EVENT_DISC          = 7,
+    BLE_GAP_EVENT_DISC_COMPLETE = 8,
     BLE_GAP_EVENT_NOTIFY_RX     = 12,
 }
+
+// Zero means 10.24s, not forever.
+enum int BLE_HS_FOREVER = int.max;
 
 // C shim functions
 extern(C) nothrow @nogc
@@ -1251,6 +1351,7 @@ extern(C) nothrow @nogc
 {
     int ble_gap_disc(ubyte own_addr_type, int duration_ms, const(ble_gap_disc_params)* params, int function(ble_gap_event*, void*) cb, void* cb_arg);
     int ble_gap_disc_cancel();
+    int ble_gap_disc_active();
     int ble_gap_connect(ubyte own_addr_type, const(ble_addr_t)* peer_addr, int duration_ms, const(ble_gap_conn_params)* params, int function(ble_gap_event*, void*) cb, void* cb_arg);
     int ble_gap_conn_cancel();
     int ble_gap_terminate(ushort conn_handle, ubyte hci_reason);

--- a/src/urt/driver/esp32/ble.d
+++ b/src/urt/driver/esp32/ble.d
@@ -289,6 +289,14 @@ byte ble_hw_get_rssi(uint port, BLEConn conn)
     return rssi;
 }
 
+ushort ble_hw_get_mtu(uint port, BLEConn conn)
+{
+    auto s = find_session(conn.id);
+    if (s is null)
+        return 0;
+    return ble_att_mtu(s.nimble_handle);
+}
+
 // --- Callbacks ---
 
 void ble_hw_set_scan_callback(uint port, BLEScanCallback cb) { _scan_cb = cb; }
@@ -803,11 +811,10 @@ extern(C) int gap_event_trampoline(ble_gap_event* event, void*) nothrow @nogc
                 auto s = alloc_session(event.connect.conn_handle);
                 if (s !is null)
                 {
-                    if (!push_control(ControlEventKind.connected, s.id))
-                    {
-                        atomicStore!(MemoryOrder.release)(s.state, SessionState.unannounced);
-                        ble_gap_terminate(event.connect.conn_handle, 0x13);
-                    }
+                    // Exchange MTU before announcing.
+                    atomicStore!(MemoryOrder.release)(s.state, SessionState.unannounced);
+                    if (ble_gattc_exchange_mtu(event.connect.conn_handle, &mtu_exchange_cb, null) != 0)
+                        announce_connection(s);
                 }
                 else
                 {
@@ -869,6 +876,26 @@ extern(C) int gap_event_trampoline(ble_gap_event* event, void*) nothrow @nogc
 }
 
 // --- GATT service discovery callback (NimBLE task) ---
+
+// The 23-byte default is usable.
+extern(C) int mtu_exchange_cb(ushort conn_handle, const(ble_gatt_error)*, ushort, void*) nothrow @nogc
+{
+    auto s = find_session_by_nimble(conn_handle);
+    if (s !is null && atomicLoad!(MemoryOrder.acquire)(s.state) == SessionState.unannounced)
+        announce_connection(s);
+    signal_wake();
+    return 0;
+}
+
+void announce_connection(Session* session) nothrow @nogc
+{
+    atomicStore!(MemoryOrder.release)(session.state, SessionState.active);
+    if (!push_control(ControlEventKind.connected, session.id))
+    {
+        atomicStore!(MemoryOrder.release)(session.state, SessionState.unannounced);
+        ble_gap_terminate(session.nimble_handle, 0x13);
+    }
+}
 
 extern(C) int svc_discover_cb(ushort conn_handle, const(ble_gatt_error)* error, const(ble_gatt_svc)* service, void*) nothrow @nogc
 {
@@ -1239,6 +1266,9 @@ extern(C) nothrow @nogc
     int ble_gattc_read(ushort conn_handle, ushort attr_handle, int function(ushort, const(ble_gatt_error)*, ble_gatt_attr*, void*) cb, void* cb_arg);
     int ble_gattc_write_flat(ushort conn_handle, ushort attr_handle, const(void)* data, ushort data_len, int function(ushort, const(ble_gatt_error)*, ble_gatt_attr*, void*) cb, void* cb_arg);
     int ble_gattc_write_no_rsp_flat(ushort conn_handle, ushort attr_handle, const(void)* data, ushort data_len);
+    int ble_gattc_exchange_mtu(ushort conn_handle, int function(ushort, const(ble_gatt_error)*, ushort, void*) cb, void* cb_arg);
+
+    ushort ble_att_mtu(ushort conn_handle);
 
     int ble_hs_id_infer_auto(int privacy, ubyte* out_addr_type);
     int ble_hs_id_copy_addr(ubyte addr_type, ubyte* out_addr, int* out_is_nrpa);

--- a/src/urt/driver/esp32/ble.d
+++ b/src/urt/driver/esp32/ble.d
@@ -328,15 +328,35 @@ bool ble_hw_gatt_subscribe(uint port, BLEConn conn, ushort handle, bool enable)
     if (s is null)
         return false;
 
-    // find CCCD handle (handle + 1 by convention for standard GATT)
-    ushort cccd_handle = cast(ushort)(handle + 1);
+    ushort cccd_handle;
+    ushort properties;
+    foreach (ref c; s.chars[0 .. s.num_chars])
+        if (c.handle == handle)
+        {
+            cccd_handle = c.cccd_handle;
+            properties = c.properties;
+            break;
+        }
+    if (cccd_handle == 0)
+        return false;
 
     ubyte[2] cccd_value;
     if (enable)
-        cccd_value[0] = 0x01; // enable notifications
+    {
+        if ((properties & GattCharProps.notify) != 0)
+            cccd_value[0] = 0x01;
+        else if ((properties & GattCharProps.indicate) != 0)
+            cccd_value[0] = 0x02;
+        else
+            return false;
+    }
 
-    if (ble_gattc_write_flat(s.nimble_handle, cccd_handle, cccd_value.ptr, 2, null, null) != 0)
+    int rc = ble_gattc_write_flat(s.nimble_handle, cccd_handle, cccd_value.ptr, 2, null, null);
+    if (rc != 0)
+    {
+        log_error("ble", "could not write CCCD ", cccd_handle, " for handle ", handle, ", NimBLE status=", rc);
         return false;
+    }
     return true;
 }
 
@@ -471,6 +491,8 @@ enum default_service_budget = 32;
 struct SessionCharInfo
 {
     ushort handle;
+    ushort def_handle;
+    ushort svc_end;
     ushort cccd_handle;
     GUID service_uuid;
     GUID char_uuid;
@@ -828,7 +850,7 @@ bool push_control(ControlEventKind kind, ubyte conn_id, BLEError error = BLEErro
     return false;
 }
 
-enum DiscoverPhase : ubyte { idle, services, chars, complete }
+enum DiscoverPhase : ubyte { idle, services, chars, descriptors, complete }
 shared DiscoverPhase _discover_phase;
 __gshared ubyte _discovering_conn;
 __gshared bool _discovery_overflow;
@@ -837,6 +859,7 @@ __gshared bool _discovery_overflow;
 __gshared ble_gatt_svc[16] _discovered_svcs;
 __gshared ubyte _num_discovered_svcs;
 __gshared ubyte _current_svc_idx;
+__gshared ubyte _current_chr_idx;
 __gshared GUID _current_svc_uuid;
 
 void finish_discovery(bool success)
@@ -1036,8 +1059,8 @@ int discover_next_svc_chars(ushort conn_handle) nothrow @nogc
         return 0;
     }
 
-    finish_discovery(true);
-    return 0;
+    _current_chr_idx = 0;
+    return discover_next_chr_descriptors(conn_handle);
 }
 
 // --- GATT characteristic discovery callback (NimBLE task) ---
@@ -1051,7 +1074,9 @@ extern(C) int chr_discover_cb(ushort conn_handle, const(ble_gatt_error)* error, 
         {
             auto ci = &s.chars[s.num_chars++];
             ci.handle = chr.val_handle;
-            ci.cccd_handle = 0; // TODO: discover descriptors for CCCD
+            ci.def_handle = chr.def_handle;
+            ci.svc_end = _discovered_svcs[_current_svc_idx].end_handle;
+            ci.cccd_handle = 0;
             ci.service_uuid = _current_svc_uuid;
             ci.char_uuid = nimble_uuid_to_guid(&chr.uuid);
             ci.properties = chr.properties;
@@ -1070,6 +1095,68 @@ extern(C) int chr_discover_cb(ushort conn_handle, const(ble_gatt_error)* error, 
 
     _current_svc_idx++;
     return discover_next_svc_chars(conn_handle);
+}
+
+// NimBLE associates descriptors with the requested start handle.
+int discover_next_chr_descriptors(ushort conn_handle) nothrow @nogc
+{
+    auto s = find_session_by_nimble(conn_handle);
+    if (s is null)
+    {
+        finish_discovery(false);
+        return 0;
+    }
+
+    while (_current_chr_idx < s.num_chars)
+    {
+        auto c = &s.chars[_current_chr_idx];
+        ushort end = c.svc_end;
+        if (_current_chr_idx + 1 < s.num_chars && s.chars[_current_chr_idx + 1].svc_end == c.svc_end)
+            end = cast(ushort)(s.chars[_current_chr_idx + 1].def_handle - 1);
+        if (end <= c.handle)
+        {
+            ++_current_chr_idx;
+            continue;
+        }
+        atomicStore!(MemoryOrder.release)(_discover_phase, DiscoverPhase.descriptors);
+
+        if (ble_gattc_disc_all_dscs(conn_handle, c.handle, end, &dsc_discover_cb, null) == 0)
+            return 0;
+
+        finish_discovery(false);
+        return 0;
+    }
+
+    finish_discovery(true);
+    return 0;
+}
+
+extern(C) int dsc_discover_cb(ushort conn_handle, const(ble_gatt_error)* error, ushort chr_val_handle, const(ble_gatt_dsc)* dsc, void*) nothrow @nogc
+{
+    if (error !is null && error.status == 0 && dsc !is null)
+    {
+        if (dsc.uuid.u.type == 16 && dsc.uuid.u16.value == 0x2902)
+        {
+            auto s = find_session_by_nimble(conn_handle);
+            if (s !is null)
+                foreach (ref c; s.chars[0 .. s.num_chars])
+                    if (c.handle == chr_val_handle)
+                    {
+                        c.cccd_handle = dsc.handle;
+                        break;
+                    }
+        }
+        return 0;
+    }
+
+    if (error is null || error.status != BLE_HS_EDONE)
+    {
+        finish_discovery(false);
+        return 0;
+    }
+
+    ++_current_chr_idx;
+    return discover_next_chr_descriptors(conn_handle);
 }
 
 // --- GATT read callback (NimBLE task) ---
@@ -1306,6 +1393,12 @@ struct ble_gatt_chr
     ble_uuid_any uuid;
 }
 
+struct ble_gatt_dsc
+{
+    ushort handle;
+    ble_uuid_any uuid;
+}
+
 struct ble_gatt_attr
 {
     ushort handle;
@@ -1364,6 +1457,7 @@ extern(C) nothrow @nogc
 
     int ble_gattc_disc_all_svcs(ushort conn_handle, int function(ushort, const(ble_gatt_error)*, const(ble_gatt_svc)*, void*) cb, void* cb_arg);
     int ble_gattc_disc_all_chrs(ushort conn_handle, ushort start_handle, ushort end_handle, int function(ushort, const(ble_gatt_error)*, const(ble_gatt_chr)*, void*) cb, void* cb_arg);
+    int ble_gattc_disc_all_dscs(ushort conn_handle, ushort start_handle, ushort end_handle, int function(ushort, const(ble_gatt_error)*, ushort, const(ble_gatt_dsc)*, void*) cb, void* cb_arg);
     int ble_gattc_read(ushort conn_handle, ushort attr_handle, int function(ushort, const(ble_gatt_error)*, ble_gatt_attr*, void*) cb, void* cb_arg);
     int ble_gattc_write_flat(ushort conn_handle, ushort attr_handle, const(void)* data, ushort data_len, int function(ushort, const(ble_gatt_error)*, ble_gatt_attr*, void*) cb, void* cb_arg);
     int ble_gattc_write_no_rsp_flat(ushort conn_handle, ushort attr_handle, const(void)* data, ushort data_len);

--- a/src/urt/driver/windows/ble.d
+++ b/src/urt/driver/windows/ble.d
@@ -267,7 +267,7 @@ bool ble_hw_disconnect(uint port, BLEConn conn)
 bool ble_hw_gatt_discover(uint port, BLEConn conn)
 {
     auto s = find_session(conn.id);
-    if (s is null || s.device3 is null)
+    if (s is null || s.device3 is null || _pending_discover.phase != DiscoverPhase.idle)
         return false;
 
     IInspectable gatt_op;
@@ -279,7 +279,8 @@ bool ble_hw_gatt_discover(uint port, BLEConn conn)
     _pending_discover.async_op = gatt_op;
     _pending_discover.conn_id = conn.id;
     _pending_discover.phase = DiscoverPhase.services;
-    s.num_chars = 0;
+    _pending_discover.overflow = false;
+    release_session_gatt(s);
 
     return true;
 }
@@ -567,6 +568,7 @@ struct SessionChar
     GUID char_uuid;
     GattCharacteristicProperties properties;
     IGattCharacteristic characteristic;
+    IGattDeviceService3 service; // Keeps the characteristic open.
     GattValueChangedHandler notify_handler;
     EventRegistrationToken notify_token;
 }
@@ -581,6 +583,7 @@ struct WinSession
     EventRegistrationToken conn_status_token;
     SessionChar[max_chars_per_session] chars;
     ubyte num_chars;
+    IGattSession gatt_session;
 }
 
 struct PendingConnect
@@ -597,8 +600,10 @@ struct PendingDiscover
     uint service_count;
     uint current_service;
     GUID current_service_uuid;
+    IGattDeviceService3 current_service_object;
     ubyte conn_id;
     DiscoverPhase phase;
+    bool overflow;
 }
 
 struct PendingGattOp
@@ -730,9 +735,9 @@ WinSession* alloc_session()
     _next_conn_id = cast(ubyte)(id + 1);
 
     auto s = &_sessions[_num_sessions++];
+    *s = WinSession.init;
     s.active = true;
     s.id = id;
-    s.num_chars = 0;
     return s;
 }
 
@@ -742,22 +747,18 @@ void remove_session(ubyte id)
     {
         if (s.id == id)
         {
-            _sessions[i] = _sessions[_num_sessions - 1];
-            _num_sessions--;
+            ubyte last = cast(ubyte)(_num_sessions - 1);
+            if (i != last)
+                _sessions[i] = _sessions[last];
+            _sessions[last] = WinSession.init;
+            --_num_sessions;
             return;
         }
     }
 }
 
-void release_session(WinSession* s)
+void release_session_gatt(WinSession* s)
 {
-    if (s.device !is null && s.conn_handler !is null)
-    {
-        s.device.remove_ConnectionStatusChanged(s.conn_status_token);
-        defaultAllocator().freeT(s.conn_handler);
-        s.conn_handler = null;
-    }
-
     foreach (ref gc; s.chars[0 .. s.num_chars])
     {
         if (gc.notify_handler !is null)
@@ -771,6 +772,31 @@ void release_session(WinSession* s)
             gc.characteristic.Release();
             gc.characteristic = null;
         }
+        if (gc.service !is null)
+        {
+            gc.service.Release();
+            gc.service = null;
+        }
+    }
+    s.num_chars = 0;
+}
+
+void release_session(WinSession* s)
+{
+    if (s.device !is null && s.conn_handler !is null)
+    {
+        s.device.remove_ConnectionStatusChanged(s.conn_status_token);
+        defaultAllocator().freeT(s.conn_handler);
+        s.conn_handler = null;
+    }
+
+    release_session_gatt(s);
+
+    if (s.gatt_session !is null)
+    {
+        s.gatt_session.put_MaintainConnection(0);
+        s.gatt_session.Release();
+        s.gatt_session = null;
     }
 
     if (s.device3 !is null)
@@ -967,50 +993,70 @@ void poll_discover(BLE ble)
     }
     else
     {
-        // phase 2: characteristics for a service
-        if (result_raw !is null && s !is null)
+        if (result_raw is null || s is null)
         {
-            auto chars_result = cast(IGattCharacteristicsResult)cast(void*)result_raw;
-            GattCommunicationStatus gatt_status;
-            chars_result.get_Status(&gatt_status);
-
-            if (gatt_status == GattCommunicationStatus.success)
-            {
-                IInspectable chars_raw;
-                chars_result.get_Characteristics(&chars_raw);
-                if (chars_raw !is null)
-                {
-                    auto chars = cast(IVectorView_IInspectable)cast(void*)chars_raw;
-                    uint count;
-                    chars.get_Size(&count);
-
-                    foreach (j; 0 .. count)
-                    {
-                        IInspectable char_raw;
-                        chars.GetAt(j, &char_raw);
-                        if (char_raw is null)
-                            continue;
-
-                        auto chr = cast(IGattCharacteristic)cast(void*)char_raw;
-                        if (s.num_chars < max_chars_per_session)
-                        {
-                            auto ci = &s.chars[s.num_chars++];
-                            chr.get_AttributeHandle(&ci.handle);
-                            ci.service_uuid = _pending_discover.current_service_uuid;
-                            chr.get_Uuid(&ci.char_uuid);
-                            chr.get_CharacteristicProperties(&ci.properties);
-                            ci.characteristic = chr;
-                        }
-                        else
-                            (cast(IUnknown)chr).Release();
-                    }
-                    chars_raw.Release();
-                }
-            }
-            result_raw.Release();
+            release_pending_discover_service();
+            finish_discover(ble, conn_id, BLEError.protocol);
+            return;
         }
 
-        _pending_discover.current_service++;
+        auto chars_result = cast(IGattCharacteristicsResult)cast(void*)result_raw;
+        GattCommunicationStatus gatt_status;
+        chars_result.get_Status(&gatt_status);
+
+        if (gatt_status != GattCommunicationStatus.success)
+        {
+            result_raw.Release();
+            release_pending_discover_service();
+            finish_discover(ble, conn_id, BLEError.protocol);
+            return;
+        }
+
+        IInspectable chars_raw;
+        chars_result.get_Characteristics(&chars_raw);
+        if (chars_raw !is null)
+        {
+            auto chars = cast(IVectorView_IInspectable)cast(void*)chars_raw;
+            uint count;
+            chars.get_Size(&count);
+
+            foreach (j; 0 .. count)
+            {
+                IInspectable char_raw;
+                chars.GetAt(j, &char_raw);
+                if (char_raw is null)
+                    continue;
+
+                auto chr = cast(IGattCharacteristic)cast(void*)char_raw;
+                if (s.num_chars < max_chars_per_session)
+                {
+                    auto ci = &s.chars[s.num_chars++];
+                    chr.get_AttributeHandle(&ci.handle);
+                    ci.service_uuid = _pending_discover.current_service_uuid;
+                    chr.get_Uuid(&ci.char_uuid);
+                    chr.get_CharacteristicProperties(&ci.properties);
+                    ci.characteristic = chr;
+                    _pending_discover.current_service_object.AddRef();
+                    ci.service = _pending_discover.current_service_object;
+                }
+                else
+                {
+                    (cast(IUnknown)chr).Release();
+                    _pending_discover.overflow = true;
+                }
+            }
+            chars_raw.Release();
+        }
+        result_raw.Release();
+        release_pending_discover_service();
+
+        if (_pending_discover.overflow)
+        {
+            finish_discover(ble, conn_id, BLEError.protocol);
+            return;
+        }
+
+        ++_pending_discover.current_service;
         if (!discover_next_service())
             finish_discover(ble, conn_id, BLEError.none);
     }
@@ -1041,17 +1087,41 @@ bool discover_next_service()
             continue;
         }
 
+        auto s = find_session(_pending_discover.conn_id);
+        if (s is null)
+        {
+            svc3.Release();
+            return false;
+        }
+        IInspectable session_raw;
+        if (svc3.get_Session(&session_raw) >= 0 && session_raw !is null)
+        {
+            if (auto gatt_session = qi!IGattSession(session_raw, &IID_IGattSession))
+            {
+                if (s.gatt_session is null)
+                {
+                    gatt_session.put_MaintainConnection(1);
+                    s.gatt_session = gatt_session;
+                }
+                else
+                    gatt_session.Release();
+            }
+            session_raw.Release();
+        }
+
+        // Cached characteristics may belong to a previous, closed connection.
         IInspectable chars_op;
-        svc3.GetCharacteristicsAsync(&chars_op);
-        svc3.Release();
+        svc3.GetCharacteristicsWithCacheModeAsync(1, &chars_op);
 
         if (chars_op is null)
         {
+            svc3.Release();
             _pending_discover.current_service++;
             continue;
         }
 
         register_completion(chars_op);
+        _pending_discover.current_service_object = svc3;
         _pending_discover.async_op = chars_op;
         return true;
     }
@@ -1065,8 +1135,18 @@ bool discover_next_service()
     return false;
 }
 
+void release_pending_discover_service()
+{
+    if (_pending_discover.current_service_object !is null)
+    {
+        _pending_discover.current_service_object.Release();
+        _pending_discover.current_service_object = null;
+    }
+}
+
 void finish_discover(BLE ble, ubyte conn_id, BLEError error)
 {
+    release_pending_discover_service();
     if (_pending_discover.services !is null)
     {
         (cast(IUnknown)_pending_discover.services).Release();
@@ -1458,6 +1538,7 @@ static immutable IID_IBluetoothLEDeviceStatics                   = GUID(0xC8CF1A
 static immutable IID_IBluetoothLEDevice3                         = GUID(0xAEE9E493, 0x44AC, 0x40DC, [0xAF,0x33,0xB2,0xC1,0x3C,0x01,0xCA,0x46]);
 static immutable IID_IGattDeviceServicesResult                   = GUID(0x171DD3EE, 0x016D, 0x419D, [0x83,0x8A,0x57,0x6C,0xF4,0x75,0xA3,0xD8]);
 static immutable IID_IGattDeviceService3                         = GUID(0xB293A950, 0x0C53, 0x437C, [0xA9,0xB3,0x5C,0x32,0x10,0xC6,0xE5,0x69]);
+static immutable IID_IGattSession                                = GUID(0xD23B5143, 0xE04E, 0x4C24, [0x99,0x9C,0x9C,0x25,0x6F,0x98,0x56,0xB1]);
 static immutable IID_IGattCharacteristic                         = GUID(0x59CB50C1, 0x5934, 0x4F68, [0xA1,0x98,0xEB,0x86,0x4F,0xA4,0x4E,0x6B]);
 static immutable IID_IGattReadResult                             = GUID(0x63A66F08, 0x1AEA, 0x4C4C, [0xA5,0x0F,0x97,0xBA,0xE4,0x74,0xB3,0x48]);
 static immutable IID_IBluetoothLEAdvertisementPublisher          = GUID(0xCDE820F9, 0xD9FA, 0x43D6, [0xA2,0x64,0xDD,0xD8,0xB7,0xDA,0x8B,0x78]);
@@ -1649,6 +1730,21 @@ nothrow @nogc:
     HRESULT get_DeviceId(HSTRING* value);
     HRESULT get_Uuid(GUID* value);
     HRESULT get_AttributeHandle(ushort* value);
+}
+
+interface IGattSession : IInspectable
+{
+nothrow @nogc:
+    HRESULT get_DeviceId(IInspectable* value);
+    HRESULT get_CanMaintainConnection(BOOL* value);
+    HRESULT put_MaintainConnection(BOOL value);
+    HRESULT get_MaintainConnection(BOOL* value);
+    HRESULT get_MaxPduSize(ushort* value);
+    HRESULT get_SessionStatus(int* value);
+    HRESULT add_MaxPduSizeChanged(IUnknown handler, EventRegistrationToken* token);
+    HRESULT remove_MaxPduSizeChanged(EventRegistrationToken token);
+    HRESULT add_SessionStatusChanged(IUnknown handler, EventRegistrationToken* token);
+    HRESULT remove_SessionStatusChanged(EventRegistrationToken token);
 }
 
 interface IGattDeviceService3 : IInspectable

--- a/src/urt/driver/windows/ble.d
+++ b/src/urt/driver/windows/ble.d
@@ -311,6 +311,16 @@ bool ble_hw_gatt_read(uint port, BLEConn conn, ushort handle)
     return true;
 }
 
+ushort ble_hw_get_mtu(uint port, BLEConn conn)
+{
+    auto s = find_session(conn.id);
+    if (s is null || s.gatt_session is null)
+        return 0;
+
+    ushort max_pdu;
+    return s.gatt_session.get_MaxPduSize(&max_pdu) >= 0 ? max_pdu : 0;
+}
+
 bool ble_hw_gatt_write(uint port, BLEConn conn, ushort handle, const(ubyte)[] data, bool with_response)
 {
     if (_num_pending_gatt >= max_gatt_ops)

--- a/src/urt/driver/windows/ble.d
+++ b/src/urt/driver/windows/ble.d
@@ -1191,6 +1191,9 @@ void poll_gatt(BLE ble)
 
         AsyncStatus status;
         async_info.get_Status(&status);
+        HRESULT error_code;
+        if (status != AsyncStatus.started && status != AsyncStatus.completed)
+            async_info.get_ErrorCode(&error_code);
         async_info.Release();
 
         if (status == AsyncStatus.started)
@@ -1236,7 +1239,7 @@ void poll_gatt(BLE ble)
             }
         }
         else if (pg.op_type != GattOpType.read)
-            log.warning("GATT write handle=", pg.handle, " did not complete: ", status);
+            log.warningf("GATT write handle={0} did not complete: status={1} hr=x{2,08x}", pg.handle, cast(int)status, cast(uint)error_code);
 
         // fire callback
         if (pg.op_type == GattOpType.read)


### PR DESCRIPTION
## Stack

1. Keep WinRT GATT services alive for retained characteristics and fail discovery instead of exposing a partial cache.
2. Report HRESULTs for failed Windows GATT operations.
3. Report the current negotiated ATT MTU on Windows and ESP32.
4. Coordinate ESP32 scanning with connection procedures and retry failed scan starts without inventing local controller state.
5. Discover ESP32 descriptors per characteristic and write the actual CCCD with the correct notify or indicate value.

## Why

Windows characteristics depended on parent WinRT objects whose lifetime was not retained. Discovery also had an arbitrary service limit and could report success with an incomplete cache. On ESP32, scanning was mirrored in fallible local state, connection parameters were incomplete, status codes were truncated, and subscriptions assumed a fixed CCCD handle offset.

The Windows characteristic cache remains bounded at 32 entries because the shared OpenWatt BLE session cache has the same bound. Overflow is now an explicit discovery failure rather than silent partial success.

## Validation

- `git diff --check dc82438...HEAD`
- Direct DMD compilation of the changed Windows BLE backend
- Forced ESP32-S3 release build with `make -B PLATFORM=esp32-s3 CONFIG=release`
- Relevant Windows and ESP32 build checks at each commit boundary
