### PR TITLE
posix: fix timespec/time_t ABI on 32-bit linux

### DIFF
--- a/src/urt/internal/sys/posix/package.d
+++ b/src/urt/internal/sys/posix/package.d
@@ -9,10 +9,18 @@ extern(C) nothrow @nogc:
 
 // ── types ──
 
+// X86/ARM keep the classic 32-bit time ABI (glibc time64 is opt-in and unused);
+// riscv32 is natively time64, and 64-bit ABIs are 64-bit throughout
+version (X86)      version = Time32;
+else version (ARM) version = Time32;
+
 alias off_t = long;
 alias mode_t = uint;
 alias ssize_t = ptrdiff_t;
-alias time_t = long;
+version (Time32)
+    alias time_t = int;
+else
+    alias time_t = long;
 alias clockid_t = int;
 alias blkcnt_t = long;
 alias dev_t = ulong;
@@ -315,7 +323,10 @@ pure int posix_memalign(void** memptr, size_t alignment, size_t size);
 struct timespec
 {
     time_t tv_sec;
-    long tv_nsec;
+    version (Time32)
+        int tv_nsec;
+    else
+        long tv_nsec;
 }
 
 struct tm

--- a/src/urt/sync/event.d
+++ b/src/urt/sync/event.d
@@ -192,8 +192,8 @@ nothrow @nogc:
             timespec ts;
             clock_gettime(CLOCK_REALTIME, &ts);
             long add_ns = timeout.as!"nsecs";
-            ts.tv_sec  += add_ns / 1_000_000_000;
-            ts.tv_nsec += add_ns % 1_000_000_000;
+            ts.tv_sec  += cast(time_t)(add_ns / 1_000_000_000);
+            ts.tv_nsec += cast(typeof(ts.tv_nsec))(add_ns % 1_000_000_000);
             if (ts.tv_nsec >= 1_000_000_000)
             {
                 ts.tv_sec  += 1;
@@ -350,13 +350,5 @@ else version (linux)
         bool flag;
     }
 
-    alias time_t = long;
-    struct timespec
-    {
-        time_t tv_sec;
-        long   tv_nsec;
-    }
-    alias clockid_t = int;
-    enum CLOCK_REALTIME = 0;
-    int clock_gettime(clockid_t, timespec*);
+    import urt.internal.sys.posix : timespec, time_t, clock_gettime, CLOCK_REALTIME;
 }

--- a/src/urt/sync/semaphore.d
+++ b/src/urt/sync/semaphore.d
@@ -157,8 +157,8 @@ nothrow @nogc:
             timespec ts;
             clock_gettime(CLOCK_REALTIME, &ts);
             long add_ns = timeout.as!"nsecs";
-            ts.tv_sec  += add_ns / 1_000_000_000;
-            ts.tv_nsec += add_ns % 1_000_000_000;
+            ts.tv_sec  += cast(time_t)(add_ns / 1_000_000_000);
+            ts.tv_nsec += cast(typeof(ts.tv_nsec))(add_ns % 1_000_000_000);
             if (ts.tv_nsec >= 1_000_000_000)
             {
                 ts.tv_sec  += 1;
@@ -292,16 +292,5 @@ version (linux)
     int sem_trywait(sem_t*);
     int sem_timedwait(sem_t*, const(timespec)*);
 
-    // timespec + clock_gettime live in <time.h>; duplicated here so this
-    // module is self-contained. Promote to internal/sys/posix on second use.
-    alias time_t = long;
-    struct timespec
-    {
-        time_t tv_sec;
-        long   tv_nsec;
-    }
-
-    alias clockid_t = int;
-    enum CLOCK_REALTIME = 0;
-    int clock_gettime(clockid_t, timespec*);
+    import urt.internal.sys.posix : timespec, time_t, clock_gettime, CLOCK_REALTIME;
 }

--- a/src/urt/time.d
+++ b/src/urt/time.d
@@ -995,7 +995,7 @@ MonoTime get_time()
     {
         timespec ts;
         clock_gettime(CLOCK_MONOTONIC, &ts);
-        return MonoTime(ts.tv_sec * 1_000_000_000 + ts.tv_nsec);
+        return MonoTime(ts.tv_sec * 1_000_000_000L + ts.tv_nsec);
     }
     else version (Embedded)
     {
@@ -1022,7 +1022,7 @@ SysTime get_sys_time()
     {
         timespec ts;
         clock_gettime(CLOCK_REALTIME, &ts);
-        return SysTime(ts.tv_sec * 1_000_000_000 + ts.tv_nsec);
+        return SysTime(ts.tv_sec * 1_000_000_000L + ts.tv_nsec);
     }
     else version (Embedded)
     {
@@ -1294,7 +1294,7 @@ package(urt) void init_clock()
         {
             clock_gettime(CLOCK_MONOTONIC, &mt);
             clock_gettime(CLOCK_REALTIME, &rt);
-            boot_time = min(boot_time, rt.tv_sec*1_000_000_000 + rt.tv_nsec - mt.tv_sec*1_000_000_000 - mt.tv_nsec);
+            boot_time = min(boot_time, rt.tv_sec*1_000_000_000L + rt.tv_nsec - mt.tv_sec*1_000_000_000L - mt.tv_nsec);
         }
         cast()sys_time_offset = boot_time;
         has_wall_time = true;


### PR DESCRIPTION
timespec was declared {long, long} unconditionally, but classic 32-bit glibc ABIs (x86, arm) have {32-bit time_t, 32-bit long}: clock_gettime writes 8 bytes into a 16-byte struct, leaving tv_sec with the nanoseconds packed into its high word. Every monotonic and wall-clock read on linux-x86 was garbage; openwatt's OBD scheduler test was the first CI test to compare a MonoTime delta against a wall-scale threshold and exposed it.

- time_t is now int on X86/ARM linux (glibc time64 is opt-in and unused), long elsewhere; riscv32 keeps 64-bit time_t (natively time64) so the NewStatLayout size assert holds
- tv_sec * 1_000_000_000 multiplies promoted to long in get_time/get_sys_time/boot-time calc
- event.d and semaphore.d carried private copies of the same wrong struct for their timedwaits; per their own promote-on-second-use note they now import the shared decl, with narrowing casts in the deadline arithmetic

Verified: linux x86_64 (WSL) full unittest run and windows x86_64 both green; 32-bit is exercised by openwatt CI.