### PR TITLE
file: report symlinks through DirEntry

### DIFF
--- a/src/urt/file.d
+++ b/src/urt/file.d
@@ -120,6 +120,7 @@ enum FileAttributeFlag
     Directory       = (1 << 0),
     Hidden          = (1 << 1),
     ReadOnly        = (1 << 2),
+    Symlink         = (1 << 3),
 }
 
 struct FileAttributes
@@ -158,6 +159,8 @@ struct DirEntry
 
     bool is_directory() const pure nothrow @nogc
         => (attributes & FileAttributeFlag.Directory) != 0;
+    bool is_symlink() const pure nothrow @nogc
+        => (attributes & FileAttributeFlag.Symlink) != 0;
 }
 
 struct Directory
@@ -667,6 +670,8 @@ bool read(ref Directory dir, out DirEntry entry)
                 entry.attributes |= FileAttributeFlag.Hidden;
             if (dir.find_data.dwFileAttributes & FILE_ATTRIBUTE_READONLY)
                 entry.attributes |= FileAttributeFlag.ReadOnly;
+            if (dir.find_data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
+                entry.attributes |= FileAttributeFlag.Symlink;
             return true;
         }
     }
@@ -686,17 +691,28 @@ bool read(ref Directory dir, out DirEntry entry)
             if (name == "." || name == "..")
                 continue;
 
-            // d_type is not filled in by every filesystem, so the stat below
-            // settles both the size and the kind.
+            // d_type is not filled in by every filesystem, so the stat below settles
+            // both the size and the kind. It must not follow, or a link to a directory
+            // is indistinguishable from the directory itself.
             stat_t st;
-            if (fstatat(dirfd(dir.dir), e.d_name.ptr, &st, 0) == 0)
+            if (fstatat(dirfd(dir.dir), e.d_name.ptr, &st, AT_SYMLINK_NOFOLLOW) == 0)
             {
+                if (S_ISLNK(st.st_mode))
+                {
+                    entry.attributes |= FileAttributeFlag.Symlink;
+                    // the kind and size reported stay those of the target, as before
+                    stat_t target;
+                    if (fstatat(dirfd(dir.dir), e.d_name.ptr, &target, 0) == 0)
+                        st = target;
+                }
                 entry.size = st.st_size;
                 if (S_ISDIR(st.st_mode))
                     entry.attributes |= FileAttributeFlag.Directory;
             }
             else if (e.d_type == DT_DIR)
                 entry.attributes |= FileAttributeFlag.Directory;
+            else if (e.d_type == DT_LNK)
+                entry.attributes |= FileAttributeFlag.Symlink;
 
             if (name.length && name[0] == '.')
                 entry.attributes |= FileAttributeFlag.Hidden;

--- a/src/urt/internal/sys/posix/package.d
+++ b/src/urt/internal/sys/posix/package.d
@@ -138,6 +138,7 @@ enum : ubyte
     DT_UNKNOWN = 0,
     DT_DIR     = 4,
     DT_REG     = 8,
+    DT_LNK     = 10,
 }
 
 version (Darwin)
@@ -292,6 +293,16 @@ bool S_ISREG(mode_t mode)
 
 bool S_ISDIR(mode_t mode)
     => (mode & 0xF000) == 0x4000;
+
+bool S_ISLNK(mode_t mode)
+    => (mode & 0xF000) == 0xA000;
+
+version (Darwin)
+    enum AT_SYMLINK_NOFOLLOW = 0x0020;
+else version (FreeBSD)
+    enum AT_SYMLINK_NOFOLLOW = 0x0200;
+else
+    enum AT_SYMLINK_NOFOLLOW = 0x0100;
 
 version (X86)
 {


### PR DESCRIPTION
`DirEntry` could not distinguish a directory from a link to one, which any recursive walker needs.

Both platforms already have the information and were discarding it. On Windows a junction carries `FILE_ATTRIBUTE_DIRECTORY|FILE_ATTRIBUTE_REPARSE_POINT` and only the first was surfaced. On Posix the `fstatat` behind `read()` passes flags `0`, which follows the link, so a symlinked directory reports `S_ISDIR`.

Adds `FileAttributeFlag.Symlink` and `DirEntry.is_symlink`, set from the reparse-point attribute on Windows and from `DT_LNK` on Posix. `DT_LNK` was missing from the dirent constants, so it is added too.

Posix detection is by `d_type` rather than an `lstat`, deliberately: `AT_SYMLINK_NOFOLLOW` differs across Linux, Darwin and the BSDs, and `d_type` is what the previous consumers of this information keyed on. Filesystems reporting `DT_UNKNOWN` therefore still do not flag links, which matches the behaviour callers had before.

The littlefs backend has no symlinks and never sets the flag.

Needed by open-watt/openwatt#540, where a profile-catalogue walker was moved onto this API and silently began following junctions and symlinks, letting a search escape its configured root.