### PR TITLE
variant: tag const and immutable scalars correctly

### DIFF
--- a/src/urt/variant.d
+++ b/src/urt/variant.d
@@ -161,7 +161,7 @@ nothrow @nogc:
         flags = b ? Flags.True : Flags.False;
     }
 
-    this(I)(I i)
+    this(I)(const I i)
         if (is_some_int!I)
     {
         static if (is_signed_int!I)
@@ -207,9 +207,11 @@ nothrow @nogc:
             else if (i <= long.max)
                 flags |= Flags.Int64Flag;
         }
+        else
+            static assert(false, "no flags for integer type " ~ I.stringof);
     }
 
-    this(F)(F f)
+    this(F)(const F f)
         if (is_some_float!F)
     {
         import urt.math : float_is_integer;
@@ -1530,6 +1532,7 @@ package:
 unittest
 {
     import urt.inet;
+    import urt.meta : AliasSeq;
     import urt.si.quantity : Metres;
 
     // fabricate some variants
@@ -1560,6 +1563,16 @@ unittest
     assert(empty != "x");
     assert(Variant("x") == "x");
     assert(Variant("x") != "");
+
+    // qualified scalars must tag exactly like their mutable form
+    static foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong, float, double))
+    {{
+        const T c = cast(T)42;
+        immutable T i = cast(T)42;
+        assert(Variant(c).isNumber && Variant(c).asLong == 42);
+        assert(Variant(i).isNumber && Variant(i).asLong == 42);
+        assert(Variant(c).flags == Variant(cast(T)42).flags);
+    }}
 }
 
 


### PR DESCRIPTION
`Variant`'s integer and float constructors deduced `I`/`F` from a plain value parameter, so a qualified argument instantiated them with the qualified type. `is_some_int` uses `Unqual`, so `const(int)` passed the template constraint and `value.l = i` stored the bits -- but the `flags` assignment chain matches exactly:

```d
static if (is(I == ubyte) || is(I == ushort))
else static if (is(I == byte) || is(I == short) || is(I == int))   // is(const(int) == int) is false
...
```

Every branch missed, `flags` stayed 0 == `Flags.Null`, and the Variant carried an integer while `isNumber()` reported false. Downstream that means `unbox_scalar_value` fails and the value is discarded -- silently, wherever the caller doesn't check.

Found in the field: Tesla vehicle telemetry writing elements from a `ref const` protobuf struct. `battery.soc`, `meter.voltage`, `meter.current`, `hvac.fan_speed` and every seat heating level vanished on the way to the data model, while `const(float)` (temperatures), `const(bool)` and unqualified int rvalues in the same functions landed fine. Decode was correct throughout; the values died in the box.

`const(float)` was hit less severely by the same root cause -- it fell through `is(F == float)` to the `else` and got tagged `NumberDouble`.

## Fix

Take the parameter as `const I` / `const F`. IFTI then deduces the type unqualified, so the branches need no `Unqual` gymnastics in the body, and `Variant(int)` / `Variant(const int)` / `Variant(immutable int)` stop instantiating three separate copies:

```
plain param:                      const param:
  T = int                           T = int
  T = const(int)
  T = immutable(int)
```

Also added `else static assert(false, ...)` on the integer fallthrough. All eight integral types are covered so it is unreachable today -- its job is to make the next missed branch a build error rather than silent data loss. Reverting the fix with the guard in place fails the build with `no flags for integer type const(ubyte)`.

## Testing

Regression test in the existing `unittest` block covers `const` and `immutable` across all eight integer types and both floats, asserting `isNumber`, the round-tripped value, and that the flags match the mutable form exactly. `134/134 modules passed unittests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)